### PR TITLE
update to latest #BenchmarkDotNet version

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -1,6 +1,7 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="benchmarkDotNetDevelop" value="https://ci.appveyor.com/nuget/benchmarkdotnet" />
   </packageSources>
 </configuration>

--- a/tests/ImageProcessorCore.Benchmarks/Config.cs
+++ b/tests/ImageProcessorCore.Benchmarks/Config.cs
@@ -1,0 +1,14 @@
+﻿using BenchmarkDotNet.Configs;
+
+namespace ImageProcessorCore.Benchmarks
+{
+    public class Config : ManualConfig
+    {
+        public Config()
+        {
+            // uncomment if you want to use any of the diagnoser
+            //Add(new BenchmarkDotNet.Diagnostics.MemoryDiagnoser());
+            //Add(new BenchmarkDotNet.Diagnostics.InliningDiagnoser());
+        }
+    }
+}

--- a/tests/ImageProcessorCore.Benchmarks/Config.cs
+++ b/tests/ImageProcessorCore.Benchmarks/Config.cs
@@ -7,8 +7,8 @@ namespace ImageProcessorCore.Benchmarks
         public Config()
         {
             // uncomment if you want to use any of the diagnoser
-            //Add(new BenchmarkDotNet.Diagnostics.MemoryDiagnoser());
-            //Add(new BenchmarkDotNet.Diagnostics.InliningDiagnoser());
+            //Add(new BenchmarkDotNet.Diagnostics.Windows.MemoryDiagnoser());
+            //Add(new BenchmarkDotNet.Diagnostics.Windows.InliningDiagnoser());
         }
     }
 }

--- a/tests/ImageProcessorCore.Benchmarks/Program.cs
+++ b/tests/ImageProcessorCore.Benchmarks/Program.cs
@@ -1,11 +1,5 @@
 ﻿namespace ImageProcessorCore.Benchmarks
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Reflection;
-
-    using BenchmarkDotNet.Attributes;
     using BenchmarkDotNet.Running;
 
     public class Program
@@ -18,20 +12,7 @@
         /// </param>
         public static void Main(string[] args)
         {
-            // Use reflection for a more maintainable way of creating the benchmark switcher,
-            Type[] benchmarks = typeof(Program).Assembly.GetTypes()
-                .Where(t => t.GetMethods(BindingFlags.Instance | BindingFlags.Public)
-                             .Any(m => m.GetCustomAttributes(typeof(BenchmarkAttribute), false).Any()))
-                .OrderBy(t => t.Namespace)
-                .ThenBy(t => t.Name)
-                .ToArray();
-
-            // TODO: This throws an exception.
-            // List<string> x = new List<string>(args) { "diagnosers=MemoryDiagnoser,InliningDiagnoser" };
-            BenchmarkSwitcher benchmarkSwitcher = new BenchmarkSwitcher(benchmarks);
-            
-            // benchmarkSwitcher.Run(x.ToArray());
-            benchmarkSwitcher.Run(args);
+            new BenchmarkSwitcher(typeof(Program).Assembly).Run(args);
         }
     }
 }

--- a/tests/ImageProcessorCore.Benchmarks/Properties/AssemblyInfo.cs
+++ b/tests/ImageProcessorCore.Benchmarks/Properties/AssemblyInfo.cs
@@ -1,6 +1,8 @@
 ﻿using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using BenchmarkDotNet.Attributes;
+using ImageProcessorCore.Benchmarks;
 
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
@@ -21,3 +23,5 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("299d8e18-102c-42de-adbf-79098ee706a8")]
+
+[assembly: Config(typeof(Config))]

--- a/tests/ImageProcessorCore.Benchmarks/project.json
+++ b/tests/ImageProcessorCore.Benchmarks/project.json
@@ -13,8 +13,8 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "BenchmarkDotNet": "0.9.7",
-    "BenchmarkDotNet.Diagnostics.Windows": "0.9.7",
+    "BenchmarkDotNet": "0.9.8-develop",
+    "BenchmarkDotNet.Diagnostics.Windows": "0.9.8-develop",
     "ImageProcessorCore": "1.0.0-*"
   },
   "commands": {
@@ -24,12 +24,8 @@
     "net451": {
       "dependencies": {
       },
-      "imports": [
-        "dnx451"
-      ],
       "frameworkAssemblies": {
-        "System.Drawing": "",
-        "System.Runtime": ""
+        "System.Drawing": ""
       }
     }
   }

--- a/tests/ImageProcessorCore.Benchmarks/project.json
+++ b/tests/ImageProcessorCore.Benchmarks/project.json
@@ -13,8 +13,7 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "BenchmarkDotNet": "0.9.8-develop",
-    "BenchmarkDotNet.Diagnostics.Windows": "0.9.8-develop",
+    "BenchmarkDotNet.Diagnostics.Windows": "0.9.8.78",
     "ImageProcessorCore": "1.0.0-*"
   },
   "commands": {


### PR DESCRIPTION
Hello!

You have  reported a [bug in BenchmarkDotNet repo](https://github.com/PerfDotNet/BenchmarkDotNet/issues/231). 
I have now fixed it. The problem is that we will not ship next version soon, so I added link to our development feed to use the latest dll with the fix.

Extras:

- `BenchmarkSwitcher` can accept `Assembly` now so you don't need to mess with the reflection on your own
- I added an assembly-wide config for you, so if you want to use some Diagnosers you just need to uncomment the corresponding code (I noticed your comments left in the code which said that it did not work before)

Best regards,
Adam

