### PR TITLE
Change encoder to use Image instead of ImageBase.

### DIFF
--- a/src/ImageProcessorCore/Formats/Bmp/BmpEncoder.cs
+++ b/src/ImageProcessorCore/Formats/Bmp/BmpEncoder.cs
@@ -43,7 +43,7 @@ namespace ImageProcessorCore.Formats
         }
 
         /// <inheritdoc/>
-        public void Encode<T,TP>(ImageBase<T,TP> image, Stream stream)
+        public void Encode<T,TP>(Image<T,TP> image, Stream stream)
             where T : IPackedVector<TP>
             where TP : struct
         {

--- a/src/ImageProcessorCore/Formats/Gif/GifEncoder.cs
+++ b/src/ImageProcessorCore/Formats/Gif/GifEncoder.cs
@@ -47,7 +47,7 @@ namespace ImageProcessorCore.Formats
         }
 
         /// <inheritdoc/>
-        public void Encode<T,TP>(ImageBase<T,TP> image, Stream stream)
+        public void Encode<T,TP>(Image<T,TP> image, Stream stream)
         where T : IPackedVector<TP>
         where TP : struct
         {

--- a/src/ImageProcessorCore/Formats/Gif/GifEncoderCore.cs
+++ b/src/ImageProcessorCore/Formats/Gif/GifEncoderCore.cs
@@ -40,20 +40,18 @@ namespace ImageProcessorCore.Formats
         public IQuantizer Quantizer { get; set; }
 
         /// <summary>
-        /// Encodes the image to the specified stream from the <see cref="ImageBase{T,TP}"/>.
+        /// Encodes the image to the specified stream from the <see cref="Image{T,TP}"/>.
         /// </summary>
         /// <typeparam name="T">The pixel format.</typeparam>
         /// <typeparam name="TP">The packed format. <example>long, float.</example></typeparam>
-        /// <param name="imageBase">The <see cref="ImageBase{T,TP}"/> to encode from.</param>
+        /// <param name="image">The <see cref="Image{T,TP}"/> to encode from.</param>
         /// <param name="stream">The <see cref="Stream"/> to encode the image data to.</param>
-        public void Encode<T, TP>(ImageBase<T, TP> imageBase, Stream stream)
+        public void Encode<T, TP>(Image<T, TP> image, Stream stream)
             where T : IPackedVector<TP>
             where TP : struct
         {
-            Guard.NotNull(imageBase, nameof(imageBase));
+            Guard.NotNull(image, nameof(image));
             Guard.NotNull(stream, nameof(stream));
-
-            Image<T, TP> image = (Image<T, TP>)imageBase;
 
             if (this.Quantizer == null)
             {
@@ -64,7 +62,7 @@ namespace ImageProcessorCore.Formats
             EndianBinaryWriter writer = new EndianBinaryWriter(EndianBitConverter.Little, stream);
 
             // Ensure that quality can be set but has a fallback.
-            int quality = this.Quality > 0 ? this.Quality : imageBase.Quality;
+            int quality = this.Quality > 0 ? this.Quality : image.Quality;
             this.Quality = quality > 0 ? quality.Clamp(1, 256) : 256;
 
             // Get the number of bits.
@@ -80,7 +78,7 @@ namespace ImageProcessorCore.Formats
             this.WriteLogicalScreenDescriptor(image, writer, quantized.TransparentIndex);
 
             // Write the first frame.
-            this.WriteGraphicalControlExtension(imageBase, writer, quantized.TransparentIndex);
+            this.WriteGraphicalControlExtension(image, writer, quantized.TransparentIndex);
             this.WriteImageDescriptor(image, writer);
             this.WriteColorTable(quantized, writer);
             this.WriteImageData(quantized, writer);

--- a/src/ImageProcessorCore/Formats/IImageEncoder.cs
+++ b/src/ImageProcessorCore/Formats/IImageEncoder.cs
@@ -38,13 +38,13 @@ namespace ImageProcessorCore.Formats
         bool IsSupportedFileExtension(string extension);
 
         /// <summary>
-        /// Encodes the image to the specified stream from the <see cref="ImageBase{T,P}"/>.
+        /// Encodes the image to the specified stream from the <see cref="Image{T,P}"/>.
         /// </summary>
         /// <typeparam name="T">The pixel format.</typeparam>
         /// <typeparam name="TP">The packed format. <example>long, float.</example></typeparam>
-        /// <param name="image">The <see cref="ImageBase{T,P}"/> to encode from.</param>
+        /// <param name="image">The <see cref="Image{T,P}"/> to encode from.</param>
         /// <param name="stream">The <see cref="Stream"/> to encode the image data to.</param>
-        void Encode<T, TP>(ImageBase<T, TP> image, Stream stream)
+        void Encode<T, TP>(Image<T, TP> image, Stream stream)
             where T : IPackedVector<TP>
             where TP : struct;
     }

--- a/src/ImageProcessorCore/Formats/Jpg/JpegDecoderCore.cs
+++ b/src/ImageProcessorCore/Formats/Jpg/JpegDecoderCore.cs
@@ -950,7 +950,7 @@ namespace ImageProcessorCore.Formats
         /// <param name="imageWidth">The width.</param>
         /// <param name="imageHeight">The height.</param>
         /// <param name="image">The image.</param>
-        private void ConvertFromGrayScale<T, TP>(int imageWidth, int imageHeight, ImageBase<T, TP> image)
+        private void ConvertFromGrayScale<T, TP>(int imageWidth, int imageHeight, Image<T, TP> image)
             where T : IPackedVector<TP>
             where TP : struct
         {
@@ -986,7 +986,7 @@ namespace ImageProcessorCore.Formats
         /// <param name="imageWidth">The width.</param>
         /// <param name="imageHeight">The height.</param>
         /// <param name="image">The image.</param>
-        private void ConvertFromYCbCr<T, TP>(int imageWidth, int imageHeight, ImageBase<T, TP> image)
+        private void ConvertFromYCbCr<T, TP>(int imageWidth, int imageHeight, Image<T, TP> image)
             where T : IPackedVector<TP>
             where TP : struct
         {
@@ -1031,7 +1031,7 @@ namespace ImageProcessorCore.Formats
         /// <param name="imageWidth">The width.</param>
         /// <param name="imageHeight">The height.</param>
         /// <param name="image">The image.</param>
-        private void ConvertFromRGB<T, TP>(int imageWidth, int imageHeight, ImageBase<T, TP> image)
+        private void ConvertFromRGB<T, TP>(int imageWidth, int imageHeight, Image<T, TP> image)
             where T : IPackedVector<TP>
             where TP : struct
         {
@@ -1071,14 +1071,14 @@ namespace ImageProcessorCore.Formats
         /// <typeparam name="T">The pixel format.</typeparam>
         /// <typeparam name="TP">The packed format. <example>long, float.</example></typeparam>
         /// <param name="image">The image to assign the resolution to.</param>
-        private void AssignResolution<T, TP>(ImageBase<T, TP> image)
+        private void AssignResolution<T, TP>(Image<T, TP> image)
             where T : IPackedVector<TP>
             where TP : struct
         {
             if (this.jfif && this.horizontalResolution > 0 && this.verticalResolution > 0)
             {
-                ((Image<T, TP>)image).HorizontalResolution = this.horizontalResolution;
-                ((Image<T, TP>)image).VerticalResolution = this.verticalResolution;
+                image.HorizontalResolution = this.horizontalResolution;
+                image.VerticalResolution = this.verticalResolution;
             }
         }
 

--- a/src/ImageProcessorCore/Formats/Jpg/JpegEncoder.cs
+++ b/src/ImageProcessorCore/Formats/Jpg/JpegEncoder.cs
@@ -78,7 +78,7 @@ namespace ImageProcessorCore.Formats
         }
 
         /// <inheritdoc/>
-        public void Encode<T, TP>(ImageBase<T, TP> image, Stream stream)
+        public void Encode<T, TP>(Image<T, TP> image, Stream stream)
             where T : IPackedVector<TP>
             where TP : struct
         {

--- a/src/ImageProcessorCore/Formats/Jpg/JpegEncoderCore.cs
+++ b/src/ImageProcessorCore/Formats/Jpg/JpegEncoderCore.cs
@@ -430,7 +430,7 @@ namespace ImageProcessorCore.Formats
 
         // Encode writes the Image m to w in JPEG 4:2:0 baseline format with the given
         // options. Default parameters are used if a nil *Options is passed.
-        public void Encode<T, TP>(ImageBase<T, TP> image, Stream stream, int quality, JpegSubsample sample)
+        public void Encode<T, TP>(Image<T, TP> image, Stream stream, int quality, JpegSubsample sample)
             where T : IPackedVector<TP>
             where TP : struct
         {
@@ -488,8 +488,8 @@ namespace ImageProcessorCore.Formats
             int componentCount = 3;
 
             // Write the Start Of Image marker.
-            double densityX = ((Image<T, TP>)image).HorizontalResolution;
-            double densityY = ((Image<T, TP>)image).VerticalResolution;
+            double densityX = image.HorizontalResolution;
+            double densityY = image.VerticalResolution;
 
             WriteApplicationHeader((short)densityX, (short)densityY);
 

--- a/src/ImageProcessorCore/Formats/Png/PngEncoder.cs
+++ b/src/ImageProcessorCore/Formats/Png/PngEncoder.cs
@@ -67,7 +67,7 @@ namespace ImageProcessorCore.Formats
         }
 
         /// <inheritdoc/>
-        public void Encode<T, TP>(ImageBase<T, TP> image, Stream stream)
+        public void Encode<T, TP>(Image<T, TP> image, Stream stream)
         where T : IPackedVector<TP>
         where TP : struct
         {

--- a/src/ImageProcessorCore/Image/ImageExtensions.cs
+++ b/src/ImageProcessorCore/Image/ImageExtensions.cs
@@ -24,7 +24,7 @@ namespace ImageProcessorCore
         /// <param name="source">The image this method extends.</param>
         /// <param name="stream">The stream to save the image to.</param>
         /// <exception cref="ArgumentNullException">Thrown if the stream is null.</exception>
-        public static void SaveAsBmp<T, TP>(this ImageBase<T, TP> source, Stream stream)
+        public static void SaveAsBmp<T, TP>(this Image<T, TP> source, Stream stream)
             where T : IPackedVector<TP>
             where TP : struct
             => new BmpEncoder().Encode(source, stream);
@@ -41,7 +41,7 @@ namespace ImageProcessorCore
         /// Anything equal to 256 and below will cause the encoder to save the image in an indexed format.
         /// </param>
         /// <exception cref="ArgumentNullException">Thrown if the stream is null.</exception>
-        public static void SaveAsPng<T, TP>(this ImageBase<T, TP> source, Stream stream, int quality = int.MaxValue)
+        public static void SaveAsPng<T, TP>(this Image<T, TP> source, Stream stream, int quality = int.MaxValue)
             where T : IPackedVector<TP>
             where TP : struct
             => new PngEncoder { Quality = quality }.Encode(source, stream);
@@ -55,7 +55,7 @@ namespace ImageProcessorCore
         /// <param name="stream">The stream to save the image to.</param>
         /// <param name="quality">The quality to save the image to. Between 1 and 100.</param>
         /// <exception cref="ArgumentNullException">Thrown if the stream is null.</exception>
-        public static void SaveAsJpeg<T, TP>(this ImageBase<T, TP> source, Stream stream, int quality = 75)
+        public static void SaveAsJpeg<T, TP>(this Image<T, TP> source, Stream stream, int quality = 75)
             where T : IPackedVector<TP>
             where TP : struct
             => new JpegEncoder { Quality = quality }.Encode(source, stream);
@@ -69,7 +69,7 @@ namespace ImageProcessorCore
         /// <param name="stream">The stream to save the image to.</param>
         /// <param name="quality">The quality to save the image to representing the number of colors. Between 1 and 256.</param>
         /// <exception cref="ArgumentNullException">Thrown if the stream is null.</exception>
-        internal static void SaveAsGif<T, TP>(this ImageBase<T, TP> source, Stream stream, int quality = 256)
+        internal static void SaveAsGif<T, TP>(this Image<T, TP> source, Stream stream, int quality = 256)
             where T : IPackedVector<TP>
             where TP : struct
             => new GifEncoder { Quality = quality }.Encode(source, stream);


### PR DESCRIPTION
Some of the encoders do a cast from ImageBase to Image to make sure they can access some properties. This patch changes the IImageEncoder to use Image instead of ImageBase and removes those casts.