### PR TITLE
Creates a cancelable event to validate the request

### DIFF
--- a/src/ImageProcessor.Web/Helpers/ValidatingRequestEventArgs.cs
+++ b/src/ImageProcessor.Web/Helpers/ValidatingRequestEventArgs.cs
@@ -1,0 +1,34 @@
+﻿using System.ComponentModel;
+using System.Web;
+
+namespace ImageProcessor.Web.Helpers
+{
+    /// <summary>
+    /// The validating request event args
+    /// </summary>
+    /// <remarks>
+    /// This can be used by event subscribers to cancel image processing based on the information contained in the 
+    /// request, or can be used to directly manipulate the querystring parameter that will be used to process the image.
+    /// </remarks>
+    public class ValidatingRequestEventArgs : CancelEventArgs
+    {
+        public ValidatingRequestEventArgs(HttpContextBase http, string queryString)
+        {
+            Context = http;
+            QueryString = queryString;
+        }
+
+        /// <summary>
+        /// Gets the current http context.
+        /// </summary>
+        public HttpContextBase Context { get; private set; }
+
+        /// <summary>
+        /// Gets/sets the query string
+        /// </summary>
+        /// <remarks>
+        /// Event subscribers can directly manipulate the querystring before it's used for image processing
+        /// </remarks>
+        public string QueryString { get; set; }
+    }
+}

--- a/src/ImageProcessor.Web/ImageProcessor.Web.csproj
+++ b/src/ImageProcessor.Web/ImageProcessor.Web.csproj
@@ -68,6 +68,7 @@
     <Compile Include="Helpers\QuerystringParser\QueryParamParser.cs" />
     <Compile Include="Helpers\QuerystringParser\Converters\GenericArrayTypeConverter.cs" />
     <Compile Include="Helpers\QuerystringParser\Converters\GenericListTypeConverter.cs" />
+    <Compile Include="Helpers\ValidatingRequestEventArgs.cs" />
     <Compile Include="Processors\DetectEdges.cs" />
     <Compile Include="Processors\EntropyCrop.cs" />
     <Compile Include="Processors\Halftone.cs" />


### PR DESCRIPTION
Creates a cancelable event to validate the request IP does the processing. This can be used to cancel the request based on parameters or to directly manipulate the parameters. This deprecates the ProcessQuerystringEventHandler and ProcessQuerystringEventHandler since events should not really return an object like string since that means multiple event handlers cannot effectively subscribe, instead the event should contain an args object that can be manipulated by multiple handlers if they are registered.