### PR TITLE
Simple change to emulate the V2 resize behaviour - if either width or…

### DIFF
--- a/src/ImageProcessor/Samplers/ImageSampleExtensions.cs
+++ b/src/ImageProcessor/Samplers/ImageSampleExtensions.cs
@@ -66,6 +66,7 @@ namespace ImageProcessor.Samplers
         /// <param name="width">The target image width.</param>
         /// <param name="height">The target image height.</param>
         /// <returns>The <see cref="Image"/></returns>
+        /// <remarks>Passing zero for one of height or width will automatically preserve the aspect ratio of the original image</remarks>
         public static Image Resize(this Image source, int width, int height)
         {
             return Resize(source, width, height, new RobidouxResampler());
@@ -79,6 +80,7 @@ namespace ImageProcessor.Samplers
         /// <param name="height">The target image height.</param>
         /// <param name="sampler">The <see cref="IResampler"/> to perform the resampling.</param>
         /// <returns>The <see cref="Image"/></returns>
+        /// <remarks>Passing zero for one of height or width will automatically preserve the aspect ratio of the original image</remarks>
         public static Image Resize(this Image source, int width, int height, IResampler sampler)
         {
             return Resize(source, width, height, sampler, source.Bounds);
@@ -96,8 +98,18 @@ namespace ImageProcessor.Samplers
         /// The <see cref="Rectangle"/> structure that specifies the portion of the image object to draw.
         /// </param>
         /// <returns>The <see cref="Image"/></returns>
+        /// <remarks>Passing zero for one of height or width will automatically preserve the aspect ratio of the original image</remarks>
         public static Image Resize(this Image source, int width, int height, IResampler sampler, Rectangle sourceRectangle)
         {
+            if (width == 0 && height > 0)
+            {
+                width = source.Width * height / source.Height;
+            }
+            if (height == 0 && width > 0)
+            {
+                height = source.Height * width / source.Width;
+            }
+
             return source.Process(width, height, sourceRectangle, new Rectangle(0, 0, width, height), new Resampler(sampler));
         }
 

--- a/tests/ImageProcessor.Tests/Processors/Samplers/SamplerTests.cs
+++ b/tests/ImageProcessor.Tests/Processors/Samplers/SamplerTests.cs
@@ -65,6 +65,62 @@
             }
         }
 
+        [Fact]
+        public void ImageShouldResizeWidthAndKeepAspect()
+        {
+            if (!Directory.Exists("TestOutput/Resize"))
+            {
+                Directory.CreateDirectory("TestOutput/Resize");
+            }
+
+            var name = "FixedWidth";
+
+            foreach (string file in Files)
+            {
+                using (FileStream stream = File.OpenRead(file))
+                {
+                    Stopwatch watch = Stopwatch.StartNew();
+                    Image image = new Image(stream);
+                    string filename = Path.GetFileNameWithoutExtension(file) + "-" + name + Path.GetExtension(file);
+                    using (FileStream output = File.OpenWrite($"TestOutput/Resize/{filename}"))
+                    {
+                        image.Resize(image.Width / 3, 0, new TriangleResampler())
+                             .Save(output);
+                    }
+
+                    Trace.WriteLine($"{name}: {watch.ElapsedMilliseconds}ms");
+                }
+            }
+        }
+
+        [Fact]
+        public void ImageShouldResizeHeightAndKeepAspect()
+        {
+            if (!Directory.Exists("TestOutput/Resize"))
+            {
+                Directory.CreateDirectory("TestOutput/Resize");
+            }
+
+            var name = "FixedHeight";
+
+            foreach (string file in Files)
+            {
+                using (FileStream stream = File.OpenRead(file))
+                {
+                    Stopwatch watch = Stopwatch.StartNew();
+                    Image image = new Image(stream);
+                    string filename = Path.GetFileNameWithoutExtension(file) + "-" + name + Path.GetExtension(file);
+                    using (FileStream output = File.OpenWrite($"TestOutput/Resize/{filename}"))
+                    {
+                        image.Resize(0, image.Height / 3, new TriangleResampler())
+                             .Save(output);
+                    }
+
+                    Trace.WriteLine($"{name}: {watch.ElapsedMilliseconds}ms");
+                }
+            }
+        }
+
         [Theory]
         [MemberData("RotateFlips")]
         public void ImageShouldRotateFlip(RotateType rotateType, FlipType flipType)


### PR DESCRIPTION
… height is zero, then the image is scaled keeping its aspect ratio.
I've added a couple of simple tests for the new code.

Please let me know if you'd like me to change anything - these are my first pull requests in GitHub, so my code may not be up to the standards you're expecting, or you may have had other expectations in terms of where the tests should have been placed, etc.