### PR TITLE
fix for allowing the loading of mac tiffs

### DIFF
--- a/src/ImageProcessor/Imaging/Formats/TiffFormat.cs
+++ b/src/ImageProcessor/Imaging/Formats/TiffFormat.cs
@@ -29,8 +29,8 @@ namespace ImageProcessor.Imaging.Formats
             {
                 return new[]
                 { 
-                    new byte[] { 73, 73, 42 }, 
-                    new byte[] { 77, 77, 42 } 
+                    new byte[] { 73, 73, 42, 0 }, 
+                    new byte[] { 77, 77, 0, 42 }
                 };
             }
         }


### PR DESCRIPTION
Tiff format file header was missing an extra byte that prevented the loading of mac tiff files.

Because windows tiff files are little-endian, the 'tiff version' (42) was always loaded in the third byte no problem, however mac tiff files being big-endian have it in the fourth and hence would never be detected as a valid file format.
