### PR TITLE
Shutdown256 patch 1

### DIFF
--- a/src/ImageProcessorCore/Common/Extensions/ByteExtensions.cs
+++ b/src/ImageProcessorCore/Common/Extensions/ByteExtensions.cs
@@ -32,7 +32,8 @@ namespace ImageProcessorCore
             {
                 result = new byte[bytes.Length * 8 / bits];
 
-                int factor = (int)Math.Pow(2, bits) - 1;
+                // BUGFIX I dont think it should be there, but I am not sure if it breaks something else
+                //int factor = (int)Math.Pow(2, bits) - 1;
                 int mask = 0xFF >> (8 - bits);
                 int resultOffset = 0;
 
@@ -40,7 +41,7 @@ namespace ImageProcessorCore
                 {
                     for (int shift = 0; shift < 8; shift += bits)
                     {
-                        int colorIndex = ((b >> (8 - bits - shift)) & mask) * (255 / factor);
+                        int colorIndex = ((b >> (8 - bits - shift)) & mask); // * (255 / factor);
 
                         result[resultOffset] = (byte)colorIndex;
 

--- a/src/ImageProcessorCore/Formats/Png/PaletteIndexReader.cs
+++ b/src/ImageProcessorCore/Formats/Png/PaletteIndexReader.cs
@@ -56,9 +56,10 @@ namespace ImageProcessorCore.Formats
                     offset = ((this.row * header.Width) + i) * 4;
                     int pixelOffset = index * 3;
                     
-                    float r = newScanline[pixelOffset] / 255f;
-                    float g = newScanline[pixelOffset + 1] / 255f;
-                    float b = newScanline[pixelOffset + 2] / 255f;
+                    // BUGFIX changed newScanline[] to this.palette[] , 99% sure it was a typo and not intent
+                    float r = this.palette[pixelOffset] / 255f;
+                    float g = this.palette[pixelOffset + 1] / 255f;
+                    float b = this.palette[pixelOffset + 2] / 255f;
                     float a = this.paletteAlpha.Length > index
                                             ? this.paletteAlpha[index] / 255f
                                             : 1;


### PR DESCRIPTION
Fix for loading indexed png files

this is my test image (it represents precipitation over Europe at some point in time):
![weather-indexed4b](https://cloud.githubusercontent.com/assets/17111455/12883811/7f14fcc8-ce5a-11e5-87a2-56f1a855b03b.png)