### PR TITLE
Explicitly list individual NuGet dependencies

### DIFF
--- a/src/ImageProcessorCore/project.json
+++ b/src/ImageProcessorCore/project.json
@@ -17,16 +17,22 @@
     "debugType": "portable"
   },
   "dependencies": {
-    "NETStandard.Library": "1.5.0-rc2-24027",
-    "System.Numerics.Vectors": "4.1.1-rc2-24027"
+    "System.Collections": "4.0.11-rc2-24027",
+    "System.Diagnostics.Debug": "4.0.11-rc2-24027",
+    "System.Diagnostics.Tools": "4.0.1-rc2-24027",
+    "System.IO": "4.1.0-rc2-24027",
+    "System.IO.Compression": "4.1.0-rc2-24027",
+    "System.Linq": "4.1.0-rc2-24027",
+    "System.Numerics.Vectors": "4.1.1-rc2-24027",
+    "System.Resources.ResourceManager": "4.0.1-rc2-24027",
+    "System.Runtime.Extensions": "4.1.0-rc2-24027",
+    "System.Runtime.InteropServices": "4.1.0-rc2-24027",
+    "System.Text.Encoding.Extensions": "4.0.11-rc2-24027",
+    "System.Threading": "4.0.11-rc2-24027",
+    "System.Threading.Tasks": "4.0.11-rc2-24027",
+    "System.Threading.Tasks.Parallel": "4.0.1-rc2-24027"
   },
   "frameworks": {
-    "netstandard1.1": {
-      "dependencies": {
-        "System.Threading": "4.0.11-rc2-24027",
-        "System.Threading.Tasks": "4.0.11-rc2-24027",
-        "System.Threading.Tasks.Parallel": "4.0.1-rc2-24027"
-      }
-    }
+    "netstandard1.1": {}
   }
 }


### PR DESCRIPTION
This replaces the "NETStandard.Library" reference with individual references to the libraries that are actually used from the standard library. This gives people who are consuming the package the freedom to be more granular about their dependencies.