### PR TITLE
Fix project.json files

### DIFF
--- a/src/ImageProcessorCore/project.json
+++ b/src/ImageProcessorCore/project.json
@@ -13,26 +13,19 @@
     ]
   },
   "buildOptions": {
-    "allowUnsafe": true
+    "allowUnsafe": true,
+    "debugType": "portable"
   },
   "dependencies": {
     "NETStandard.Library": "1.5.0-rc2-24027",
     "System.Numerics.Vectors": "4.1.1-rc2-24027"
   },
   "frameworks": {
-    "netstandard1.5": {
-      "imports": "dnxcore50",
+    "netstandard1.1": {
       "dependencies": {
         "System.Threading": "4.0.11-rc2-24027",
         "System.Threading.Tasks": "4.0.11-rc2-24027",
         "System.Threading.Tasks.Parallel": "4.0.1-rc2-24027"
-      }
-    },
-    "net4.5.1": {
-      "frameworkAssemblies": {
-        "System.Threading": "4.0.0",
-        "System.Threading.Tasks": "4.0.0",
-        "System.Threading.Tasks.Parallel": "4.0.0"
       }
     }
   }

--- a/tests/ImageProcessorCore.Benchmarks/project.json
+++ b/tests/ImageProcessorCore.Benchmarks/project.json
@@ -20,10 +20,15 @@
     "ImageProcessorCore.Benchmarks": "ImageProcessorCore.Benchmarks"
   },
   "frameworks": {
-    "net4.5.1": {
-      "frameworkAssemblies": {
-        "System.Drawing": "4.0.0.0"
-      }
-    }
+        "net451": {
+            "dependencies": {
+            },
+            "imports": [
+                "dnx451"
+            ],
+            "frameworkAssemblies": {
+              "System.Drawing":"4.0.0.0"
+            }
+        }
   }
 }

--- a/tests/ImageProcessorCore.Tests/project.json
+++ b/tests/ImageProcessorCore.Tests/project.json
@@ -9,16 +9,27 @@
       "Image Resize Crop Quality Gif Jpg Jpeg Bitmap Png Fluent Animated"
     ]
   },
+  "buildOptions": {
+    "debugType": "portable"
+  },
   "dependencies": {
     "ImageProcessorCore": "1.0.0-*",
-    "xunit": "2.2.0-beta1-build3239",
-    "xunit.runner.dnx": "2.1.0-rc1-build204"
+    "System.Diagnostics.TraceSource": "4.0.0-rc2-24027",
+    "xunit": "2.1.0",
+    "dotnet-test-xunit": "1.0.0-rc2-build10015"
   },
   "frameworks": {
-    "dnx451": {
-    }
-  },
-  "commands": {
-    "test": "xunit.runner.dnx"
+        "netcoreapp1.1": {
+            "dependencies": {
+                "Microsoft.NETCore.App": {
+                    "type": "platform",
+                    "version": "1.0.0-rc2-3002702"
+                }
+            },
+            "imports": [
+                "dnxcore50",
+                "portable-net45+win8"
+            ]
+        }
   }
 }


### PR DESCRIPTION
With these changes the project compiles against netstandard 1.1 which increases the number of platforms it can be used on by a lot  (see [platforms](https://github.com/dotnet/corefx/blob/master/Documentation/architecture/net-platform-standard.md)). The test project is compiled against netcoreapp1.0 and therefor runs on both the full framework as well as .net core. BenchmarkDotNet unfortunately only supports the full framework so I had to go with .net 4.5.1 for it. 