### PR TITLE
Fix for #70 - Height and width ratio should round up to nearest pixel

### DIFF
--- a/src/ImageProcessor/Processors/Resize.cs
+++ b/src/ImageProcessor/Processors/Resize.cs
@@ -546,13 +546,13 @@ namespace ImageProcessor.Processors
                 // Replace 0 width
                 if (size.Width == 0 && size.Height > 0 && input.Contains(WidthRatio) && !input.Contains(HeightRatio))
                 {
-                    size.Width = (int)(value.ToPositiveFloatArray()[0] * size.Height);
+                    size.Width = (int)Math.Ceiling(value.ToPositiveFloatArray()[0] * size.Height);
                 }
 
                 // Replace 0 height
                 if (size.Height == 0 && size.Width > 0 && input.Contains(HeightRatio) && !input.Contains(WidthRatio))
                 {
-                    size.Height = (int)(value.ToPositiveFloatArray()[0] * size.Width);
+                    size.Height = (int)Math.Ceiling(value.ToPositiveFloatArray()[0] * size.Width);
                 }
             }
 


### PR DESCRIPTION
Currently a 1px black line is being added due to this issue in certain situations. More detal herehttp://our.umbraco.org/projects/website-utilities/slimsy/slimsy-feedback/55014-Slimsy-adding-padding-to-side-of-wide-image?p=0#comment189658
