### PR TITLE
Added support for explicitly loading IGraphicsProcessors

### DIFF
--- a/src/ImageProcessor.Web/NET45/Config/ImageProcessingSection.cs
+++ b/src/ImageProcessor.Web/NET45/Config/ImageProcessingSection.cs
@@ -72,12 +72,24 @@ namespace ImageProcessor.Web.Config
             }
 
             /// <summary>
+            /// Gets or sets the type of the plugin file.
+            /// </summary>
+            /// <value>The full Type definition of the plugin</value>
+            [ConfigurationProperty("type", DefaultValue = "", IsRequired = true)]
+            public string Type
+            {
+                get { return (string)this["type"]; }
+
+                set { this["type"] = value; }
+            }
+
+            /// <summary>
             /// Gets the <see cref="T:ImageProcessor.Web.Config.ImageProcessingSection.SettingElementCollection"/>.
             /// </summary>
             /// <value>
             /// The <see cref="T:ImageProcessor.Web.Config.ImageProcessingSection.SettingElementCollection"/>.
             /// </value>
-            [ConfigurationProperty("settings", IsRequired = true)]
+            [ConfigurationProperty("settings", IsRequired = false)]
             public SettingElementCollection Settings
             {
                 get
@@ -112,6 +124,18 @@ namespace ImageProcessor.Web.Config
             protected override string ElementName
             {
                 get { return "plugin"; }
+            }
+
+            /// <summary>
+            /// Gets or sets the autoLoadPlugins of the plugin file.
+            /// </summary>
+            /// <value>If True plugins are auto discovered and loaded from all assemblies otherwise they must be defined in the configuration file</value>
+            [ConfigurationProperty("autoLoadPlugins", DefaultValue = true, IsRequired = false)]
+            public bool AutoLoadPlugins
+            {
+                get { return (bool)this["autoLoadPlugins"]; }
+
+                set { this["autoLoadPlugins"] = value; }
             }
 
             /// <summary>

--- a/src/TestWebsites/NET45/Test_Website_NET45/config/imageprocessor/processing.config
+++ b/src/TestWebsites/NET45/Test_Website_NET45/config/imageprocessor/processing.config
@@ -1,27 +1,40 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <processing>
-  <plugins>
-    <plugin name="Resize">
+  <plugins autoLoadPlugins="false">
+    <plugin name="Alpha" type="ImageProcessor.Processors.Alpha, ImageProcessor"/>
+    <plugin name="Brightness" type="ImageProcessor.Processors.Brightness, ImageProcessor"/>
+    <plugin name="Contrast" type="ImageProcessor.Processors.Contrast, ImageProcessor"/>
+    <plugin name="Crop" type="ImageProcessor.Processors.Crop, ImageProcessor"/>
+    <plugin name="Filter" type="ImageProcessor.Processors.Filter, ImageProcessor"/>
+    <plugin name="Flip" type="ImageProcessor.Processors.Flip, ImageProcessor"/>
+    <plugin name="Format" type="ImageProcessor.Processors.Format, ImageProcessor"/>
+    <plugin name="GaussianBlur" type="ImageProcessor.Processors.GaussianBlur, ImageProcessor">
+      <settings>
+        <setting key="MaxSize" value="22"/>
+        <setting key="MaxSigma" value="5.1"/>
+        <setting key="MaxThreshold" value="100"/>
+      </settings>
+    </plugin>
+    <plugin name="GaussianSharpen" type="ImageProcessor.Processors.GaussianSharpen, ImageProcessor">
+      <settings>
+        <setting key="MaxSize" value="22"/>
+        <setting key="MaxSigma" value="5.1"/>
+        <setting key="MaxThreshold" value="100"/>
+      </settings>
+    </plugin>
+    <plugin name="Quality" type="ImageProcessor.Processors.Quality, ImageProcessor"/>
+    <plugin name="Resize" type="ImageProcessor.Processors.Resize, ImageProcessor">
       <settings>
         <setting key="MaxWidth" value="3000"/>
         <setting key="MaxHeight" value="3000"/>
       </settings>
     </plugin>
-    <plugin name="GaussianBlur">
-      <settings>
-        <setting key="MaxSize" value="22"/>
-        <setting key="MaxSigma" value="5.1"/>
-        <setting key="MaxThreshold" value="100"/>
-      </settings>
-    </plugin>
-    <plugin name="GaussianSharpen">
-      <settings>
-        <setting key="MaxSize" value="22"/>
-        <setting key="MaxSigma" value="5.1"/>
-        <setting key="MaxThreshold" value="100"/>
-      </settings>
-    </plugin>
-    <plugin name="Preset">
+    <plugin name="Rotate" type="ImageProcessor.Processors.Rotate, ImageProcessor"/>
+    <plugin name="RoundedCorners" type="ImageProcessor.Processors.RoundedCorners, ImageProcessor"/>
+    <plugin name="Saturation" type="ImageProcessor.Processors.Saturation, ImageProcessor"/>
+    <plugin name="Vignette" type="ImageProcessor.Processors.Vignette, ImageProcessor"/>
+    <plugin name="Watermark" type="ImageProcessor.Processors.Watermark, ImageProcessor"/>
+    <plugin name="Preset" type="ImageProcessor.Web.Preset, ImageProcessor">
       <settings>
         <setting key="demo" value="width=300&#038;height=150"/>
       </settings>


### PR DESCRIPTION
Auto-loading IGraphicsProcessor means that all DLLs are loaded. This can cause issues if you have reference issues in your bin (don't ask!)

This change is off by default and controlled via config. If autoLoadPlugins is false then only the plugins defined will be loaded.

```
<processing>
  <plugins **autoLoadPlugins="false"**>
    <plugin name="Format" **type="ImageProcessor.Processors.Format, ImageProcessor"**/>
    <plugin name="GaussianBlur" type="ImageProcessor.Processors.GaussianBlur, ImageProcessor">
      <settings>
        <setting key="MaxSize" value="22"/>
        <setting key="MaxSigma" value="5.1"/>
        <setting key="MaxThreshold" value="100"/>
      </settings>
    </plugin>
  </plugins>
</processing>
```
