### PR TITLE
Remove "preset=" from queryString

### DIFF
--- a/src/ImageProcessor.Web/HttpModules/ImageProcessingModule.cs
+++ b/src/ImageProcessor.Web/HttpModules/ImageProcessingModule.cs
@@ -555,7 +555,7 @@ namespace ImageProcessor.Web.HttpModules
 
                         // We use the processor config system to store the preset values.
                         string replacements = ImageProcessorConfiguration.Instance.GetPresetSettings(preset);
-                        queryString = Regex.Replace(queryString, preset, replacements ?? string.Empty);
+                        queryString = Regex.Replace(queryString, match.Value, replacements ?? string.Empty);
                     }
                 }
             }


### PR DESCRIPTION
There was a problem with the preset parameters. After changing the preset name in the Query String, the "preset =" value persisted. This problem meant that the preset settings were not all supported by ImageProcessor.