### PR TITLE
Fix for ImageMaths.RotatePoint + added tests

### DIFF
--- a/src/ImageProcessor.UnitTests/ImageProcessor.UnitTests.csproj
+++ b/src/ImageProcessor.UnitTests/ImageProcessor.UnitTests.csproj
@@ -78,34 +78,34 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
-    <Content Include="Images\animated\animated-bird.gif" >
+    <Content Include="Images\animated\animated-bird.gif">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <Content Include="Images\animated\animated-meter.gif" >
+    <Content Include="Images\animated\animated-meter.gif">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <Content Include="Images\animated\animated-pattern.gif" >
+    <Content Include="Images\animated\animated-pattern.gif">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <Content Include="Images\animated\animated-startrek.gif" >
+    <Content Include="Images\animated\animated-startrek.gif">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="Images\exif\autorotate.jpg">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <Content Include="Images\gamma\gamma-1.0-or-2.2.png" >
+    <Content Include="Images\gamma\gamma-1.0-or-2.2.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <Content Include="Images\gamma\gamma-dalai-lama-gray-tft.jpg" >
+    <Content Include="Images\gamma\gamma-dalai-lama-gray-tft.jpg">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <Content Include="Images\gamma\gamma-dalai-lama-gray.jpg" >
+    <Content Include="Images\gamma\gamma-dalai-lama-gray.jpg">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <Content Include="Images\gamma\gamma-fly.jpg" >
+    <Content Include="Images\gamma\gamma-fly.jpg">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <Content Include="Images\gamma\gamma-saturn.jpg" >
+    <Content Include="Images\gamma\gamma-saturn.jpg">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="Images\icc-profiles\cmyk-profile-euroscale.jpg">
@@ -150,10 +150,10 @@
     <Content Include="Images\icc-profiles\profile-srgb.jpg">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <Content Include="Images\imageprocessor\mask\mask.png" >
+    <Content Include="Images\imageprocessor\mask\mask.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <Content Include="Images\imageprocessor\overlay\monster.png" >
+    <Content Include="Images\imageprocessor\overlay\monster.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="Images\stretched.jpg">
@@ -170,7 +170,9 @@
     </PropertyGroup>
     <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
   </Target>
-  <ItemGroup />
+  <ItemGroup>
+    <Folder Include="Imaging\Formats\" />
+  </ItemGroup>
   <ItemGroup />
   <ItemGroup />
 </Project>

--- a/src/ImageProcessor.UnitTests/Imaging/Helpers/ImageMathsUnitTests.cs
+++ b/src/ImageProcessor.UnitTests/Imaging/Helpers/ImageMathsUnitTests.cs
@@ -12,6 +12,8 @@ namespace ImageProcessor.UnitTests.Imaging.Helpers
 {
     using System.Drawing;
     using FluentAssertions;
+    using FluentAssertions.Equivalency;
+
     using ImageProcessor.Imaging.Helpers;
     using NUnit.Framework;
 
@@ -21,50 +23,128 @@ namespace ImageProcessor.UnitTests.Imaging.Helpers
     public class ImageMathsUnitTests
     {
         /// <summary>
-        /// Tests that the bounding rectangle of a rotated image is calculated
+        /// The when getting rotated bounding rectangle is calculated.
         /// </summary>
-        /// <param name="width">The width of the image.</param>
-        /// <param name="height">The height of the image.</param>
-        /// <param name="angle">The rotation angle.</param>
-        /// <param name="expectedWidth">The expected width.</param>
-        /// <param name="expectedHeight">The expected height.</param>
-        [Test]
-        [TestCase(100, 100, 45, 141, 141)]
-        [TestCase(100, 100, 30, 137, 137)]
-        [TestCase(100, 200, 50, 217, 205)]
-        [TestCase(100, 200, -50, 217, 205)]
-        public void BoundingRotatedRectangleIsCalculated(int width, int height, float angle, int expectedWidth, int expectedHeight)
+        [TestFixture]
+        public class WhenGettingRotatedBoundingRectangleIsCalculated
         {
-            Rectangle result = ImageMaths.GetBoundingRotatedRectangle(width, height, angle);
+            /// <summary>
+            /// Tests that the bounding rectangle of a rotated image is calculated
+            /// </summary>
+            /// <param name="width">The width of the image.</param>
+            /// <param name="height">The height of the image.</param>
+            /// <param name="angle">The rotation angle.</param>
+            /// <param name="expectedWidth">The expected width.</param>
+            /// <param name="expectedHeight">The expected height.</param>
+            [Test]
+            [TestCase(100, 100, 45, 141, 141)]
+            [TestCase(100, 100, 30, 137, 137)]
+            [TestCase(100, 200, 50, 217, 205)]
+            [TestCase(100, 200, -50, 217, 205)]
+            public void BoundingRotatedRectangleIsCalculated(int width, int height, float angle, int expectedWidth, int expectedHeight)
+            {
+                Rectangle result = ImageMaths.GetBoundingRotatedRectangle(width, height, angle);
 
-            result.Width.Should().Be(expectedWidth, "because the rotated width should have been calculated");
-            result.Height.Should().Be(expectedHeight, "because the rotated height should have been calculated");
+                result.Width.Should().Be(expectedWidth, "because the rotated width should have been calculated");
+                result.Height.Should().Be(expectedHeight, "because the rotated height should have been calculated");
+            }
+
+            /// <summary>
+            /// Tests that the zoom needed for an "inside" rotation is calculated
+            /// </summary>
+            /// <param name="imageWidth">Width of the image.</param>
+            /// <param name="imageHeight">Height of the image.</param>
+            /// <param name="angle">The rotation angle.</param>
+            /// <param name="expected">The expected zoom.</param>
+            [Test]
+            [TestCase(100, 100, 45, 1.41f)]
+            [TestCase(100, 100, 15, 1.22f)]
+            [TestCase(100, 200, 45, 2.12f)]
+            [TestCase(200, 100, 45, 2.12f)]
+            [TestCase(600, 450, 20, 1.39f)]
+            [TestCase(600, 450, 45, 1.64f)]
+            [TestCase(100, 200, -45, 2.12f)]
+            public void RotationZoomIsCalculated(int imageWidth, int imageHeight, float angle, float expected)
+            {
+                float result = ImageMaths.ZoomAfterRotation(imageWidth, imageHeight, angle);
+
+                result.Should().BeApproximately(expected, 0.01f, "because the zoom level after rotation should have been calculated");
+
+                result.Should().BePositive("because we're always zooming in so the zoom level should always be positive");
+
+                result.Should().BeGreaterOrEqualTo(1, "because the zoom should always increase the size and not reduce it");
+            }
         }
 
         /// <summary>
-        /// Tests that the zoom needed for an "inside" rotation is calculated
+        /// The when rotate point.
         /// </summary>
-        /// <param name="imageWidth">Width of the image.</param>
-        /// <param name="imageHeight">Height of the image.</param>
-        /// <param name="angle">The rotation angle.</param>
-        /// <param name="expected">The expected zoom.</param>
-        [Test]
-        [TestCase(100, 100, 45, 1.41f)]
-        [TestCase(100, 100, 15, 1.22f)]
-        [TestCase(100, 200, 45, 2.12f)]
-        [TestCase(200, 100, 45, 2.12f)]
-        [TestCase(600, 450, 20, 1.39f)]
-        [TestCase(600, 450, 45, 1.64f)]
-        [TestCase(100, 200, -45, 2.12f)]
-        public void RotationZoomIsCalculated(int imageWidth, int imageHeight, float angle, float expected)
+        [TestFixture]
+        public class WhenRotatePoint
         {
-            float result = ImageMaths.ZoomAfterRotation(imageWidth, imageHeight, angle);
+            /// <summary>
+            /// The then should return point with x 2 and y 2 given null center point and point to rotate x and y.
+            /// </summary>
+            /// <param name="pointToRotateX">
+            /// The point to rotate x.
+            /// </param>
+            /// <param name="pointToRotateY">
+            /// The point to rotate y.
+            /// </param>
+            /// <param name="expectedX">
+            /// The expected x.
+            /// </param>
+            /// <param name="expectedY">
+            /// The expected y.
+            /// </param>
+            [Test]
+            [TestCase(0, -25, 25, 0)]
+            [TestCase(25, 0, 0, 25)]
+            [TestCase(0, 25, -25, 0)]
+            [TestCase(-25, 0, 0, -25)]
+            public void ThenShouldReturnPointWithX2AndY2GivenNullCenterPointAndPointToRotateXAndY(int pointToRotateX, int pointToRotateY, int expectedX, int expectedY)
+            {
+                // Arrange
+                var pointToRotate = new Point(pointToRotateX, pointToRotateY);
 
-            result.Should().BeApproximately(expected, 0.01f, "because the zoom level after rotation should have been calculated");
+                // Act
+                var rotatePoint = ImageMaths.RotatePoint(pointToRotate, 90);
 
-            result.Should().BePositive("because we're always zooming in so the zoom level should always be positive");
+                // Assert
+                Assert.That(rotatePoint, Is.EqualTo(new Point(expectedX, expectedY)));
+            }
 
-            result.Should().BeGreaterOrEqualTo(1, "because the zoom should always increase the size and not reduce it");
+            /// <summary>
+            /// The then should return point with x 2 and y 2 given center point 25 and negative 25 and point to rotate x and y.
+            /// </summary>
+            /// <param name="pointToRotateX">
+            /// The point to rotate x.
+            /// </param>
+            /// <param name="pointToRotateY">
+            /// The point to rotate y.
+            /// </param>
+            /// <param name="expectedX">
+            /// The expected x.
+            /// </param>
+            /// <param name="expectedY">
+            /// The expected y.
+            /// </param>
+            [Test]
+            [TestCase(25, -30, 30, -25)]
+            [TestCase(30, -25, 25, -20)]
+            [TestCase(25, -20, 20, -25)]
+            [TestCase(20, -25, 25, -30)]
+            public void ThenShouldReturnPointWithX2AndY2GivenCenterPoint25AndNegative25AndPointToRotateXAndY(int pointToRotateX, int pointToRotateY, int expectedX, int expectedY)
+            {
+                // Arrange
+                var pointToRotate = new Point(pointToRotateX, pointToRotateY);
+
+                // Act
+                var rotatePoint = ImageMaths.RotatePoint(pointToRotate, 90, new Point(25, -25));
+
+                // Assert
+                Assert.That(rotatePoint, Is.EqualTo(new Point(expectedX, expectedY)));
+            }
         }
     }
 }

--- a/src/ImageProcessor/Imaging/Helpers/ImageMaths.cs
+++ b/src/ImageProcessor/Imaging/Helpers/ImageMaths.cs
@@ -281,7 +281,7 @@ namespace ImageProcessor.Imaging.Helpers
 
         /// <summary>
         /// Rotates one point around another
-        /// <see href="http://stackoverflow.com/questions/2259476/rotating-a-point-about-another-point-2d"/>
+        /// <see href="http://stackoverflow.com/a/13695630/82333"/>
         /// </summary>
         /// <param name="pointToRotate">The point to rotate.</param>
         /// <param name="angleInDegrees">The rotation angle in degrees.</param>
@@ -296,14 +296,17 @@ namespace ImageProcessor.Imaging.Helpers
             double angleInRadians = DegreesToRadians(angleInDegrees);
             double cosTheta = Math.Cos(angleInRadians);
             double sinTheta = Math.Sin(angleInRadians);
-
-            // translate back
-            // rotate point
-            var newX = ((pointToRotate.X - center.X) * cosTheta) - ((pointToRotate.Y - center.Y) * sinTheta);
-            var newY = ((pointToRotate.X - center.X) * sinTheta) + ((pointToRotate.Y - center.Y) * cosTheta);
-
-            // translate point back to origin
-            return new Point((int)(newX + center.X), (int)(newY + center.Y));
+            return new Point
+            {
+                X =
+                    (int)
+                    (cosTheta * (pointToRotate.X - center.X) -
+                    sinTheta * (pointToRotate.Y - center.Y) + center.X),
+                Y =
+                    (int)
+                    (sinTheta * (pointToRotate.X - center.X) +
+                    cosTheta * (pointToRotate.Y - center.Y) + center.Y)
+            };
         }
 
         /// <summary>

--- a/src/ImageProcessor/Imaging/Helpers/ImageMaths.cs
+++ b/src/ImageProcessor/Imaging/Helpers/ImageMaths.cs
@@ -281,7 +281,7 @@ namespace ImageProcessor.Imaging.Helpers
 
         /// <summary>
         /// Rotates one point around another
-        /// <see href="http://stackoverflow.com/questions/13695317/rotate-a-point-around-another-point"/>
+        /// <see href="http://stackoverflow.com/questions/2259476/rotating-a-point-about-another-point-2d"/>
         /// </summary>
         /// <param name="pointToRotate">The point to rotate.</param>
         /// <param name="angleInDegrees">The rotation angle in degrees.</param>
@@ -296,15 +296,14 @@ namespace ImageProcessor.Imaging.Helpers
             double angleInRadians = DegreesToRadians(angleInDegrees);
             double cosTheta = Math.Cos(angleInRadians);
             double sinTheta = Math.Sin(angleInRadians);
-            return new Point
-            {
-                X =
-                    (int)((cosTheta * (pointToRotate.X - center.X)) -
-                          ((sinTheta * (pointToRotate.Y - center.Y)) + center.X)),
-                Y =
-                    (int)((sinTheta * (pointToRotate.X - center.X)) +
-                          ((cosTheta * (pointToRotate.Y - center.Y)) + center.Y))
-            };
+
+            // translate back
+            // rotate point
+            var newX = ((pointToRotate.X - center.X) * cosTheta) - ((pointToRotate.Y - center.Y) * sinTheta);
+            var newY = ((pointToRotate.X - center.X) * sinTheta) + ((pointToRotate.Y - center.Y) * cosTheta);
+
+            // translate point back to origin
+            return new Point((int)(newX + center.X), (int)(newY + center.Y));
         }
 
         /// <summary>


### PR DESCRIPTION
Original code was using a bad stackoverflow answer that didn't work when you tried to rotate around a center point that wasn't 0, 0. This can be observed by running the new unit tests in the old version of the code.