### PR TITLE
Modify RequestQuerystringEvent to pass request.RawUrl

### DIFF
--- a/src/ImageProcessor.Web/Helpers/ProcessQueryStringEventArgs.cs
+++ b/src/ImageProcessor.Web/Helpers/ProcessQueryStringEventArgs.cs
@@ -21,5 +21,10 @@ namespace ImageProcessor.Web.Helpers
         /// Gets or sets the querystring.
         /// </summary>
         public string Querystring { get; set; }
+
+        /// <summary>
+        /// Gets or sets the raw http request url.
+        /// </summary>
+        public string RawUrl { get; set; }
     }
 }

--- a/src/ImageProcessor.Web/HttpModules/ImageProcessingModule.cs
+++ b/src/ImageProcessor.Web/HttpModules/ImageProcessingModule.cs
@@ -346,6 +346,9 @@ namespace ImageProcessor.Web.HttpModules
 
                 // Replace any presets in the querystring with the actual value.
                 queryString = this.ReplacePresetsInQueryString(queryString);
+                
+                // Execute the handler which can change the querystring 
+                queryString = this.CheckQuerystringHandler( queryString, request.RawUrl );
 
                 // If the current service doesn't require a prefix, don't fetch it.
                 // Let the static file handler take over.
@@ -557,13 +560,26 @@ namespace ImageProcessor.Web.HttpModules
                     }
                 }
             }
-
+            return queryString;
+        }
+        /// <summary>
+        /// Checks if there is a handler that changes the querystring and executes that handler.
+        /// </summary>
+        /// <param name="queryString">
+        /// The query string.
+        /// </param>
+        /// <param name="rawUrl">
+        /// The raw request url.
+        /// </param>
+        /// <returns>
+        /// The <see cref="string"/> containing the updated querystring.
+        /// </returns>
+        private string CheckQuerystringHandler(string queryString, string rawUrl) {
             // Fire the process querystring event.
             ProcessQuerystringEventHandler handler = OnProcessQuerystring;
-            if (handler != null)
-            {
-                ProcessQueryStringEventArgs args = new ProcessQueryStringEventArgs { Querystring = queryString ?? string.Empty };
-                queryString = handler(this, args);
+            if ( handler != null ) {
+                ProcessQueryStringEventArgs args = new ProcessQueryStringEventArgs { Querystring = queryString ?? string.Empty, RawUrl = rawUrl ?? string.Empty };
+                queryString = handler( this, args );
             }
 
             return queryString;

--- a/src/TestWebsites/MVC/Global.asax.cs
+++ b/src/TestWebsites/MVC/Global.asax.cs
@@ -32,7 +32,7 @@ namespace Test_Website_NET45
 
             ImageProcessingModule.OnProcessQuerystring += (sender, args) =>
                 {
-                    if (!args.Querystring.Contains("watermark"))
+                    if (!args.RawUrl.Contains("penguins"))
                     {
                         return args.Querystring += "watermark=protected&color=fff&fontsize=36&fontopacity=70textshadow=true&fontfamily=arial";
                     }


### PR DESCRIPTION
I use a different folder to store the images I need to be watermarked. So I need the RawUrl of the request to determine if a watermark is needed on that image.

Thanks for the great library!