### PR TITLE
Changes to ImageProperty

### DIFF
--- a/src/ImageProcessorCore/Image/ImageProperty.cs
+++ b/src/ImageProcessorCore/Image/ImageProperty.cs
@@ -12,7 +12,7 @@ namespace ImageProcessorCore
     /// the copyright information, the date, where the image was created
     /// or some other information.
     /// </summary>
-    public struct ImageProperty : IEquatable<ImageProperty>
+    public class ImageProperty : IEquatable<ImageProperty>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ImageProperty"/> struct.
@@ -56,7 +56,7 @@ namespace ImageProcessorCore
         /// </returns>
         public static bool operator ==(ImageProperty left, ImageProperty right)
         {
-            return left.Equals(right);
+            return Equals(left, right);
         }
 
         /// <summary>
@@ -75,7 +75,7 @@ namespace ImageProcessorCore
         /// </returns>
         public static bool operator !=(ImageProperty left, ImageProperty right)
         {
-            return !left.Equals(right);
+            return !Equals(left, right);
         }
 
         /// <summary>
@@ -90,12 +90,12 @@ namespace ImageProcessorCore
         /// </returns>
         public override bool Equals(object obj)
         {
-            if (!(obj is ImageProperty))
+            ImageProperty other = obj as ImageProperty;
+
+            if (other == null)
             {
                 return false;
             }
-
-            ImageProperty other = (ImageProperty)obj;
 
             return other.Name == this.Name && other.Value == this.Value;
         }
@@ -136,6 +136,16 @@ namespace ImageProcessorCore
         /// <param name="other">An object to compare with this object.</param>
         public bool Equals(ImageProperty other)
         {
+            if (ReferenceEquals(other, null))
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, other))
+            {
+                return true;
+            }
+
             return this.Name.Equals(other.Name) && this.Value.Equals(other.Value);
         }
     }

--- a/src/ImageProcessorCore/Image/ImageProperty.cs
+++ b/src/ImageProcessorCore/Image/ImageProperty.cs
@@ -21,6 +21,8 @@ namespace ImageProcessorCore
         /// <param name="value">The value of the property.</param>
         public ImageProperty(string name, string value)
         {
+            Guard.NotNullOrEmpty(name, nameof(name));
+
             this.Name = name;
             this.Value = value;
         }
@@ -92,12 +94,7 @@ namespace ImageProcessorCore
         {
             ImageProperty other = obj as ImageProperty;
 
-            if (other == null)
-            {
-                return false;
-            }
-
-            return other.Name == this.Name && other.Value == this.Value;
+            return Equals(other);
         }
 
         /// <summary>
@@ -111,7 +108,11 @@ namespace ImageProcessorCore
             unchecked
             {
                 int hashCode = this.Name.GetHashCode();
-                hashCode = (hashCode * 397) ^ this.Value.GetHashCode();
+                if (this.Value != null)
+                {
+                    hashCode = (hashCode * 397) ^ this.Value.GetHashCode();
+                }
+
                 return hashCode;
             }
         }
@@ -146,7 +147,7 @@ namespace ImageProcessorCore
                 return true;
             }
 
-            return this.Name.Equals(other.Name) && this.Value.Equals(other.Value);
+            return this.Name.Equals(other.Name) && Equals(this.Value, other.Value);
         }
     }
 }

--- a/tests/ImageProcessorCore.Tests/Image/ImagePropertyTests.cs
+++ b/tests/ImageProcessorCore.Tests/Image/ImagePropertyTests.cs
@@ -56,11 +56,9 @@ namespace ImageProcessorCore.Tests
         [Fact]
         public void ConstructorThrowsWhenNameIsNullOrEmpty()
         {
-            Exception ex = Record.Exception(() => new ImageProperty(null, "Foo"));
-            Assert.IsType<ArgumentNullException>(ex);
+            Assert.Throws<ArgumentNullException>(() => new ImageProperty(null, "Foo"));
 
-            ex = Record.Exception(() => new ImageProperty(string.Empty, "Foo"));
-            Assert.IsType<ArgumentException>(ex);
+            Assert.Throws<ArgumentException>(() => new ImageProperty(string.Empty, "Foo"));
         }
 
         /// <summary>

--- a/tests/ImageProcessorCore.Tests/Image/ImagePropertyTests.cs
+++ b/tests/ImageProcessorCore.Tests/Image/ImagePropertyTests.cs
@@ -5,6 +5,7 @@
 
 namespace ImageProcessorCore.Tests
 {
+    using System;
     using Xunit;
 
     /// <summary>
@@ -36,6 +37,7 @@ namespace ImageProcessorCore.Tests
             ImageProperty property1 = new ImageProperty("Foo", "Bar");
             ImageProperty property2 = new ImageProperty("Foo", "Foo");
             ImageProperty property3 = new ImageProperty("Bar", "Bar");
+            ImageProperty property4 = new ImageProperty("Foo", null);
 
             Assert.False(property1.Equals("Foo"));
 
@@ -45,8 +47,34 @@ namespace ImageProcessorCore.Tests
             Assert.True(property1 != property2);
 
             Assert.NotEqual(property1, property3);
-            Assert.True(property1 != property3);
+            Assert.NotEqual(property1, property4);
         }
 
+        /// <summary>
+        /// Tests whether the constructor throws an exception when the property name is null or empty.
+        /// </summary>
+        [Fact]
+        public void ConstructorThrowsWhenNameIsNullOrEmpty()
+        {
+            Exception ex = Record.Exception(() => new ImageProperty(null, "Foo"));
+            Assert.IsType<ArgumentNullException>(ex);
+
+            ex = Record.Exception(() => new ImageProperty(string.Empty, "Foo"));
+            Assert.IsType<ArgumentException>(ex);
+        }
+
+        /// <summary>
+        /// Tests whether the constructor correctly assigns properties.
+        /// </summary>
+        [Fact]
+        public void ConstructorAssignsProperties()
+        {
+            ImageProperty property = new ImageProperty("Foo", null);
+            Assert.Equal("Foo", property.Name);
+            Assert.Equal(null, property.Value);
+
+            property = new ImageProperty("Foo", string.Empty);
+            Assert.Equal(string.Empty, property.Value);
+        }
     }
 }

--- a/tests/ImageProcessorCore.Tests/Image/ImagePropertyTests.cs
+++ b/tests/ImageProcessorCore.Tests/Image/ImagePropertyTests.cs
@@ -1,0 +1,52 @@
+﻿// <copyright file="ColorConversionTests.cs" company="James Jackson-South">
+// Copyright (c) James Jackson-South and contributors.
+// Licensed under the Apache License, Version 2.0.
+// </copyright>
+
+namespace ImageProcessorCore.Tests
+{
+    using Xunit;
+
+    /// <summary>
+    /// Tests the <see cref="ImageProperty"/> class.
+    /// </summary>
+    public class ImagePropertyTests
+    {
+        /// <summary>
+        /// Tests the equality operators for inequality.
+        /// </summary>
+        [Fact]
+        public void AreEqual()
+        {
+            ImageProperty property1 = new ImageProperty("Foo", "Bar");
+            ImageProperty property2 = new ImageProperty("Foo", "Bar");
+            ImageProperty property3 = null;
+
+            Assert.Equal(property1, property2);
+            Assert.True(property1 == property2);
+            Assert.Equal(property3, null);
+        }
+
+        /// <summary>
+        /// Tests the equality operators for equality.
+        /// </summary>
+        [Fact]
+        public void AreNotEqual()
+        {
+            ImageProperty property1 = new ImageProperty("Foo", "Bar");
+            ImageProperty property2 = new ImageProperty("Foo", "Foo");
+            ImageProperty property3 = new ImageProperty("Bar", "Bar");
+
+            Assert.False(property1.Equals("Foo"));
+
+            Assert.NotEqual(property1, null);
+
+            Assert.NotEqual(property1, property2);
+            Assert.True(property1 != property2);
+
+            Assert.NotEqual(property1, property3);
+            Assert.True(property1 != property3);
+        }
+
+    }
+}


### PR DESCRIPTION
This pull request includes the following changes for ImageProperty :

It is no longer a struct.
Guard that the name of a property can not be null or empty.
Make sure that Equals and GetHashCode can handle a null value.
Added unit tests.