### PR TITLE
Fix watermark text centering

### DIFF
--- a/src/ImageProcessor/ImageProcessor.csproj
+++ b/src/ImageProcessor/ImageProcessor.csproj
@@ -140,6 +140,7 @@
     <Compile Include="Configuration\NativeMethods.cs" />
     <Compile Include="Imaging\ComputerArchitectureInfo.cs" />
     <Compile Include="Imaging\AnimationProcessMode.cs" />
+    <Compile Include="Imaging\ComputerArchitectureInfo.cs" />
     <Compile Include="Imaging\Formats\IAnimatedImageFormat.cs" />
     <Compile Include="Imaging\Helpers\Converters\BigEndianBitConverter.cs" />
     <Compile Include="Imaging\Helpers\Converters\Endianness.cs" />

--- a/src/ImageProcessor/ImageProcessor.csproj
+++ b/src/ImageProcessor/ImageProcessor.csproj
@@ -140,7 +140,6 @@
     <Compile Include="Configuration\NativeMethods.cs" />
     <Compile Include="Imaging\ComputerArchitectureInfo.cs" />
     <Compile Include="Imaging\AnimationProcessMode.cs" />
-    <Compile Include="Imaging\ComputerArchitectureInfo.cs" />
     <Compile Include="Imaging\Formats\IAnimatedImageFormat.cs" />
     <Compile Include="Imaging\Helpers\Converters\BigEndianBitConverter.cs" />
     <Compile Include="Imaging\Helpers\Converters\Endianness.cs" />

--- a/src/ImageProcessor/Processors/Watermark.cs
+++ b/src/ImageProcessor/Processors/Watermark.cs
@@ -85,7 +85,7 @@ namespace ImageProcessor.Processors
                 {
                     using (Font font = this.GetFont(textLayer.FontFamily, fontSize, fontStyle))
                     {
-                        using (StringFormat drawFormat = new StringFormat())
+                        using (StringFormat drawFormat = StringFormat.GenericTypographic)
                         {
                             StringFormatFlags? formatFlags = this.GetFlags(textLayer);
                             if (formatFlags != null)
@@ -113,7 +113,7 @@ namespace ImageProcessor.Processors
                                 }
 
                                 // Set the hinting and draw the text.
-                                graphics.TextRenderingHint = TextRenderingHint.AntiAliasGridFit;
+                                graphics.TextRenderingHint = TextRenderingHint.AntiAlias;
 
                                 // Create bounds for the text.
                                 RectangleF bounds;


### PR DESCRIPTION
Updated PR from https://github.com/JimBobSquarePants/ImageProcessor/pull/326

> I discovered an issue while Watermark where centering the text was always a bit off. It was more obvious when the string barely fits in the parent image.

>I searched around and found the issue discussed here.

>http://stackoverflow.com/questions/1203087/why-is-graphics-measurestring-returning-a-higher-than-expected-number

Test code

```csharp
			using (var outStream = new MemoryStream())
			using (var imageFactory = new ImageFactory(false))
			{

				imageFactory.Load(imgBytes)
					.Watermark(new TextLayer { Text = "This should be a long enough string - that the text is not center aligned", FontColor = Color.White, FontSize = 36 })
					.Save(outStream);

				File.WriteAllBytes("before-pr.png", outStream.ToArray());

			}
```

**Before**

![before-pr](https://cloud.githubusercontent.com/assets/1302588/13009967/5d427998-d16d-11e5-8d8d-79818074cedd.png)

**After**

![after-pr](https://cloud.githubusercontent.com/assets/1302588/13009971/621b7bcc-d16d-11e5-8654-1fe39c15a2f5.png)