### PR TITLE
Make the DLL COM visible

### DIFF
--- a/src/ImageProcessor/Properties/AssemblyInfo.cs
+++ b/src/ImageProcessor/Properties/AssemblyInfo.cs
@@ -26,7 +26,7 @@ using System.Runtime.InteropServices;
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
+[assembly: ComVisible(true)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("bdaae9bd-0dc8-4b06-8722-e2e0c9a74301")]


### PR DESCRIPTION
Marks the DLL as COM-visible, so that we can use it in Ruby through `require 'win32ole'`.

I'm not sure why there are multiple commits on this merge, only the `AssemblyInfo.cs` file is modified.