### PR TITLE
Used the Unvalidated version of RawUrl

### DIFF
--- a/src/ImageProcessor.Web/HttpModules/ImageProcessingModule.cs
+++ b/src/ImageProcessor.Web/HttpModules/ImageProcessingModule.cs
@@ -294,7 +294,7 @@ namespace ImageProcessor.Web.HttpModules
             HttpRequest request = context.Request;
 
             // Should we ignore this request?
-            if (request.RawUrl.ToUpperInvariant().Contains("IPIGNORE=TRUE"))
+            if (request.Unvalidated.RawUrl.ToUpperInvariant().Contains("IPIGNORE=TRUE"))
             {
                 return;
             }
@@ -364,7 +364,7 @@ namespace ImageProcessor.Web.HttpModules
                 queryString = this.ReplacePresetsInQueryString(queryString);
 
                 // Execute the handler which can change the querystring 
-                queryString = this.CheckQuerystringHandler(queryString, request.RawUrl);
+                queryString = this.CheckQuerystringHandler(queryString, request.Unvalidated.RawUrl);
 
                 // If the current service doesn't require a prefix, don't fetch it.
                 // Let the static file handler take over.


### PR DESCRIPTION
Accordingly to this SO issue (http://stackoverflow.com/questions/30075396/http-module-intercept-requests-and-breaks-custom-errors-configuration), if I was trying to use a special URL to simulate an attack on the webapp (for example, .../App/<c), the custom error pages didn't reacted anymore.