### PR TITLE
304 passthrough for AzureBlobCache.streamCachedImage

### DIFF
--- a/src/ImageProcessor.Web.Plugins.AzureBlobCache/AzureBlobCache.cs
+++ b/src/ImageProcessor.Web.Plugins.AzureBlobCache/AzureBlobCache.cs
@@ -231,7 +231,7 @@ namespace ImageProcessor.Web.Plugins.AzureBlobCache
             await blockBlob.UploadFromStreamAsync(stream);
 
             blockBlob.Properties.ContentType = contentType;
-            blockBlob.Properties.CacheControl = string.Format("public, max-age={0}", this.MaxDays * 86400);
+            blockBlob.Properties.CacheControl = string.Format("public, max-age={0}", this.BrowserMaxDays * 86400);
             await blockBlob.SetPropertiesAsync();
 
             blockBlob.Metadata.Add("ImageProcessedBy", "ImageProcessor.Web/" + AssemblyVersion);


### PR DESCRIPTION
Fix for #428 

Maps HTTP headers between browser and Azure CDN to enable automatic handling of 304s