### PR TITLE
Support for separate disk cache and bug fixes

### DIFF
--- a/src/ImageProcessor.Web/Caching/IImageCache.cs
+++ b/src/ImageProcessor.Web/Caching/IImageCache.cs
@@ -36,6 +36,11 @@ namespace ImageProcessor.Web.Caching
         int MaxDays { get; set; }
 
         /// <summary>
+        /// Gets or sets the maximum number of days to cache the image in the browser.
+        /// </summary>
+        int BrowserMaxDays { get; set; }
+
+        /// <summary>
         /// Gets a value indicating whether the image is new or updated in an asynchronous manner.
         /// </summary>
         /// <returns>

--- a/src/ImageProcessor.Web/Caching/ImageCacheBase.cs
+++ b/src/ImageProcessor.Web/Caching/ImageCacheBase.cs
@@ -191,7 +191,7 @@ namespace ImageProcessor.Web.Caching
         /// </returns>
         protected virtual bool IsExpired(DateTime creationDate)
         {
-            return creationDate.AddDays(this.MaxDays) < DateTime.UtcNow.AddDays(-this.MaxDays);
+            return creationDate < DateTime.UtcNow.AddDays(-this.MaxDays);
         }
     }
 }

--- a/src/ImageProcessor.Web/Caching/ImageCacheBase.cs
+++ b/src/ImageProcessor.Web/Caching/ImageCacheBase.cs
@@ -63,6 +63,7 @@ namespace ImageProcessor.Web.Caching
             this.Querystring = querystring;
             this.Settings = ImageProcessorConfiguration.Instance.ImageCacheSettings;
             this.MaxDays = ImageProcessorConfiguration.Instance.ImageCacheMaxDays;
+            this.BrowserMaxDays = ImageProcessorConfiguration.Instance.BrowserCacheMaxDays;
         }
 
         /// <summary>
@@ -79,6 +80,11 @@ namespace ImageProcessor.Web.Caching
         /// Gets or sets the maximum number of days to store the image.
         /// </summary>
         public int MaxDays { get; set; }
+
+        /// <summary>
+        /// Gets or sets the maximum number of days to cache the image in the browser.
+        /// </summary>
+        public int BrowserMaxDays { get; set; }
 
         /// <summary>
         /// Gets a value indicating whether the image is new or updated in an asynchronous manner.

--- a/src/ImageProcessor.Web/Configuration/ImageCacheSection.cs
+++ b/src/ImageProcessor.Web/Configuration/ImageCacheSection.cs
@@ -124,6 +124,26 @@ namespace ImageProcessor.Web.Configuration
             }
 
             /// <summary>
+            /// Gets or sets the maximum number of days to store an image in the browser cache.
+            /// </summary>
+            /// <value>The maximum number of days to store an image in the browser cache.</value>
+            /// <remarks>Defaults to 365 days if not set.</remarks>
+            [ConfigurationProperty("browserMaxDays", DefaultValue = "365", IsRequired = true)]
+            [IntegerValidator(ExcludeRange = false, MinValue = -1)]
+            public int BrowserMaxDays
+            {
+                get
+                {
+                    return (int)this["browserMaxDays"];
+                }
+
+                set
+                {
+                    this["browserMaxDays"] = value;
+                }
+            }
+
+            /// <summary>
             /// Gets the <see cref="SettingElementCollection"/>.
             /// </summary>
             /// <value>

--- a/src/ImageProcessor.Web/Configuration/ImageCacheSection.cs
+++ b/src/ImageProcessor.Web/Configuration/ImageCacheSection.cs
@@ -128,13 +128,17 @@ namespace ImageProcessor.Web.Configuration
             /// </summary>
             /// <value>The maximum number of days to store an image in the browser cache.</value>
             /// <remarks>Defaults to 365 days if not set.</remarks>
-            [ConfigurationProperty("browserMaxDays", DefaultValue = "365", IsRequired = true)]
+            [ConfigurationProperty("browserMaxDays", DefaultValue = "0", IsRequired = false)]
             [IntegerValidator(ExcludeRange = false, MinValue = -1)]
             public int BrowserMaxDays
             {
                 get
                 {
-                    return (int)this["browserMaxDays"];
+                    var maxDays = (int)this["browserMaxDays"];
+                    if (maxDays == 0) {
+                        maxDays = (int)this["maxDays"];
+                    }
+                    return maxDays;
                 }
 
                 set

--- a/src/ImageProcessor.Web/Configuration/ImageProcessorConfiguration.cs
+++ b/src/ImageProcessor.Web/Configuration/ImageProcessorConfiguration.cs
@@ -104,6 +104,11 @@ namespace ImageProcessor.Web.Configuration
         public int ImageCacheMaxDays { get; private set; }
 
         /// <summary>
+        /// Gets the browser cache max days.
+        /// </summary>
+        public int BrowserCacheMaxDays { get; private set; }
+
+        /// <summary>
         /// Gets the image cache settings.
         /// </summary>
         public Dictionary<string, string> ImageCacheSettings { get; private set; }
@@ -492,6 +497,7 @@ namespace ImageProcessor.Web.Configuration
 
                         this.ImageCache = type;
                         this.ImageCacheMaxDays = cache.MaxDays;
+                        this.BrowserCacheMaxDays = cache.BrowserMaxDays;
                         this.ImageCacheSettings = cache.Settings
                                                        .Cast<SettingElement>()
                                                        .ToDictionary(setting => setting.Key, setting => setting.Value);

--- a/src/ImageProcessor.Web/Configuration/Resources/cache.config.transform
+++ b/src/ImageProcessor.Web/Configuration/Resources/cache.config.transform
@@ -1,6 +1,6 @@
 <caching currentCache="DiskCache">
   <caches>
-    <cache name="DiskCache" type="ImageProcessor.Web.Caching.DiskCache, ImageProcessor.Web" maxDays="365">
+    <cache name="DiskCache" type="ImageProcessor.Web.Caching.DiskCache, ImageProcessor.Web" maxDays="365" browserMaxDays="7">
       <settings>
         <setting key="VirtualCachePath" value="~/app_data/cache"/>
       </settings>

--- a/src/ImageProcessor.Web/HttpModules/ImageProcessingModule.cs
+++ b/src/ImageProcessor.Web/HttpModules/ImageProcessingModule.cs
@@ -393,7 +393,7 @@ namespace ImageProcessor.Web.HttpModules
             // Set the headers
             if (this.imageCache != null)
             {
-                SetHeaders(context, responseType, dependencyFiles, this.imageCache.MaxDays);
+                SetHeaders(context, responseType, dependencyFiles, this.imageCache.BrowserMaxDays);
             }
         }
 

--- a/src/ImageProcessor.Web/HttpModules/ImageProcessingModule.cs
+++ b/src/ImageProcessor.Web/HttpModules/ImageProcessingModule.cs
@@ -510,13 +510,6 @@ namespace ImageProcessor.Web.HttpModules
                     resourcePath = requestPath;
                 }
 
-                // Check whether the path is valid for other requests.
-                // We've already checked the LocalImageService in GetImageServiceForRequest().
-                if (!(currentService is LocalFileImageService) && !currentService.IsValidRequest(resourcePath.ToString()))
-                {
-                    return;
-                }
-
                 string combined = requestPath + fullPath + queryString;
                 using (await Locker.LockAsync(combined))
                 {
@@ -724,22 +717,16 @@ namespace ImageProcessor.Web.HttpModules
         /// </returns>
         private IImageService GetImageServiceForRequest(HttpRequest request)
         {
-            IImageService imageService = null;
             IList<IImageService> services = ImageProcessorConfiguration.Instance.ImageServices;
 
             string path = request.Path.TrimStart('/');
             foreach (IImageService service in services)
             {
                 string key = service.Prefix;
-                if (!string.IsNullOrWhiteSpace(key) && path.StartsWith(key, StringComparison.InvariantCultureIgnoreCase))
+                if (!string.IsNullOrWhiteSpace(key) && path.StartsWith(key, StringComparison.InvariantCultureIgnoreCase) && service.IsValidRequest(path))
                 {
-                    imageService = service;
+                    return service;
                 }
-            }
-
-            if (imageService != null)
-            {
-                return imageService;
             }
 
             // Return the file based service.

--- a/tests/ImageProcessor.TestWebsite/config/imageprocessor/cache.config
+++ b/tests/ImageProcessor.TestWebsite/config/imageprocessor/cache.config
@@ -1,6 +1,6 @@
 ﻿<caching currentCache="DiskCache">
   <caches>
-    <cache name="DiskCache" type="ImageProcessor.Web.Caching.DiskCache, ImageProcessor.Web" maxDays="365" browserMaxDays="365">
+    <cache name="DiskCache" type="ImageProcessor.Web.Caching.DiskCache, ImageProcessor.Web" maxDays="365" browserMaxDays="7">
       <settings>
         <setting key="VirtualCachePath" value="~/app_data/cache"/>
       </settings>

--- a/tests/ImageProcessor.TestWebsite/config/imageprocessor/cache.config
+++ b/tests/ImageProcessor.TestWebsite/config/imageprocessor/cache.config
@@ -1,6 +1,6 @@
 ﻿<caching currentCache="DiskCache">
   <caches>
-    <cache name="DiskCache" type="ImageProcessor.Web.Caching.DiskCache, ImageProcessor.Web" maxDays="365">
+    <cache name="DiskCache" type="ImageProcessor.Web.Caching.DiskCache, ImageProcessor.Web" maxDays="365" browserMaxDays="365">
       <settings>
         <setting key="VirtualCachePath" value="~/app_data/cache"/>
       </settings>


### PR DESCRIPTION
For the project I am looking to use this tool for, I want to cache the disk based images for a long time (a year is a good default), however I need to make sure the browser cache expires in a reasonable amount of time and attempts to re-validate the image with the source in case it has changed. The code currently sends a value of 365 days for the images to be cached in the browser, so if an image is update before it expires in the browser, the user won't ever see the updated version.

Hence I think it is better to separate the amount of time it is cached on disk, and the amount of time it is cached in the browser.

I also fixed the expiration time stamp for the disk cache, and fixed the MVC sample project.

I also fixed up compile issues for the Framework branch and recovered missing images. Some unit tests still fail but I am not sure how to fix those (quite possibly the unit test images I recovered are incorrect and the correct ones need to be checked into Git).