### PR TITLE
Caching images having a different internal format vs file extension

### DIFF
--- a/src/ImageProcessor/ImageFactory.cs
+++ b/src/ImageProcessor/ImageFactory.cs
@@ -860,9 +860,9 @@ namespace ImageProcessor
                 int length = filePath.LastIndexOf(".", StringComparison.Ordinal);
                 string extension = this.ImageFormat.GetFileExtension(this.OriginalExtension);
 
-                if (!string.IsNullOrWhiteSpace(extension))
+                if (length == -1)
                 {
-                    filePath = length == -1 ? filePath + extension : filePath.Substring(0, length) + extension;
+                    filePath = filePath + extension;
                 }
 
                 // Fix the colour palette of indexed images.


### PR DESCRIPTION
Hi James,

First of all, thank you for your efforts on developing this very useful library!

I recently came across an issue while using the caching mechanism. The following exception was being raised by the instantiation of the HostFileChangeMonitor class:
"System.ArgumentOutOfRangeException: The UTC time represented when the offset is applied must be between year 0 and 10,000."

I know there is a closed issue addressing the same error, but the changes didn't solve the problem in my case. By investigating a bit, I found out that the exception was labeled as being related to a bug in the .NET platform < 4.5.1. Actually, in my case the exception was a consequence of another issue - the cached image was missing from the hard drive, so the HostFileChangeMonitor instance was monitoring a missing file. 

It turned out that the cashed file was having a different extension that the original file, due to a miscorrelation between the internal format of the original image and its file extension.

I solved the problem in this fork by constraining the cached image files to have the same extension as the original ones. 
