### PR TITLE
Added CmykColorTests.cs

### DIFF
--- a/src/ImageProcessor.UnitTests/ImageProcessor.UnitTests.csproj
+++ b/src/ImageProcessor.UnitTests/ImageProcessor.UnitTests.csproj
@@ -65,6 +65,7 @@
     </Compile>
     <Compile Include="Extensions\DoubleExtensionsUnitTests.cs" />
     <Compile Include="Extensions\IntegerExtensionsUnitTests.cs" />
+    <Compile Include="Imaging\Colors\CmykColorTests.cs" />
     <Compile Include="Imaging\ColorUnitTests.cs" />
     <Compile Include="Imaging\CropLayerUnitTests.cs" />
     <Compile Include="Imaging\FastBitmapUnitTests.cs" />

--- a/src/ImageProcessor.UnitTests/Imaging/Colors/CmykColorTests.cs
+++ b/src/ImageProcessor.UnitTests/Imaging/Colors/CmykColorTests.cs
@@ -1,0 +1,110 @@
+﻿using System;
+using System.Drawing;
+using ImageProcessor.Imaging.Colors;
+using NUnit.Framework;
+namespace ImageProcessor.UnitTests.Imaging.Colors
+{
+    public class CmykColorTests
+    {
+        [TestFixture]
+        public class when_to_string
+        {
+            [Test]
+            public void then_should_return_empty_given_empty()
+            {
+                // Arrange
+                var cmyk = CmykColor.Empty;
+
+                // Act
+                var s = cmyk.ToString();
+
+                // Assert
+                Assert.That(s, Is.EqualTo("CmykColor [Empty]"));
+            }
+
+            [Test]
+            public void then_should_return_bracketed_cmyk_colors_given_color()
+            {
+                // Arrange
+                var cmyk = CmykColor.FromCmykColor(100f, 100f, 100f, 10f);
+
+                // Act
+                var s = cmyk.ToString();
+
+                // Assert
+                Assert.That(s, Is.EqualTo("CmykColor [ C=100, M=100, Y=100, K=10]"));
+            }
+        }
+
+        [TestFixture]
+        public class when_implicitly_converting_from_color_ranges
+        {
+            [Test]
+            public void then_should_return_cmyk_version_of_system_drawing_color_given_red()
+            {
+                // Arrange
+                var color = Color.Red;
+
+                // Act
+                CmykColor cmyk = color;
+
+                // Assert
+                Assert.That(cmyk.C, Is.EqualTo(0));
+                Assert.That(cmyk.M, Is.EqualTo(100));
+                Assert.That(cmyk.Y, Is.EqualTo(100));
+                Assert.That(cmyk.K, Is.EqualTo(0));
+            }
+
+            [Test]
+            public void then_should_return_cmyk_version_of_rgba_color_given_red()
+            {
+                // Arrange
+                var rgbaColor = RgbaColor.FromRgba(0xff, 0x0, 0x0);
+
+                // Act
+                var cmyk = (CmykColor)rgbaColor;
+
+                // Assert
+                Assert.That(cmyk.C, Is.EqualTo(0));
+                Assert.That(cmyk.M, Is.EqualTo(100));
+                Assert.That(cmyk.Y, Is.EqualTo(100));
+                Assert.That(cmyk.K, Is.EqualTo(0));
+            }
+            
+            [Test]
+            public void then_should_return_cmyk_version_of_hsla_color_given_red()
+            {
+                // Arrange
+                var hslaColor = HslaColor.FromHslaColor(0f, 1f, .5f, 1f);
+
+                // Act
+                var cmyk = (CmykColor)hslaColor;
+
+                // Assert
+                Assert.That(cmyk.C, Is.EqualTo(0));
+                Assert.That(cmyk.M, Is.EqualTo(100));
+                Assert.That(cmyk.Y, Is.EqualTo(100));
+                Assert.That(cmyk.K, Is.EqualTo(0));
+            }
+
+            /// <summary>
+            /// http://www.equasys.de/colorconversion.html
+            /// </summary>
+            [Test]
+            public void then_should_return_cmyk_version_of_ycbcr_color_given_red()
+            {
+                // Arrange
+                var yCbCrColor = YCbCrColor.FromColor(Color.Red); // :*( [See Below]
+
+                // Act
+                var cmyk = (CmykColor)yCbCrColor;
+
+                // Assert
+                Assert.That(cmyk.C, Is.EqualTo(0));
+                Assert.That(Math.Round(cmyk.M), Is.EqualTo(100)); // See, here's the thing
+                Assert.That(cmyk.Y, Is.EqualTo(100));             // YCbCr doesn't happily convert to RGB
+                Assert.That(Math.Round(cmyk.K), Is.EqualTo(0));   // Sad for me
+            }
+        }
+    }
+}

--- a/src/ImageProcessor/Imaging/Colors/RGBAColor.cs
+++ b/src/ImageProcessor/Imaging/Colors/RGBAColor.cs
@@ -270,21 +270,6 @@ namespace ImageProcessor.Imaging.Colors
         }
 
         /// <summary>
-        /// Allows the implicit conversion of an instance of <see cref="RgbaColor"/> to a 
-        /// <see cref="CmykColor"/>.
-        /// </summary>
-        /// <param name="rgbaColor">
-        /// The instance of <see cref="RgbaColor"/> to convert.
-        /// </param>
-        /// <returns>
-        /// An instance of <see cref="CmykColor"/>.
-        /// </returns>
-        public static implicit operator CmykColor(RgbaColor rgbaColor)
-        {
-            return CmykColor.FromColor(rgbaColor);
-        }
-
-        /// <summary>
         /// Returns a <see cref="System.String" /> that represents this instance.
         /// </summary>
         /// <returns>

--- a/src/ImageProcessor/Imaging/Colors/YCbCrColor.cs
+++ b/src/ImageProcessor/Imaging/Colors/YCbCrColor.cs
@@ -231,21 +231,6 @@ namespace ImageProcessor.Imaging.Colors
         }
 
         /// <summary>
-        /// Allows the implicit conversion of an instance of <see cref="YCbCrColor"/> to a 
-        /// <see cref="CmykColor"/>.
-        /// </summary>
-        /// <param name="ycbcrColor">
-        /// The instance of <see cref="YCbCrColor"/> to convert.
-        /// </param>
-        /// <returns>
-        /// An instance of <see cref="CmykColor"/>.
-        /// </returns>
-        public static implicit operator CmykColor(YCbCrColor ycbcrColor)
-        {
-            return CmykColor.FromColor(ycbcrColor);
-        }
-
-        /// <summary>
         /// Returns a <see cref="System.String" /> that represents this instance.
         /// </summary>
         /// <returns>


### PR DESCRIPTION
More tests need to be added.

Due to the the static analyzer saying some of the implicit operators were unusable due to ambiguousness, and per http://stackoverflow.com/questions/25775645/ambiguous-implicit-user-defined-conversions-in-net, I removed some implicit operators that were converting to other colors types.