### PR TITLE
Fix failing ImageProcessor project build

### DIFF
--- a/src/ImageProcessor/ImageProcessor.csproj
+++ b/src/ImageProcessor/ImageProcessor.csproj
@@ -138,7 +138,6 @@
     <Compile Include="Common\Helpers\IOHelper.cs" />
     <Compile Include="Configuration\NativeBinaryFactory.cs" />
     <Compile Include="Configuration\NativeMethods.cs" />
-    <Compile Include="Imaging\ComputerArchitectureInfo.cs" />
     <Compile Include="Imaging\AnimationProcessMode.cs" />
     <Compile Include="Imaging\ComputerArchitectureInfo.cs" />
     <Compile Include="Imaging\Formats\IAnimatedImageFormat.cs" />


### PR DESCRIPTION
Remove duplicate file reference in .csproj from previous merge