### PR TITLE
Customisation of Settings within ImageCacheBase

### DIFF
--- a/src/ImageProcessor.Web/Caching/ImageCacheBase.cs
+++ b/src/ImageProcessor.Web/Caching/ImageCacheBase.cs
@@ -61,10 +61,23 @@ namespace ImageProcessor.Web.Caching
             this.RequestPath = requestPath;
             this.FullPath = fullPath;
             this.Querystring = querystring;
-            this.Settings = ImageProcessorConfiguration.Instance.ImageCacheSettings;
+            this.Settings = this.AugmentSettingsCore(ImageProcessorConfiguration.Instance.ImageCacheSettings);
             this.MaxDays = ImageProcessorConfiguration.Instance.ImageCacheMaxDays;
             this.BrowserMaxDays = ImageProcessorConfiguration.Instance.BrowserCacheMaxDays;
         }
+
+        /// <summary>
+        /// Provides an entry point to augmentation of the <see cref="Settings"/> dictionary
+        /// </summary>
+        /// <param name="settings">Dictionary of settings</param>
+        /// <returns>augmented dictionary of settings</returns>
+        private Dictionary<string, string> AugmentSettingsCore(Dictionary<string, string> settings)
+        {
+            AugmentSettings(settings);
+            return settings;
+        }
+
+        protected virtual void AugmentSettings(Dictionary<string, string> settings) { }
 
         /// <summary>
         /// Gets or sets any additional settings required by the cache.


### PR DESCRIPTION
re #432 

As suggested, I have however added the ```AugmentSettings``` method to the base ```ImageCacheBase``` so that the S3 cache can use the same method to create the cache with custom settings resolver.