### PR TITLE
Added HSLA color tests and cleaned up implicit conversions

### DIFF
--- a/src/ImageProcessor.UnitTests/ImageProcessor.UnitTests.csproj
+++ b/src/ImageProcessor.UnitTests/ImageProcessor.UnitTests.csproj
@@ -67,6 +67,7 @@
     <Compile Include="Extensions\IntegerExtensionsUnitTests.cs" />
     <Compile Include="Imaging\Colors\CmykColorTests.cs" />
     <Compile Include="Imaging\Colors\HslaColorTests.cs" />
+    <Compile Include="Imaging\Colors\RgbaColorTests.cs" />
     <Compile Include="Imaging\ColorUnitTests.cs" />
     <Compile Include="Imaging\CropLayerUnitTests.cs" />
     <Compile Include="Imaging\FastBitmapUnitTests.cs" />

--- a/src/ImageProcessor.UnitTests/ImageProcessor.UnitTests.csproj
+++ b/src/ImageProcessor.UnitTests/ImageProcessor.UnitTests.csproj
@@ -66,6 +66,7 @@
     <Compile Include="Extensions\DoubleExtensionsUnitTests.cs" />
     <Compile Include="Extensions\IntegerExtensionsUnitTests.cs" />
     <Compile Include="Imaging\Colors\CmykColorTests.cs" />
+    <Compile Include="Imaging\Colors\HslaColorTests.cs" />
     <Compile Include="Imaging\ColorUnitTests.cs" />
     <Compile Include="Imaging\CropLayerUnitTests.cs" />
     <Compile Include="Imaging\FastBitmapUnitTests.cs" />

--- a/src/ImageProcessor.UnitTests/Imaging/Colors/HslaColorTests.cs
+++ b/src/ImageProcessor.UnitTests/Imaging/Colors/HslaColorTests.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Drawing;
+using ImageProcessor.Imaging.Colors;
+using NUnit.Framework;
+
+namespace ImageProcessor.UnitTests.Imaging.Colors
+{
+    public class HslaColorTests
+    {
+        [TestFixture]
+        public class when_implicitly_converting_from_color_ranges
+        {
+            [Test]
+            public void then_should_return_hsla_version_of_system_drawing_color_given_red()
+            {
+                // Arrange
+                var color = Color.Red;
+
+                // Act
+                HslaColor hslaColor = color;
+
+                // Assert
+                Assert.That(hslaColor.H, Is.EqualTo(0));
+                Assert.That(hslaColor.S, Is.EqualTo(1.0f));
+                Assert.That(hslaColor.L, Is.EqualTo(.5f));
+                Assert.That(hslaColor.A, Is.EqualTo(1.0f));
+            }
+
+            [Test]
+            public void then_should_return_hsla_version_of_rgba_color_given_red()
+            {
+                // Arrange
+                var rgbaColor = RgbaColor.FromRgba(0xff, 0x0, 0x0);
+
+                // Act
+                var hslaColor = (HslaColor)rgbaColor;
+
+                // Assert
+                Assert.That(hslaColor.H, Is.EqualTo(0));
+                Assert.That(hslaColor.S, Is.EqualTo(1.0f));
+                Assert.That(hslaColor.L, Is.EqualTo(.5f));
+                Assert.That(hslaColor.A, Is.EqualTo(1.0f));
+            }
+
+            [Test]
+            public void then_should_return_hsla_version_of_cmyk_color_given_red()
+            {
+                // Arrange
+                var cmykColor = CmykColor.FromColor(Color.Red);
+
+                // Act
+                var hslaColor = (HslaColor)cmykColor;
+
+                // Assert
+                Assert.That(hslaColor.H, Is.EqualTo(0));
+                Assert.That(hslaColor.S, Is.EqualTo(1.0f));
+                Assert.That(hslaColor.L, Is.EqualTo(.5f));
+                Assert.That(hslaColor.A, Is.EqualTo(1.0f));
+            }
+
+            [Test]
+            public void then_should_return_hsla_version_of_ycbcr_color_given_red()
+            {
+                // Arrange
+                var yCbCrColor = YCbCrColor.FromColor(Color.Red);
+
+                // Act
+                var hslaColor = (HslaColor)yCbCrColor;
+
+                // Assert
+                Assert.That(hslaColor.H, Is.EqualTo(0));
+                Assert.That(hslaColor.S, Is.EqualTo(1.0f));
+                Assert.That(Math.Round(hslaColor.L, 1), Is.EqualTo(.5f));   //YCbCr rounding issue
+                Assert.That(hslaColor.A, Is.EqualTo(1.0f));
+            }
+        }
+
+    }
+}

--- a/src/ImageProcessor.UnitTests/Imaging/Colors/RgbaColorTests.cs
+++ b/src/ImageProcessor.UnitTests/Imaging/Colors/RgbaColorTests.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Drawing;
+using ImageProcessor.Imaging.Colors;
+using NUnit.Framework;
+
+namespace ImageProcessor.UnitTests.Imaging.Colors
+{
+    public class RgbaColorTests
+    {
+        [TestFixture]
+        public class when_implicitly_converting_from_color_ranges
+        {
+            [Test]
+            public void then_should_return_rgba_version_of_system_drawing_color_given_red()
+            {
+                // Arrange
+                var color = Color.Red;
+
+                // Act
+                RgbaColor rgbaColor = color;
+
+                // Assert
+                Assert.That(rgbaColor.R, Is.EqualTo(255));
+                Assert.That(rgbaColor.G, Is.EqualTo(0));
+                Assert.That(rgbaColor.B, Is.EqualTo(0));
+                Assert.That(rgbaColor.A, Is.EqualTo(255));
+            }
+
+            [Test]
+            public void then_should_return_rgba_version_of_cmyk_color_given_red()
+            {
+                // Arrange
+                var cmykColor = CmykColor.FromColor(Color.Red);
+
+                // Act
+                var rgbaColor = (RgbaColor)cmykColor;
+
+                // Assert
+                Assert.That(rgbaColor.R, Is.EqualTo(255));
+                Assert.That(rgbaColor.G, Is.EqualTo(0));
+                Assert.That(rgbaColor.B, Is.EqualTo(0));
+                Assert.That(rgbaColor.A, Is.EqualTo(255));
+            }
+
+            [Test]
+            public void then_should_return_rgba_version_of_hsla_color_given_red()
+            {
+                // Arrange
+                var hslaColor = HslaColor.FromColor(Color.Red);
+
+                // Act
+                var rgbaColor = (RgbaColor)hslaColor;
+
+                // Assert
+                Assert.That(rgbaColor.R, Is.EqualTo(255));
+                Assert.That(rgbaColor.G, Is.EqualTo(0));
+                Assert.That(rgbaColor.B, Is.EqualTo(0));
+                Assert.That(rgbaColor.A, Is.EqualTo(255));
+            }
+
+            [Test]
+            public void then_should_return_rgba_version_of_ycbcr_color_given_red()
+            {
+                // Arrange
+                var yCbCrColor = YCbCrColor.FromColor(Color.Red);
+
+                // Act
+                var rgbaColor = (RgbaColor)yCbCrColor;
+
+                // Assert
+                Assert.That(rgbaColor.R, Is.EqualTo(254)); //Conversion not perfect
+                Assert.That(rgbaColor.G, Is.EqualTo(0));
+                Assert.That(rgbaColor.B, Is.EqualTo(0));
+                Assert.That(rgbaColor.A, Is.EqualTo(255));
+            }
+        }
+
+    }
+}

--- a/src/ImageProcessor/Imaging/Colors/HSLAColor.cs
+++ b/src/ImageProcessor/Imaging/Colors/HSLAColor.cs
@@ -288,43 +288,6 @@ namespace ImageProcessor.Imaging.Colors
 
         /// <summary>
         /// Allows the implicit conversion of an instance of <see cref="HslaColor"/> to a 
-        /// <see cref="RgbaColor"/>.
-        /// </summary>
-        /// <param name="hslaColor">
-        /// The instance of <see cref="HslaColor"/> to convert.
-        /// </param>
-        /// <returns>
-        /// An instance of <see cref="RgbaColor"/>.
-        /// </returns>
-        public static implicit operator RgbaColor(HslaColor hslaColor)
-        {
-            float r = 0, g = 0, b = 0;
-            if (Math.Abs(hslaColor.l - 0) > .0001)
-            {
-                if (Math.Abs(hslaColor.s - 0) <= .0001)
-                {
-                    r = g = b = hslaColor.l;
-                }
-                else
-                {
-                    float temp2 = GetTemp2(hslaColor);
-                    float temp1 = (2.0f * hslaColor.l) - temp2;
-
-                    r = GetColorComponent(temp1, temp2, hslaColor.h + (1.0f / 3.0f));
-                    g = GetColorComponent(temp1, temp2, hslaColor.h);
-                    b = GetColorComponent(temp1, temp2, hslaColor.h - (1.0f / 3.0f));
-                }
-            }
-
-            return RgbaColor.FromRgba(
-                Convert.ToByte(255 * r),
-                Convert.ToByte(255 * g),
-                Convert.ToByte(255 * b),
-                Convert.ToByte(255 * hslaColor.a));
-        }
-
-        /// <summary>
-        /// Allows the implicit conversion of an instance of <see cref="HslaColor"/> to a 
         /// <see cref="YCbCrColor"/>.
         /// </summary>
         /// <param name="hslaColor">

--- a/src/ImageProcessor/Imaging/Colors/RGBAColor.cs
+++ b/src/ImageProcessor/Imaging/Colors/RGBAColor.cs
@@ -241,21 +241,6 @@ namespace ImageProcessor.Imaging.Colors
 
         /// <summary>
         /// Allows the implicit conversion of an instance of <see cref="RgbaColor"/> to a 
-        /// <see cref="HslaColor"/>.
-        /// </summary>
-        /// <param name="rgbaColor">
-        /// The instance of <see cref="RgbaColor"/> to convert.
-        /// </param>
-        /// <returns>
-        /// An instance of <see cref="HslaColor"/>.
-        /// </returns>
-        public static implicit operator HslaColor(RgbaColor rgbaColor)
-        {
-            return HslaColor.FromColor(rgbaColor);
-        }
-
-        /// <summary>
-        /// Allows the implicit conversion of an instance of <see cref="RgbaColor"/> to a 
         /// <see cref="YCbCrColor"/>.
         /// </summary>
         /// <param name="rgbaColor">

--- a/src/ImageProcessor/Imaging/Colors/YCbCrColor.cs
+++ b/src/ImageProcessor/Imaging/Colors/YCbCrColor.cs
@@ -201,21 +201,6 @@ namespace ImageProcessor.Imaging.Colors
         }
 
         /// <summary>
-        /// Allows the implicit conversion of an instance of <see cref="YCbCrColor"/> to a 
-        /// <see cref="RgbaColor"/>.
-        /// </summary>
-        /// <param name="ycbcrColor">
-        /// The instance of <see cref="YCbCrColor"/> to convert.
-        /// </param>
-        /// <returns>
-        /// An instance of <see cref="RgbaColor"/>.
-        /// </returns>
-        public static implicit operator RgbaColor(YCbCrColor ycbcrColor)
-        {
-            return RgbaColor.FromColor(ycbcrColor);
-        }
-
-        /// <summary>
         /// Returns a <see cref="System.String" /> that represents this instance.
         /// </summary>
         /// <returns>

--- a/src/ImageProcessor/Imaging/Colors/YCbCrColor.cs
+++ b/src/ImageProcessor/Imaging/Colors/YCbCrColor.cs
@@ -216,21 +216,6 @@ namespace ImageProcessor.Imaging.Colors
         }
 
         /// <summary>
-        /// Allows the implicit conversion of an instance of <see cref="YCbCrColor"/> to a 
-        /// <see cref="HslaColor"/>.
-        /// </summary>
-        /// <param name="ycbcrColor">
-        /// The instance of <see cref="YCbCrColor"/> to convert.
-        /// </param>
-        /// <returns>
-        /// An instance of <see cref="HslaColor"/>.
-        /// </returns>
-        public static implicit operator HslaColor(YCbCrColor ycbcrColor)
-        {
-            return HslaColor.FromColor(ycbcrColor);
-        }
-
-        /// <summary>
         /// Returns a <see cref="System.String" /> that represents this instance.
         /// </summary>
         /// <returns>


### PR DESCRIPTION
Same idea as the CmykColorTests, this provides tests to uncover the issue then cleans up implicit operators so they no longer conflict.