### PR TITLE
Use jagged instead of multidimensional array

### DIFF
--- a/src/ImageProcessorCore/Samplers/Processors/Convolution/Convolution2DFilter.cs
+++ b/src/ImageProcessorCore/Samplers/Processors/Convolution/Convolution2DFilter.cs
@@ -23,7 +23,7 @@ namespace ImageProcessorCore.Processors
         /// </summary>
         /// <param name="kernelX">The horizontal gradient operator.</param>
         /// <param name="kernelY">The vertical gradient operator.</param>
-        public Convolution2DFilter(float[,] kernelX, float[,] kernelY)
+        public Convolution2DFilter(float[][] kernelX, float[][] kernelY)
         {
             this.KernelX = kernelX;
             this.KernelY = kernelY;
@@ -32,22 +32,20 @@ namespace ImageProcessorCore.Processors
         /// <summary>
         /// Gets the horizontal gradient operator.
         /// </summary>
-        public float[,] KernelX { get; }
+        public float[][] KernelX { get; }
 
         /// <summary>
         /// Gets the vertical gradient operator.
         /// </summary>
-        public float[,] KernelY { get; }
+        public float[][] KernelY { get; }
 
         /// <inheritdoc/>
         public override void Apply(ImageBase<TColor, TPacked> target, ImageBase<TColor, TPacked> source, Rectangle targetRectangle, Rectangle sourceRectangle, int startY, int endY)
         {
-            float[,] kernelX = this.KernelX;
-            float[,] kernelY = this.KernelY;
-            int kernelYHeight = kernelY.GetLength(0);
-            int kernelYWidth = kernelY.GetLength(1);
-            int kernelXHeight = kernelX.GetLength(0);
-            int kernelXWidth = kernelX.GetLength(1);
+            int kernelYHeight = KernelY.Length;
+            int kernelYWidth = KernelY[0].Length;
+            int kernelXHeight = KernelX.Length;
+            int kernelXWidth = KernelX[0].Length;
             int radiusY = kernelYHeight >> 1;
             int radiusX = kernelXWidth >> 1;
 
@@ -100,16 +98,16 @@ namespace ImageProcessorCore.Processors
 
                                     if (fy < kernelXHeight)
                                     {
-                                        rX += kernelX[fy, fx] * r;
-                                        gX += kernelX[fy, fx] * g;
-                                        bX += kernelX[fy, fx] * b;
+                                        rX += KernelX[fy][fx] * r;
+                                        gX += KernelX[fy][fx] * g;
+                                        bX += KernelX[fy][fx] * b;
                                     }
 
                                     if (fx < kernelYWidth)
                                     {
-                                        rY += kernelY[fy, fx] * r;
-                                        gY += kernelY[fy, fx] * g;
-                                        bY += kernelY[fy, fx] * b;
+                                        rY += KernelY[fy][fx] * r;
+                                        gY += KernelY[fy][fx] * g;
+                                        bY += KernelY[fy][fx] * b;
                                     }
                                 }
                             }

--- a/src/ImageProcessorCore/Samplers/Processors/Convolution/EdgeDetection/EdgeDetector2DFilter.cs
+++ b/src/ImageProcessorCore/Samplers/Processors/Convolution/EdgeDetection/EdgeDetector2DFilter.cs
@@ -18,12 +18,12 @@ namespace ImageProcessorCore.Processors
         /// <summary>
         /// Gets the horizontal gradient operator.
         /// </summary>
-        public abstract float[,] KernelX { get; }
+        public abstract float[][] KernelX { get; }
 
         /// <summary>
         /// Gets the vertical gradient operator.
         /// </summary>
-        public abstract float[,] KernelY { get; }
+        public abstract float[][] KernelY { get; }
 
         /// <inheritdoc/>
         public bool Grayscale { get; set; }

--- a/src/ImageProcessorCore/Samplers/Processors/Convolution/EdgeDetection/KayyaliProcessor.cs
+++ b/src/ImageProcessorCore/Samplers/Processors/Convolution/EdgeDetection/KayyaliProcessor.cs
@@ -15,20 +15,24 @@ namespace ImageProcessorCore.Processors
         where TColor : IPackedVector<TPacked>
         where TPacked : struct
     {
-        /// <inheritdoc/>
-        public override float[,] KernelX => new float[,]
+        private static readonly float[][] kernelX = new float[3][]
         {
-            { 6, 0, -6 },
-            { 0, 0, 0 },
-            { -6, 0, 6 }
+            new float[] { 6, 0, -6 },
+            new float[] { 0, 0, 0 },
+            new float[] { -6, 0, 6 }
+        };
+
+        private static readonly float[][] kernelY = new float[3][]
+        {
+            new float[] { -6, 0, 6 },
+            new float[] { 0, 0, 0 },
+            new float[] { 6, 0, -6 }
         };
 
         /// <inheritdoc/>
-        public override float[,] KernelY => new float[,]
-        {
-            { -6, 0, 6 },
-            { 0, 0, 0 },
-            { 6, 0, -6 }
-        };
+        public override float[][] KernelX => kernelX;
+
+        /// <inheritdoc/>
+        public override float[][] KernelY => kernelY;
     }
 }

--- a/src/ImageProcessorCore/Samplers/Processors/Convolution/EdgeDetection/PrewittProcessor.cs
+++ b/src/ImageProcessorCore/Samplers/Processors/Convolution/EdgeDetection/PrewittProcessor.cs
@@ -15,20 +15,24 @@ namespace ImageProcessorCore.Processors
         where TColor : IPackedVector<TPacked>
         where TPacked : struct
     {
-        /// <inheritdoc/>
-        public override float[,] KernelX => new float[,]
+        private static readonly float[][] kernelX = new float[3][]
         {
-            { -1, 0, 1 },
-            { -1, 0, 1 },
-            { -1, 0, 1 }
+            new float[] { -1, 0, 1 },
+            new float[] { -1, 0, 1 },
+            new float[] { -1, 0, 1 }
+        };
+
+        private static readonly float[][] kernelY = new float[3][]
+        {
+            new float[] { 1, 1, 1 },
+            new float[] { 0, 0, 0 },
+            new float[] { -1, -1, -1 }
         };
 
         /// <inheritdoc/>
-        public override float[,] KernelY => new float[,]
-        {
-            { 1, 1, 1 },
-            { 0, 0, 0 },
-            { -1, -1, -1 }
-        };
+        public override float[][] KernelX => kernelX;
+
+        /// <inheritdoc/>
+        public override float[][] KernelY => kernelY;
     }
 }

--- a/src/ImageProcessorCore/Samplers/Processors/Convolution/EdgeDetection/RobertsCrossProcessor.cs
+++ b/src/ImageProcessorCore/Samplers/Processors/Convolution/EdgeDetection/RobertsCrossProcessor.cs
@@ -15,18 +15,22 @@ namespace ImageProcessorCore.Processors
         where TColor : IPackedVector<TPacked>
         where TPacked : struct
     {
-        /// <inheritdoc/>
-        public override float[,] KernelX => new float[,]
+        private static readonly float[][] kernelX = new float[2][]
         {
-            { 1, 0 },
-            { 0, -1 }
+            new float[] { 1, 0 },
+            new float[] { 0, -1 }
+        };
+
+        private static readonly float[][] kernelY = new float[2][]
+        {
+            new float[] { 0, 1 },
+            new float[] { -1, 0 }
         };
 
         /// <inheritdoc/>
-        public override float[,] KernelY => new float[,]
-        {
-            { 0, 1 },
-            { -1, 0 }
-        };
+        public override float[][] KernelX => kernelX;
+
+        /// <inheritdoc/>
+        public override float[][] KernelY => kernelY;
     }
 }

--- a/src/ImageProcessorCore/Samplers/Processors/Convolution/EdgeDetection/ScharrProcessor.cs
+++ b/src/ImageProcessorCore/Samplers/Processors/Convolution/EdgeDetection/ScharrProcessor.cs
@@ -15,20 +15,24 @@ namespace ImageProcessorCore.Processors
         where TColor : IPackedVector<TPacked>
         where TPacked : struct
     {
-        /// <inheritdoc/>
-        public override float[,] KernelX => new float[,]
+        private static readonly float[][] kernelX = new float[3][]
         {
-            { -3, 0, 3 },
-            { -10, 0, 10 },
-            { -3, 0, 3 }
+            new float[] { -3, 0, 3 },
+            new float[] { -10, 0, 10 },
+            new float[] { -3, 0, 3 }
+        };
+
+        private static readonly float[][] kernelY = new float[3][]
+        {
+            new float[] { 3, 10, 3 },
+            new float[] { 0, 0, 0 },
+            new float[] { -3, -10, -3 }
         };
 
         /// <inheritdoc/>
-        public override float[,] KernelY => new float[,]
-        {
-            { 3, 10, 3 },
-            { 0, 0, 0 },
-            { -3, -10, -3 }
-        };
+        public override float[][] KernelX => kernelX;
+
+        /// <inheritdoc/>
+        public override float[][] KernelY => kernelY;
     }
 }

--- a/src/ImageProcessorCore/Samplers/Processors/Convolution/EdgeDetection/SobelProcessor.cs
+++ b/src/ImageProcessorCore/Samplers/Processors/Convolution/EdgeDetection/SobelProcessor.cs
@@ -15,20 +15,24 @@ namespace ImageProcessorCore.Processors
         where TColor : IPackedVector<TPacked>
         where TPacked : struct
     {
-        /// <inheritdoc/>
-        public override float[,] KernelX => new float[,]
+        private static readonly float[][] kernelX = new float[3][]
         {
-            { -1, 0, 1 },
-            { -2, 0, 2 },
-            { -1, 0, 1 }
+            new float[] { -1, 0, 1 },
+            new float[] { -2, 0, 2 },
+            new float[] { -1, 0, 1 }
+        };
+
+        private static readonly float[][] kernelY = new float[3][]
+        {
+            new float[] { -1, -2, -1 },
+            new float[] { 0, 0, 0 },
+            new float[] { 1, 2, 1 }
         };
 
         /// <inheritdoc/>
-        public override float[,] KernelY => new float[,]
-        {
-            { -1, -2, -1 },
-            { 0, 0, 0 },
-            { 1, 2, 1 }
-        };
+        public override float[][] KernelX => kernelX;
+
+        /// <inheritdoc/>
+        public override float[][] KernelY => kernelY;
     }
 }

--- a/tests/ImageProcessorCore.Benchmarks/Samplers/DetectEdges.cs
+++ b/tests/ImageProcessorCore.Benchmarks/Samplers/DetectEdges.cs
@@ -1,0 +1,47 @@
+﻿// <copyright file="DetectEdges.cs" company="James Jackson-South">
+// Copyright (c) James Jackson-South and contributors.
+// Licensed under the Apache License, Version 2.0.
+// </copyright>
+
+
+namespace ImageProcessorCore.Benchmarks
+{
+    using System.IO;
+
+    using BenchmarkDotNet.Attributes;
+
+    using CoreImage = ImageProcessorCore.Image;
+
+    public class DetectEdges
+    {
+        private CoreImage image;
+
+        [Setup]
+        public void ReadImage()
+        {
+            if (image == null)
+            {
+                using(FileStream stream = File.OpenRead("../ImageProcessorCore.Tests/TestImages/Formats/Bmp/Car.bmp"))
+                {
+                    image = new CoreImage(stream);
+                }
+            }
+        }
+
+        [Benchmark(Description = "ImageProcessorCore DetectEdges")]
+        public void ImageProcessorCoreDetectEdges()
+        {
+            image.DetectEdges(EdgeDetection.Kayyali);
+            image.DetectEdges(EdgeDetection.Kayyali);
+            image.DetectEdges(EdgeDetection.Kirsch);
+            image.DetectEdges(EdgeDetection.Lapacian3X3);
+            image.DetectEdges(EdgeDetection.Lapacian5X5);
+            image.DetectEdges(EdgeDetection.LaplacianOfGaussian);
+            image.DetectEdges(EdgeDetection.Prewitt);
+            image.DetectEdges(EdgeDetection.RobertsCross);
+            image.DetectEdges(EdgeDetection.Robinson);
+            image.DetectEdges(EdgeDetection.Scharr);
+            image.DetectEdges(EdgeDetection.Sobel);
+        }
+    }
+}


### PR DESCRIPTION
Use jagged instead of multidimensional array as suggested in #462.
Only create the kernels once in the filters.