### PR TITLE
Cleanup of XML documentation - cref is for classes!

### DIFF
--- a/src/ImageProcessor/Extensions/ImageInfo.cs
+++ b/src/ImageProcessor/Extensions/ImageInfo.cs
@@ -16,7 +16,7 @@ namespace ImageProcessor.Extensions
 
     /// <summary>
     /// Provides information about an image.
-    /// <see cref="http://madskristensen.net/post/examine-animated-gife28099s-in-c"/>
+    /// <see href="http://madskristensen.net/post/examine-animated-gife28099s-in-c"/>
     /// </summary>
     public class ImageInfo
     {

--- a/src/ImageProcessor/Imaging/ExifPropertyTag.cs
+++ b/src/ImageProcessor/Imaging/ExifPropertyTag.cs
@@ -12,7 +12,7 @@ namespace ImageProcessor.Imaging
 {
     /// <summary>
     /// The following enum gives descriptions of the property items supported by Windows GDI+.
-    /// <see cref="http://msdn.microsoft.com/en-us/library/ms534417%28VS.85%29.aspx"/>
+    /// <see href="http://msdn.microsoft.com/en-us/library/ms534417%28VS.85%29.aspx"/>
     /// TODO: Add more XML descriptions.
     /// </summary>
     public enum ExifPropertyTag

--- a/src/ImageProcessor/Imaging/ExifPropertyTagType.cs
+++ b/src/ImageProcessor/Imaging/ExifPropertyTagType.cs
@@ -13,7 +13,7 @@ namespace ImageProcessor.Imaging
 {
     /// <summary>
     /// Specifies the data type of the values stored in the value data member of that same PropertyItem object.
-    /// <see cref="http://msdn.microsoft.com/en-us/library/system.drawing.imaging.propertyitem.type.aspx"/>
+    /// <see href="http://msdn.microsoft.com/en-us/library/system.drawing.imaging.propertyitem.type.aspx"/>
     /// </summary>
     public enum ExifPropertyTagType : short
     {

--- a/src/ImageProcessor/Imaging/GifEncoder.cs
+++ b/src/ImageProcessor/Imaging/GifEncoder.cs
@@ -29,7 +29,7 @@ namespace ImageProcessor.Imaging
     /// Always wire this up in a using block.
     /// Disposing the encoder will complete the file.
     /// Uses default .NET GIF encoding and adds animation headers.
-    /// Adapted from <see cref="http://github.com/DataDink/Bumpkit/blob/master/BumpKit/BumpKit/GifEncoder.cs"/>
+    /// Adapted from <see href="http://github.com/DataDink/Bumpkit/blob/master/BumpKit/BumpKit/GifEncoder.cs"/>
     /// </remarks>
     /// </summary>
     public class GifEncoder : IDisposable

--- a/src/ImageProcessor/Processors/Alpha.cs
+++ b/src/ImageProcessor/Processors/Alpha.cs
@@ -25,7 +25,7 @@ namespace ImageProcessor.Processors
     {
         /// <summary>
         /// The regular expression to search strings for.
-        /// <see cref="http://stackoverflow.com/a/6400969/427899"/> 
+        /// <see href="http://stackoverflow.com/a/6400969/427899"/> 
         /// </summary>
         private static readonly Regex QueryRegex = new Regex(@"alpha=(?:100|[1-9]?[0-9])", RegexOptions.Compiled);
 

--- a/src/ImageProcessor/Processors/Brightness.cs
+++ b/src/ImageProcessor/Processors/Brightness.cs
@@ -25,7 +25,7 @@ namespace ImageProcessor.Processors
     {
         /// <summary>
         /// The regular expression to search strings for.
-        /// <see cref="http://stackoverflow.com/a/6400969/427899"/> 
+        /// <see href="http://stackoverflow.com/a/6400969/427899"/> 
         /// </summary>
         private static readonly Regex QueryRegex = new Regex(@"brightness=(-?(?:100)|-?([1-9]?[0-9]))", RegexOptions.Compiled);
 

--- a/src/ImageProcessor/Processors/Contrast.cs
+++ b/src/ImageProcessor/Processors/Contrast.cs
@@ -25,7 +25,7 @@ namespace ImageProcessor.Processors
     {
         /// <summary>
         /// The regular expression to search strings for.
-        /// <see cref="http://stackoverflow.com/a/6400969/427899"/> 
+        /// <see href="http://stackoverflow.com/a/6400969/427899"/> 
         /// </summary>
         private static readonly Regex QueryRegex = new Regex(@"contrast=(-?(?:100)|-?([1-9]?[0-9]))", RegexOptions.Compiled);
 

--- a/src/ImageProcessor/Processors/Crop.cs
+++ b/src/ImageProcessor/Processors/Crop.cs
@@ -30,7 +30,7 @@ namespace ImageProcessor.Processors
     {
         /// <summary>
         /// The regular expression to search strings for.
-        /// <see cref="http://stackoverflow.com/a/6400969/427899"/>
+        /// <see href="http://stackoverflow.com/a/6400969/427899"/>
         /// </summary>
         private static readonly Regex QueryRegex = new Regex(@"crop=\d+(.\d+)?[,-]\d+(.\d+)?[,-]\d+(.\d+)?[,-]\d+(.\d+)?|cropmode=(pixels|percent)", RegexOptions.Compiled);
 

--- a/src/ImageProcessor/Processors/Flip.cs
+++ b/src/ImageProcessor/Processors/Flip.cs
@@ -23,7 +23,7 @@ namespace ImageProcessor.Processors
     {
         /// <summary>
         /// The regular expression to search strings for.
-        /// <see cref="http://stackoverflow.com/a/6400969/427899"/>
+        /// <see href="http://stackoverflow.com/a/6400969/427899"/>
         /// </summary>
         private static readonly Regex QueryRegex = new Regex(@"flip=(horizontal|vertical|both)", RegexOptions.Compiled);
 

--- a/src/ImageProcessor/Processors/Rotate.cs
+++ b/src/ImageProcessor/Processors/Rotate.cs
@@ -184,7 +184,7 @@ namespace ImageProcessor.Processors
         /// <param name="backgroundColor">The background color to fill an image with.</param>
         /// <returns>The image rotated to the given angle at the given position.</returns>
         /// <remarks> 
-        /// Based on <see cref="http://www.codeproject.com/Articles/58815/C-Image-PictureBox-Rotations?msg=4155374#xx4155374xx"/> 
+        /// Based on <see href="http://www.codeproject.com/Articles/58815/C-Image-PictureBox-Rotations?msg=4155374#xx4155374xx"/> 
         /// </remarks>
         private Bitmap RotateImage(Image image, float rotateAtX, float rotateAtY, float angle, Color backgroundColor)
         {

--- a/src/ImageProcessor/Processors/Saturation.cs
+++ b/src/ImageProcessor/Processors/Saturation.cs
@@ -23,13 +23,13 @@ namespace ImageProcessor.Processors
     /// Encapsulates methods to change the saturation component of the image.
     /// </summary>
     /// <remarks>
-    /// <see cref="http://www.bobpowell.net/imagesaturation.htm"/> 
+    /// <see href="http://www.bobpowell.net/imagesaturation.htm"/> 
     /// </remarks>
     public class Saturation : IGraphicsProcessor
     {
         /// <summary>
         /// The regular expression to search strings for.
-        /// <see cref="http://stackoverflow.com/a/6400969/427899"/> 
+        /// <see href="http://stackoverflow.com/a/6400969/427899"/> 
         /// </summary>
         private static readonly Regex QueryRegex = new Regex(@"saturation=(-?(?:100)|-?([1-9]?[0-9]))", RegexOptions.Compiled);
 


### PR DESCRIPTION
Actually href is not the official way, but there is no official way to add a link in XML documentation. Sandcastle understands href, so...
