### PR TITLE
Fix 404 error handling in RemoteFile

### DIFF
--- a/src/ImageProcessor.Web/Helpers/RemoteFile.cs
+++ b/src/ImageProcessor.Web/Helpers/RemoteFile.cs
@@ -178,7 +178,7 @@ namespace ImageProcessor.Web.Helpers
             }
             catch (WebException ex)
             {
-                if (response != null)
+                if (ex.Response != null)
                 {
                     HttpWebResponse errorResponse = (HttpWebResponse)ex.Response;
                     if (errorResponse.StatusCode == HttpStatusCode.NotFound)


### PR DESCRIPTION
The response is always null when a 404 WebException is thrown, so the error handling was never performed.
Using ex.Response works as expected.