### PR TITLE
Add overload for loading image data from a byte array.

### DIFF
--- a/src/ImageProcessor.UnitTests/ImageFactoryUnitTests.cs
+++ b/src/ImageProcessor.UnitTests/ImageFactoryUnitTests.cs
@@ -77,6 +77,23 @@ namespace ImageProcessor.UnitTests
             }
         }
 
+		[Test]
+		public void ImageIsLoadedFromByteArray()
+		{
+			foreach (FileInfo file in this.ListInputFiles())
+			{
+				byte[] photoBytes = File.ReadAllBytes(file.FullName);
+
+				using (ImageFactory imageFactory = new ImageFactory())
+				{
+					imageFactory.Load(photoBytes);
+
+					imageFactory.ImagePath.Should().BeNull("because an image loaded from byte array should not have a file path");
+					imageFactory.Image.Should().NotBeNull("because the image should have been loaded");
+				}
+			}			
+		}
+
         /// <summary>
         /// Tests that the save method actually saves a file
         /// </summary>


### PR DESCRIPTION
I found myself writing a lot of code similar to this

```
var bytes = File.ReadAllBytes(...)
using (var memStream = new MemoryStream(bytes)) { // extraneous
   ...
   imageFactory.Load(memStream)
}
```

This overload removes the need to create an extra memory stream, since ImageFactory.Load already contains ones internally.