### PR TITLE
OutOfMemory exception processing animated GIF #308

### DIFF
--- a/src/ImageProcessor.Web/HttpModules/ImageProcessingModule.cs
+++ b/src/ImageProcessor.Web/HttpModules/ImageProcessingModule.cs
@@ -12,6 +12,7 @@ namespace ImageProcessor.Web.HttpModules
 {
     using System;
     using System.Collections.Generic;
+    using System.Collections.Specialized;
     using System.IO;
     using System.Linq;
     using System.Net;
@@ -21,6 +22,7 @@ namespace ImageProcessor.Web.HttpModules
     using System.Web;
     using System.Web.Hosting;
 
+    using ImageProcessor.Imaging;
     using ImageProcessor.Imaging.Formats;
     using ImageProcessor.Web.Caching;
     using ImageProcessor.Web.Configuration;
@@ -80,7 +82,7 @@ namespace ImageProcessor.Web.HttpModules
         /// without querystring parameters.
         /// </summary>
         private static bool? interceptAllRequests;
-
+        
         /// <summary>
         /// A value indicating whether this instance of the given entity has been disposed.
         /// </summary>
@@ -529,7 +531,9 @@ namespace ImageProcessor.Web.HttpModules
                         // Process the image.
                         bool exif = preserveExifMetaData != null && preserveExifMetaData.Value;
                         bool gamma = fixGamma != null && fixGamma.Value;
-                        using (ImageFactory imageFactory = new ImageFactory(exif, gamma))
+                        AnimationProcessMode mode = this.ParseAnimationMode(queryString);
+
+                        using (ImageFactory imageFactory = new ImageFactory(exif, gamma) { AnimationProcessMode = mode })
                         {
                             byte[] imageBuffer = null;
                             string mimeType;
@@ -628,6 +632,24 @@ namespace ImageProcessor.Web.HttpModules
                     }
                 }
             }
+        }
+
+        /// <summary>
+        /// Gets the animation mode passed in through the querystring, defaults to the default behaviour (All) if nothing found.
+        /// </summary>
+        /// <param name="queryString">The query string to search.</param>
+        /// <returns>
+        /// The process mode for frames in animated images.
+        /// </returns>
+        public AnimationProcessMode ParseAnimationMode(string queryString)
+        {
+            AnimationProcessMode mode = AnimationProcessMode.All;
+            NameValueCollection queryCollection = HttpUtility.ParseQueryString(queryString);
+            if (queryCollection.AllKeys.Contains("animationprocessmode", StringComparer.InvariantCultureIgnoreCase))
+            {
+                mode = QueryParamParser.Instance.ParseValue<AnimationProcessMode>(queryCollection["animationprocessmode"]);
+            }
+            return mode;
         }
 
         /// <summary>

--- a/src/ImageProcessor/Common/Extensions/ImageExtensions.cs
+++ b/src/ImageProcessor/Common/Extensions/ImageExtensions.cs
@@ -13,6 +13,7 @@ namespace ImageProcessor.Common.Extensions
     using System.Drawing;
     using System.Drawing.Imaging;
 
+    using ImageProcessor.Imaging;
     using ImageProcessor.Imaging.Formats;
 
     /// <summary>
@@ -28,16 +29,20 @@ namespace ImageProcessor.Common.Extensions
         /// </remarks>
         /// </summary>
         /// <param name="source">The source image to copy.</param>
+        /// <param name="animationProcessMode">The process mode for frames in animated images.</param>
         /// <param name="format">The <see cref="PixelFormat"/> to set the copied image to.</param>
         /// <returns>
         /// The <see cref="Image"/>.
         /// </returns>
-        public static Image Copy(this Image source, PixelFormat format = PixelFormat.Format32bppPArgb)
+        public static Image Copy(this Image source, AnimationProcessMode animationProcessMode, PixelFormat format = PixelFormat.Format32bppPArgb)
         {
             if (FormatUtilities.IsAnimated(source))
             {
+                // read from the correct first frame when performing additional processing
+                source.SelectActiveFrame(FrameDimension.Time, 0);
+
                 // TODO: Ensure that we handle other animated types.
-                GifDecoder decoder = new GifDecoder(source);
+                GifDecoder decoder = new GifDecoder(source, animationProcessMode);
                 GifEncoder encoder = new GifEncoder(null, null, decoder.LoopCount);
                 foreach (GifFrame frame in decoder.GifFrames)
                 {
@@ -52,6 +57,23 @@ namespace ImageProcessor.Common.Extensions
             Bitmap copy = ((Bitmap)source).Clone(new Rectangle(0, 0, source.Width, source.Height), format);
             copy.SetResolution(source.HorizontalResolution, source.VerticalResolution);
             return copy;
+        }
+
+        /// <summary>
+        /// Creates a copy of an image allowing you to set the pixel format.
+        /// Disposing of the original is the responsibility of the user.
+        /// <remarks>
+        /// Unlike the native <see cref="Image.Clone"/> method this also copies animation frames.
+        /// </remarks>
+        /// </summary>
+        /// <param name="source">The source image to copy.</param>
+        /// <param name="format">The <see cref="PixelFormat"/> to set the copied image to.</param>
+        /// <returns>
+        /// The <see cref="Image"/>.
+        /// </returns>
+        public static Image Copy(this Image source, PixelFormat format = PixelFormat.Format32bppPArgb)
+        {
+            return Copy(source, AnimationProcessMode.All, format);
         }
     }
 }

--- a/src/ImageProcessor/ImageFactory.cs
+++ b/src/ImageProcessor/ImageFactory.cs
@@ -161,6 +161,11 @@ namespace ImageProcessor
         internal Stream InputStream { get; set; }
         #endregion
 
+        /// <summary>
+        /// Gets or sets process mode for frames in animated images.
+        /// </summary>
+        public AnimationProcessMode AnimationProcessMode { get; set; }
+
         #region Methods
         /// <summary>
         /// Loads the image to process. Always call this method first.
@@ -211,10 +216,16 @@ namespace ImageProcessor
                 this.ExifPropertyItems[id] = this.Image.GetPropertyItem(id);
             }
 
+            IAnimatedImageFormat imageFormat = this.CurrentImageFormat as IAnimatedImageFormat;
+            if (imageFormat != null)
+            {
+                imageFormat.AnimationProcessMode = this.AnimationProcessMode;
+            }
+
             this.backupExifPropertyItems = this.ExifPropertyItems;
 
             // Ensure the image is in the most efficient format.
-            Image formatted = this.Image.Copy();
+            Image formatted = this.Image.Copy(this.AnimationProcessMode);
             this.Image.Dispose();
             this.Image = formatted;
 
@@ -276,8 +287,14 @@ namespace ImageProcessor
 
                     this.backupExifPropertyItems = this.ExifPropertyItems;
 
+                    IAnimatedImageFormat imageFormat = this.CurrentImageFormat as IAnimatedImageFormat;
+                    if (imageFormat != null)
+                    {
+                        imageFormat.AnimationProcessMode = this.AnimationProcessMode;
+                    }
+
                     // Ensure the image is in the most efficient format.
-                    Image formatted = this.Image.Copy();
+                    Image formatted = this.Image.Copy(this.AnimationProcessMode);
                     this.Image.Dispose();
                     this.Image = formatted;
 
@@ -331,8 +348,14 @@ namespace ImageProcessor
                 this.ExifPropertyItems[id] = this.Image.GetPropertyItem(id);
             }
 
+            IAnimatedImageFormat imageFormat = this.CurrentImageFormat as IAnimatedImageFormat;
+            if (imageFormat != null)
+            {
+                imageFormat.AnimationProcessMode = this.AnimationProcessMode;
+            }
+
             // Ensure the image is in the most efficient format.
-            Image formatted = this.Image.Copy();
+            Image formatted = this.Image.Copy(this.AnimationProcessMode);
             this.Image.Dispose();
             this.Image = formatted;
 
@@ -365,7 +388,7 @@ namespace ImageProcessor
 
                 // Dispose and reassign the image.
                 // Ensure the image is in the most efficient format.
-                Image formatted = newImage.Copy();
+                Image formatted = newImage.Copy(this.AnimationProcessMode);
                 newImage.Dispose();
                 this.Image.Dispose();
                 this.Image = formatted;

--- a/src/ImageProcessor/ImageProcessor.csproj
+++ b/src/ImageProcessor/ImageProcessor.csproj
@@ -138,7 +138,9 @@
     <Compile Include="Common\Helpers\IOHelper.cs" />
     <Compile Include="Configuration\NativeBinaryFactory.cs" />
     <Compile Include="Configuration\NativeMethods.cs" />
+    <Compile Include="Imaging\AnimationProcessMode.cs" />
     <Compile Include="Imaging\ComputerArchitectureInfo.cs" />
+    <Compile Include="Imaging\Formats\IAnimatedImageFormat.cs" />
     <Compile Include="Imaging\Helpers\Converters\BigEndianBitConverter.cs" />
     <Compile Include="Imaging\Helpers\Converters\Endianness.cs" />
     <Compile Include="Imaging\Helpers\Converters\LittleEndianBitConverter.cs" />

--- a/src/ImageProcessor/Imaging/AnimationProcessMode.cs
+++ b/src/ImageProcessor/Imaging/AnimationProcessMode.cs
@@ -1,0 +1,28 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="AnimationProcessMode.cs" company="James South">
+//   Copyright (c) James South.
+//   Licensed under the Apache License, Version 2.0.
+// </copyright>
+// <summary>
+//   Enumerated frame process modes to apply to animated images.
+// </summary>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace ImageProcessor.Imaging
+{
+    /// <summary>
+    /// Enumerated frame process modes to apply to animated images.
+    /// </summary>
+    public enum AnimationProcessMode
+    {
+        /// <summary>
+        /// Processes and keeps all the frames of an animated image.
+        /// </summary>
+        All,
+
+        /// <summary>
+        /// Processes and keeps only the first frame of an animated image.
+        /// </summary>
+        First
+    }
+}

--- a/src/ImageProcessor/Imaging/Formats/GifDecoder.cs
+++ b/src/ImageProcessor/Imaging/Formats/GifDecoder.cs
@@ -28,7 +28,10 @@ namespace ImageProcessor.Imaging.Formats
         /// <param name="image">
         /// The <see cref="Image"/> to decode.
         /// </param>
-        public GifDecoder(Image image)
+        /// <param name="animationProcessMode">
+        /// The <see cref="AnimationProcessMode" /> to use.
+        /// </param>
+        public GifDecoder(Image image, AnimationProcessMode animationProcessMode)
         {
             this.Height = image.Height;
             this.Width = image.Width;
@@ -48,7 +51,12 @@ namespace ImageProcessor.Imaging.Formats
                     // Get the times stored in the gif.
                     byte[] times = image.GetPropertyItem((int)ExifPropertyTag.FrameDelay).Value;
 
-                    for (int i = 0; i < frameCount; i++)
+                    AnimationProcessMode processMode = animationProcessMode;
+                    int framesToProcess = frameCount;
+                    if (processMode == AnimationProcessMode.First)
+                        framesToProcess = 1;
+
+                    for (int i = 0; i < framesToProcess; i++)
                     {
                         // Convert each 4-byte chunk into an integer.
                         // GDI returns a single array with all delays, while Mono returns a different array for each frame.
@@ -58,7 +66,7 @@ namespace ImageProcessor.Imaging.Formats
                         image.SelectActiveFrame(FrameDimension.Time, i);
                         Bitmap frame = new Bitmap(image);
                         frame.SetResolution(image.HorizontalResolution, image.VerticalResolution);
-                        
+
                         // TODO: Get positions.
                         gifFrames.Add(new GifFrame { Delay = delay, Image = frame });
 
@@ -81,6 +89,18 @@ namespace ImageProcessor.Imaging.Formats
             }
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GifDecoder"/> class.
+        /// </summary>
+        /// <param name="image">
+        /// The <see cref="Image"/> to decode.
+        /// </param>
+        public GifDecoder(Image image)
+            : this(image, AnimationProcessMode.All)
+        {
+            
+        }
+        
         /// <summary>
         /// Gets or sets the image width.
         /// </summary>
@@ -115,5 +135,6 @@ namespace ImageProcessor.Imaging.Formats
         /// Gets or sets the animation length in milliseconds.
         /// </summary>
         public double AnimationLength { get; set; }
+        
     }
 }

--- a/src/ImageProcessor/Imaging/Formats/GifFormat.cs
+++ b/src/ImageProcessor/Imaging/Formats/GifFormat.cs
@@ -22,12 +22,17 @@ namespace ImageProcessor.Imaging.Formats
     /// <summary>
     /// Provides the necessary information to support gif images.
     /// </summary>
-    public class GifFormat : FormatBase, IQuantizableImageFormat
+    public class GifFormat : FormatBase, IQuantizableImageFormat, IAnimatedImageFormat
     {
         /// <summary>
         /// The quantizer for reducing the image palette.
         /// </summary>
         private IQuantizer quantizer = new OctreeQuantizer(255, 8);
+
+        /// <summary>
+        /// The process mode for frames in animated images.
+        /// </summary>
+        public AnimationProcessMode AnimationProcessMode { get; set; }
 
         /// <summary>
         /// Gets the file headers.
@@ -96,7 +101,7 @@ namespace ImageProcessor.Imaging.Formats
         /// <param name="factory">The <see cref="ImageFactory" />.</param>
         public override void ApplyProcessor(Func<ImageFactory, Image> processor, ImageFactory factory)
         {
-            GifDecoder decoder = new GifDecoder(factory.Image);
+            GifDecoder decoder = new GifDecoder(factory.Image, factory.AnimationProcessMode);
             if (decoder.IsAnimated)
             {
                 GifEncoder encoder = new GifEncoder(null, null, decoder.LoopCount);

--- a/src/ImageProcessor/Imaging/Formats/IAnimatedImageFormat.cs
+++ b/src/ImageProcessor/Imaging/Formats/IAnimatedImageFormat.cs
@@ -1,0 +1,23 @@
+// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="IAnimatedImageFormat.cs" company="James South">
+//   Copyright (c) James South.
+//   Licensed under the Apache License, Version 2.0.
+// </copyright>
+// <summary>
+// The IAnimatedImageFormat interface for identifying animated image formats.
+// </summary>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace ImageProcessor.Imaging.Formats
+{
+    /// <summary>
+    /// The IAnimatedImageFormat interface for identifying animated image formats.
+    /// </summary>
+    public interface IAnimatedImageFormat
+    {
+        /// <summary>
+        /// Gets the animation process mode.
+        /// </summary>
+        AnimationProcessMode AnimationProcessMode { get; set; }
+    }
+}

--- a/src/ImageProcessor/Imaging/Resizer.cs
+++ b/src/ImageProcessor/Imaging/Resizer.cs
@@ -60,6 +60,11 @@ namespace ImageProcessor.Imaging
         public ISupportedImageFormat ImageFormat { get; set; }
 
         /// <summary>
+        /// Gets or sets process mode for frames in animated images.
+        /// </summary>
+        public AnimationProcessMode AnimationProcessMode { get; set; }
+
+        /// <summary>
         /// Resizes the given image.
         /// </summary>
         /// <param name="source">The source <see cref="Image"/> to resize.</param>
@@ -137,8 +142,24 @@ namespace ImageProcessor.Imaging
         /// </returns>
         protected virtual Bitmap ResizeLinear(Image source, int width, int height, Rectangle destination)
         {
+            return ResizeLinear(source, width, height, destination, AnimationProcessMode.All);
+        }
+
+        /// <summary>
+        /// Gets an image resized using the linear color space with gamma correction adjustments.
+        /// </summary>
+        /// <param name="source">The source image.</param>
+        /// <param name="width">The width to resize to.</param>
+        /// <param name="height">The height to resize to.</param>
+        /// <param name="destination">The destination rectangle.</param>
+        /// <param name="animationProcessMode">The process mode for frames in animated images.</param>
+        /// <returns>
+        /// The <see cref="Bitmap"/>.
+        /// </returns>
+        protected virtual Bitmap ResizeLinear(Image source, int width, int height, Rectangle destination, AnimationProcessMode animationProcessMode)
+        {
             // Adjust the gamma value so that the image is in the linear color space.
-            Bitmap linear = Adjustments.ToLinear(source.Copy());
+            Bitmap linear = Adjustments.ToLinear(source.Copy(animationProcessMode));
 
             Bitmap resized = new Bitmap(width, height, PixelFormat.Format32bppPArgb);
             resized.SetResolution(source.HorizontalResolution, source.VerticalResolution);
@@ -538,7 +559,7 @@ namespace ImageProcessor.Imaging
                     // Do the resize.
                     Rectangle destination = new Rectangle(destinationX, destinationY, destinationWidth, destinationHeight);
 
-                    newImage = linear ? this.ResizeLinear(source, width, height, destination) : this.ResizeComposite(source, width, height, destination);
+                    newImage = linear ? this.ResizeLinear(source, width, height, destination, AnimationProcessMode) : this.ResizeComposite(source, width, height, destination);
 
                     // Reassign the image.
                     source.Dispose();

--- a/src/ImageProcessor/Processors/Overlay.cs
+++ b/src/ImageProcessor/Processors/Overlay.cs
@@ -86,7 +86,8 @@ namespace ImageProcessor.Processors
                 {
                     // Find the maximum possible dimensions and resize the image.
                     ResizeLayer layer = new ResizeLayer(new Size(overlayWidth, overlayHeight), ResizeMode.Max);
-                    overlay = new Resizer(layer).ResizeImage(overlay, factory.FixGamma);
+                    Resizer resizer = new Resizer(layer) { AnimationProcessMode = factory.AnimationProcessMode };
+                    overlay = resizer.ResizeImage(overlay, factory.FixGamma);
                     overlayWidth = overlay.Width;
                     overlayHeight = overlay.Height;
                 }

--- a/src/ImageProcessor/Processors/Resize.cs
+++ b/src/ImageProcessor/Processors/Resize.cs
@@ -90,7 +90,7 @@ namespace ImageProcessor.Processors
 
                 resizeLayer.MaxSize = maxSize;
 
-                Resizer resizer = new Resizer(resizeLayer) { ImageFormat = factory.CurrentImageFormat };
+                Resizer resizer = new Resizer(resizeLayer) { ImageFormat = factory.CurrentImageFormat, AnimationProcessMode = factory.AnimationProcessMode };
                 newImage = resizer.ResizeImage(image, factory.FixGamma);
 
                 // Check that the original image has not been returned.


### PR DESCRIPTION
Learned some stuff about the code and noticed that what's handled in `GifDecoder` gets sent to `ImageExtensions.Copy`, sweet! So only need to update code in one place (I should've known).

So, this is just starting the conversation and explains a bit of what I've tried:
- I tried taking 10 frames from that giant 694 frame GIF and making an animation out of that with disastrous results (so this took frame number 0, 69, 69x2, 69x3, etc until 69x10 and mashed them together): 
  
![ogb-insider-blogs-googlelogox2-animated 1](https://cloud.githubusercontent.com/assets/304656/12787256/ec1f3c94-ca94-11e5-9149-c78f53133cfb.gif)
- I don't think processing many more than 10 frames is a very good idea, if there's many gifs, it will be rough on CPU/memory. 
- Decided to stick with just showing the first frame
  - This is currently hardcoded but needs to be configurable from querystring (please advise, not sure how to get the variable in the `GifDecoder`)
- The code is currently doing: 

```
                        // Reset the position.
                        if (i == last)
                        {
                            image.SelectActiveFrame(FrameDimension.Time, 0);
                        }
```

I don't know what this achieves, but if this is required to run then I need to fix it here for when there's only one frame processed (please advise).