### PR TITLE
Feature/better cache

### DIFF
--- a/src/ImageProcessor.Web.Plugins.AzureBlobCache/AzureBlobCache.cs
+++ b/src/ImageProcessor.Web.Plugins.AzureBlobCache/AzureBlobCache.cs
@@ -153,8 +153,6 @@ namespace ImageProcessor.Web.Plugins.AzureBlobCache
             // if the last time it was checked is greater than 5 seconds. This would be much better for perf
             // if there is a high throughput of image requests.
             string cachedFileName = await this.CreateCachedFileNameAsync();
-
-            // TODO: Make this configurable
             this.CachedPath = CachedImageHelper.GetCachedPath(cloudCachedBlobContainer.Uri.ToString(), cachedFileName, true, this.FolderDepth);
 
             // Do we insert the cache container? This seems to break some setups.
@@ -167,18 +165,13 @@ namespace ImageProcessor.Web.Plugins.AzureBlobCache
 
             if (new Uri(this.CachedPath).IsFile)
             {
-                FileInfo fileInfo = new FileInfo(this.CachedPath);
-
-                if (fileInfo.Exists)
+                if (File.Exists(this.CachedPath))
                 {
-                    // Pull the latest info.
-                    fileInfo.Refresh();
-
                     cachedImage = new CachedImage
                     {
                         Key = Path.GetFileNameWithoutExtension(this.CachedPath),
                         Path = this.CachedPath,
-                        CreationTimeUtc = fileInfo.CreationTimeUtc
+                        CreationTimeUtc = File.GetCreationTimeUtc(this.CachedPath)
                     };
 
                     CacheIndexer.Add(cachedImage);

--- a/src/ImageProcessor.Web.Plugins.AzureBlobCache/AzureBlobCache.cs
+++ b/src/ImageProcessor.Web.Plugins.AzureBlobCache/AzureBlobCache.cs
@@ -13,7 +13,6 @@ namespace ImageProcessor.Web.Plugins.AzureBlobCache
 {
     using System;
     using System.Collections.Generic;
-    using System.Globalization;
     using System.IO;
     using System.Linq;
     using System.Net;
@@ -23,8 +22,6 @@ namespace ImageProcessor.Web.Plugins.AzureBlobCache
 
     using ImageProcessor.Configuration;
     using ImageProcessor.Web.Caching;
-    using ImageProcessor.Web.Extensions;
-    using ImageProcessor.Web.Helpers;
     using ImageProcessor.Web.HttpModules;
 
     using Microsoft.WindowsAzure.Storage;
@@ -157,25 +154,13 @@ namespace ImageProcessor.Web.Plugins.AzureBlobCache
             // if there is a high throughput of image requests.
             string cachedFileName = await this.CreateCachedFileNameAsync();
 
-            // Collision rate of about 1 in 10000 for the folder structure.
-            // That gives us massive scope to store millions of files.
-            string pathFromKey = string.Join("\\", cachedFileName.ToCharArray().Take(6));
-            this.CachedPath = Path.Combine(cloudCachedBlobContainer.Uri.ToString(), pathFromKey, cachedFileName).Replace(@"\", "/");
+            // TODO: Make this configurable
+            this.CachedPath = CachedImageHelper.GetCachedPath(cloudCachedBlobContainer.Uri.ToString(), cachedFileName, true, 6);
 
             // Do we insert the cache container? This seems to break some setups.
             bool useCachedContainerInUrl = this.Settings.ContainsKey("UseCachedContainerInUrl") && this.Settings["UseCachedContainerInUrl"].ToLower() != "false";
 
-            if (useCachedContainerInUrl)
-            {
-                this.cachedRewritePath =
-                    Path.Combine(this.cachedCdnRoot, cloudCachedBlobContainer.Name, pathFromKey, cachedFileName)
-                        .Replace(@"\", "/");
-            }
-            else
-            {
-                this.cachedRewritePath = Path.Combine(this.cachedCdnRoot, pathFromKey, cachedFileName)
-                    .Replace(@"\", "/");
-            }
+            this.cachedRewritePath = CachedImageHelper.GetCachedPath(useCachedContainerInUrl ? Path.Combine(this.cachedCdnRoot, cloudCachedBlobContainer.Name) : this.cachedCdnRoot, cachedFileName, true, 0);
 
             bool isUpdated = false;
             CachedImage cachedImage = CacheIndexer.Get(this.CachedPath);
@@ -183,7 +168,7 @@ namespace ImageProcessor.Web.Plugins.AzureBlobCache
             if (new Uri(this.CachedPath).IsFile)
             {
                 FileInfo fileInfo = new FileInfo(this.CachedPath);
-
+            6
                 if (fileInfo.Exists)
                 {
                     // Pull the latest info.
@@ -231,8 +216,9 @@ namespace ImageProcessor.Web.Plugins.AzureBlobCache
             }
             else
             {
-                // Check to see if the cached image is set to expire.
-                if (this.IsExpired(cachedImage.CreationTimeUtc))
+                // Check to see if the cached image is set to expire
+                // or a new file with the same name has replaced our current image
+                if (this.IsExpired(cachedImage.CreationTimeUtc) || await this.IsUpdatedAsync(cachedImage.CreationTimeUtc))
                 {
                     CacheIndexer.Remove(this.CachedPath);
                     isUpdated = true;
@@ -277,17 +263,13 @@ namespace ImageProcessor.Web.Plugins.AzureBlobCache
         /// </returns>
         public override async Task TrimCacheAsync()
         {
-            Uri uri = new Uri(this.CachedPath);
-            string path = uri.GetLeftPart(UriPartial.Path).Substring(cloudCachedBlobContainer.Uri.ToString().Length + 1);
-            string parent = path.Substring(0, path.LastIndexOf('/') - 9);
-
             BlobContinuationToken continuationToken = null;
             List<IListBlobItem> results = new List<IListBlobItem>();
 
             // Loop through the all the files in a non blocking fashion.
             do
             {
-                BlobResultSegment response = await cloudCachedBlobContainer.ListBlobsSegmentedAsync(parent, true, BlobListingDetails.Metadata, 5000, continuationToken, null, null);
+                BlobResultSegment response = await cloudCachedBlobContainer.ListBlobsSegmentedAsync(string.Empty, true, BlobListingDetails.Metadata, 5000, continuationToken, null, null);
                 continuationToken = response.ContinuationToken;
                 results.AddRange(response.Results);
             }
@@ -312,31 +294,26 @@ namespace ImageProcessor.Web.Plugins.AzureBlobCache
         }
 
         /// <summary>
-        /// Gets a string identifying the cached file name.
+        /// Returns a value indicating whether the requested image has been updated.
         /// </summary>
-        /// <returns>
-        /// The asynchronous <see cref="Task"/> returning the value.
-        /// </returns>
-        public override async Task<string> CreateCachedFileNameAsync()
+        /// <param name="creationDate">The creation date.</param>
+        /// <returns>The <see cref="bool"/></returns>
+        private async Task<bool> IsUpdatedAsync(DateTime creationDate)
         {
-            string streamHash = string.Empty;
+            bool isUpdated = false;
 
             try
             {
                 if (new Uri(this.RequestPath).IsFile)
                 {
-                    // Get the hash for the filestream. That way we can ensure that if the image is
-                    // updated but has the same name we will know.
                     FileInfo imageFileInfo = new FileInfo(this.RequestPath);
                     if (imageFileInfo.Exists)
                     {
                         // Pull the latest info.
                         imageFileInfo.Refresh();
 
-                        // Checking the stream itself is far too processor intensive so we make a best guess.
-                        string creation = imageFileInfo.CreationTimeUtc.ToString(CultureInfo.InvariantCulture);
-                        string length = imageFileInfo.Length.ToString(CultureInfo.InvariantCulture);
-                        streamHash = $"{creation}{length}";
+                        // If it's newer than the cached file then it must be an update.
+                        isUpdated = imageFileInfo.LastWriteTimeUtc > creationDate;
                     }
                 }
                 else if (cloudSourceBlobContainer != null)
@@ -353,10 +330,7 @@ namespace ImageProcessor.Web.Plugins.AzureBlobCache
 
                         if (blockBlob.Properties.LastModified.HasValue)
                         {
-                            string creation = blockBlob.Properties.LastModified.Value.UtcDateTime.ToString(CultureInfo.InvariantCulture);
-
-                            string length = blockBlob.Properties.Length.ToString(CultureInfo.InvariantCulture);
-                            streamHash = $"{creation}{length}";
+                            isUpdated = blockBlob.Properties.LastModified.Value.UtcDateTime > creationDate;
                         }
                     }
                 }
@@ -366,28 +340,18 @@ namespace ImageProcessor.Web.Plugins.AzureBlobCache
                     HttpWebRequest request = (HttpWebRequest)WebRequest.Create(this.RequestPath);
                     request.Method = "HEAD";
 
-                    using (HttpWebResponse response = (HttpWebResponse)(await request.GetResponseAsync()))
+                    using (HttpWebResponse response = (HttpWebResponse)await request.GetResponseAsync())
                     {
-                        string lastModified = response.LastModified.ToUniversalTime().ToString(CultureInfo.InvariantCulture);
-                        string length = response.ContentLength.ToString(CultureInfo.InvariantCulture);
-                        streamHash = $"{lastModified}{length}";
+                        isUpdated = response.LastModified.ToUniversalTime() > creationDate;
                     }
                 }
             }
             catch
             {
-                streamHash = string.Empty;
+                isUpdated = false;
             }
 
-            // Use an sha1 hash of the full path including the querystring to create the image name.
-            // That name can also be used as a key for the cached image and we should be able to use
-            // The characters of that hash as sub-folders.
-            string parsedExtension = ImageHelpers.Instance.GetExtension(this.FullPath, this.Querystring);
-            string encryptedName = (streamHash + this.FullPath).ToSHA1Fingerprint();
-
-            string cachedFileName = $"{encryptedName}.{(!string.IsNullOrWhiteSpace(parsedExtension) ? parsedExtension.Replace(".", string.Empty) : "jpg")}";
-
-            return cachedFileName;
+            return isUpdated;
         }
 
         /// <summary>

--- a/src/ImageProcessor.Web.Plugins.AzureBlobCache/AzureBlobCache.cs
+++ b/src/ImageProcessor.Web.Plugins.AzureBlobCache/AzureBlobCache.cs
@@ -268,11 +268,8 @@ namespace ImageProcessor.Web.Plugins.AzureBlobCache
                 return;
             }
 
-            // Only perform one trimming operation at a time.
-            if (!IsTrimming)
+            await this.DebounceTrimmerAsync(async () =>
             {
-                IsTrimming = true;
-
                 // Jump up to the parent branch to clean through the cache.
                 string parent = string.Empty;
 
@@ -311,9 +308,7 @@ namespace ImageProcessor.Web.Plugins.AzureBlobCache
                     CacheIndexer.Remove(blob.Name);
                     await blob.DeleteAsync();
                 }
-
-                IsTrimming = false;
-            }
+            });
         }
 
         /// <summary>

--- a/src/ImageProcessor.Web.Plugins.AzureBlobCache/AzureBlobCache.cs
+++ b/src/ImageProcessor.Web.Plugins.AzureBlobCache/AzureBlobCache.cs
@@ -324,14 +324,10 @@ namespace ImageProcessor.Web.Plugins.AzureBlobCache
             {
                 if (new Uri(this.RequestPath).IsFile)
                 {
-                    FileInfo imageFileInfo = new FileInfo(this.RequestPath);
-                    if (imageFileInfo.Exists)
+                    if (File.Exists(this.RequestPath))
                     {
-                        // Pull the latest info.
-                        imageFileInfo.Refresh();
-
                         // If it's newer than the cached file then it must be an update.
-                        isUpdated = imageFileInfo.LastWriteTimeUtc > creationDate;
+                        isUpdated = File.GetLastWriteTimeUtc(this.RequestPath) > creationDate;
                     }
                 }
                 else if (cloudSourceBlobContainer != null)

--- a/src/ImageProcessor.Web/Caching/CachedImageHelper.cs
+++ b/src/ImageProcessor.Web/Caching/CachedImageHelper.cs
@@ -62,9 +62,9 @@ namespace ImageProcessor.Web.Caching
             // That name can also be used as a key for the cached image and we should be able to use
             // The characters of that hash as sub-folders.
             string parsedExtension = ImageHelpers.Instance.GetExtension(path, querystring);
-            string encryptedName = (path).ToSHA1Fingerprint();
+            string hashedName = (path).ToSHA1Fingerprint();
 
-            return $"{encryptedName}.{(!string.IsNullOrWhiteSpace(parsedExtension) ? parsedExtension.Replace(".", string.Empty) : "jpg")}";
+            return $"{hashedName}.{parsedExtension.Replace(".", string.Empty)}";
         }
 
         /// <summary>

--- a/src/ImageProcessor.Web/Caching/CachedImageHelper.cs
+++ b/src/ImageProcessor.Web/Caching/CachedImageHelper.cs
@@ -29,6 +29,11 @@ namespace ImageProcessor.Web.Caching
         /// <returns>The <see cref="string"/></returns>
         public static string GetCachedImageFileName(string path)
         {
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                throw new ArgumentNullException(nameof(path));
+            }
+
             int index = path.LastIndexOf("?", StringComparison.Ordinal);
 
             // Prevent overflow if path ends with a "?"

--- a/src/ImageProcessor.Web/Caching/CachedImageHelper.cs
+++ b/src/ImageProcessor.Web/Caching/CachedImageHelper.cs
@@ -1,0 +1,82 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="CachedFileHelper.cs" company="James Jackson-South">
+//   Copyright (c) James Jackson-South.
+//   Licensed under the Apache License, Version 2.0.
+// </copyright>
+// <summary>
+//   Provides helper methods to generate cached file names and paths.
+// </summary>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace ImageProcessor.Web.Caching
+{
+    using System;
+    using System.IO;
+    using System.Linq;
+
+    using ImageProcessor.Web.Extensions;
+    using ImageProcessor.Web.Helpers;
+
+    /// <summary>
+    /// Provides helper methods to generate cached file names and paths.
+    /// </summary>
+    public static class CachedImageHelper
+    {
+        /// <summary>
+        /// Gets the cached file name from the given path.
+        /// </summary>
+        /// <param name="path">The path to the image. This can be the full path plus querystring.</param>
+        /// <returns>The <see cref="string"/></returns>
+        public static string GetCachedImageFileName(string path)
+        {
+            int index = path.LastIndexOf("?", StringComparison.Ordinal);
+
+            // Prevent overflow if path ends with a "?"
+            if (index == path.Length - 1)
+            {
+                index = 0;
+            }
+
+            return GetCachedImageFileName(path, index > 0 ? path.Substring(index + 1) : string.Empty);
+        }
+
+        /// <summary>
+        /// Gets the cached file name from the given path.
+        /// </summary>
+        /// <param name="path">The request path to the image. This can be the full path plus querystring.</param>
+        /// <param name="querystring">The request querystring.</param>
+        /// <returns>The <see cref="string"/></returns>
+        public static string GetCachedImageFileName(string path, string querystring)
+        {
+            // Use an sha1 hash of the full path including the querystring to create the image name.
+            // That name can also be used as a key for the cached image and we should be able to use
+            // The characters of that hash as sub-folders.
+            string parsedExtension = ImageHelpers.Instance.GetExtension(path, querystring);
+            string encryptedName = (path).ToSHA1Fingerprint();
+
+            return $"{encryptedName}.{(!string.IsNullOrWhiteSpace(parsedExtension) ? parsedExtension.Replace(".", string.Empty) : "jpg")}";
+        }
+
+        /// <summary>
+        /// Gets the path to the cached file.
+        /// </summary>
+        /// <param name="cachedFolderPath">The path to the cached folder, relative or absolute.</param>
+        /// <param name="cachedFileName">The cached file name.</param>
+        /// <param name="makeVirtual">Whether to reverse the slashes in the path.</param>
+        /// <param name="depth">How deep to nest the image files in folders.</param>
+        /// <returns>The <see cref="string"/></returns>
+        public static string GetCachedPath(string cachedFolderPath, string cachedFileName, bool makeVirtual, int depth = 6)
+        {
+            if (depth < 0)
+            {
+                depth = 0;
+            }
+
+            string pathFromKey = string.Join("\\", cachedFileName.ToCharArray().Take(Math.Min(Path.GetFileNameWithoutExtension(cachedFileName).Length, depth)));
+
+            return makeVirtual
+                ? Path.Combine(cachedFolderPath, pathFromKey, cachedFileName).Replace(@"\", "/")
+                : Path.Combine(cachedFolderPath, pathFromKey, cachedFileName);
+        }
+    }
+}

--- a/src/ImageProcessor.Web/Caching/CachedImageHelper.cs
+++ b/src/ImageProcessor.Web/Caching/CachedImageHelper.cs
@@ -48,6 +48,16 @@ namespace ImageProcessor.Web.Caching
         /// <returns>The <see cref="string"/></returns>
         public static string GetCachedImageFileName(string path, string querystring)
         {
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                throw new ArgumentNullException(nameof(path));
+            }
+
+            if (string.IsNullOrWhiteSpace(querystring))
+            {
+                throw new ArgumentNullException(nameof(querystring));
+            }
+
             // Use an sha1 hash of the full path including the querystring to create the image name.
             // That name can also be used as a key for the cached image and we should be able to use
             // The characters of that hash as sub-folders.
@@ -67,6 +77,16 @@ namespace ImageProcessor.Web.Caching
         /// <returns>The <see cref="string"/></returns>
         public static string GetCachedPath(string cachedFolderPath, string cachedFileName, bool makeVirtual, int depth = 6)
         {
+            if (string.IsNullOrWhiteSpace(cachedFolderPath))
+            {
+                throw new ArgumentNullException(nameof(cachedFolderPath));
+            }
+
+            if (string.IsNullOrWhiteSpace(cachedFileName))
+            {
+                throw new ArgumentNullException(nameof(cachedFileName));
+            }
+
             if (depth < 0)
             {
                 depth = 0;

--- a/src/ImageProcessor.Web/Caching/DiskCache.cs
+++ b/src/ImageProcessor.Web/Caching/DiskCache.cs
@@ -152,15 +152,10 @@ namespace ImageProcessor.Web.Caching
             }
             else
             {
-                // Check to see if the cached image is set to expire.
-                if (this.IsExpired(cachedImage.CreationTimeUtc))
+                // Check to see if the cached image is set to expire
+                // or a new file with the same name has replaced our current image
+                if (this.IsExpired(cachedImage.CreationTimeUtc) || await this.IsUpdatedAsync(cachedImage.CreationTimeUtc))
                 {
-                    CacheIndexer.Remove(this.CachedPath);
-                    isUpdated = true;
-                }
-                else if (await this.IsUpdatedAsync(cachedImage.CreationTimeUtc))
-                {
-                    // A new file with the same name has replaced our current image
                     CacheIndexer.Remove(this.CachedPath);
                     isUpdated = true;
                 }
@@ -483,7 +478,7 @@ namespace ImageProcessor.Web.Caching
                     HttpWebRequest request = (HttpWebRequest)WebRequest.Create(this.RequestPath);
                     request.Method = "HEAD";
 
-                    using (HttpWebResponse response = (HttpWebResponse)(await request.GetResponseAsync()))
+                    using (HttpWebResponse response = (HttpWebResponse)await request.GetResponseAsync())
                     {
                         isUpdated = response.LastModified.ToUniversalTime() > creationDate;
                     }

--- a/src/ImageProcessor.Web/Caching/DiskCache.cs
+++ b/src/ImageProcessor.Web/Caching/DiskCache.cs
@@ -117,8 +117,6 @@ namespace ImageProcessor.Web.Caching
             // if the last time it was checked is greater than 5 seconds. This would be much better for perf
             // if there is a high throughput of image requests.
             string cachedFileName = await this.CreateCachedFileNameAsync();
-
-            // TODO: Make depth configurable.
             this.CachedPath = CachedImageHelper.GetCachedPath(this.absoluteCachePath, cachedFileName, false, this.FolderDepth);
             this.virtualCachedFilePath = CachedImageHelper.GetCachedPath(this.virtualCachePath, cachedFileName, true, this.FolderDepth);
 
@@ -127,18 +125,13 @@ namespace ImageProcessor.Web.Caching
 
             if (cachedImage == null)
             {
-                FileInfo fileInfo = new FileInfo(this.CachedPath);
-
-                if (fileInfo.Exists)
+                if (File.Exists(this.CachedPath))
                 {
-                    // Pull the latest info.
-                    fileInfo.Refresh();
-
                     cachedImage = new CachedImage
                     {
                         Key = Path.GetFileNameWithoutExtension(this.CachedPath),
                         Path = this.CachedPath,
-                        CreationTimeUtc = fileInfo.CreationTimeUtc
+                        CreationTimeUtc = File.GetCreationTimeUtc(this.CachedPath)
                     };
 
                     CacheIndexer.Add(cachedImage);

--- a/src/ImageProcessor.Web/Caching/DiskCache.cs
+++ b/src/ImageProcessor.Web/Caching/DiskCache.cs
@@ -220,7 +220,7 @@ namespace ImageProcessor.Web.Caching
                      // UNC folders can throw exceptions if the file doesn't exist.
                      foreach (DirectoryInfo directory in directories)
                      {
-                         IEnumerable<FileInfo> files = directory.EnumerateFiles().OrderBy(f => f.CreationTimeUtc);
+                         IEnumerable<FileInfo> files = directory.EnumerateFiles().AsParallel().OrderBy(f => f.CreationTimeUtc);
                          int count = files.Count();
 
                          foreach (FileInfo fileInfo in files)

--- a/src/ImageProcessor.Web/Caching/DiskCache.cs
+++ b/src/ImageProcessor.Web/Caching/DiskCache.cs
@@ -119,8 +119,8 @@ namespace ImageProcessor.Web.Caching
             string cachedFileName = await this.CreateCachedFileNameAsync();
 
             // TODO: Make depth configurable.
-            this.CachedPath = CachedImageHelper.GetCachedPath(this.absoluteCachePath, cachedFileName, false, 6);
-            this.virtualCachedFilePath = CachedImageHelper.GetCachedPath(this.virtualCachePath, cachedFileName, true, 6);
+            this.CachedPath = CachedImageHelper.GetCachedPath(this.absoluteCachePath, cachedFileName, false, this.FolderDepth);
+            this.virtualCachedFilePath = CachedImageHelper.GetCachedPath(this.virtualCachePath, cachedFileName, true, this.FolderDepth);
 
             bool isUpdated = false;
             CachedImage cachedImage = CacheIndexer.Get(this.CachedPath);
@@ -200,12 +200,19 @@ namespace ImageProcessor.Web.Caching
         /// </returns>
         public override async Task TrimCacheAsync()
         {
+            if (!this.TrimCache)
+            {
+                return;
+            }
+
             string directory = Path.GetDirectoryName(this.CachedPath);
 
             if (directory != null)
             {
-                // Jump up to the parent branch to clean through 1/36th of the cache.
-                DirectoryInfo rootDirectoryInfo = new DirectoryInfo(Path.Combine(validatedAbsoluteCachePath, Path.GetFileName(this.CachedPath).Substring(0, 1)));
+                // Jump up to the parent branch to clean through the cache.
+                // ReSharper disable once PossibleNullReferenceException
+                string parent = this.FolderDepth > 0 ? Path.GetFileName(this.CachedPath).Substring(0, 1) : string.Empty;
+                DirectoryInfo rootDirectoryInfo = new DirectoryInfo(Path.Combine(validatedAbsoluteCachePath, parent));
 
                 // UNC folders can throw exceptions if the file doesn't exist.
                 foreach (DirectoryInfo enumerateDirectory in await rootDirectoryInfo.SafeEnumerateDirectoriesAsync())

--- a/src/ImageProcessor.Web/Caching/IImageCache.cs
+++ b/src/ImageProcessor.Web/Caching/IImageCache.cs
@@ -41,6 +41,16 @@ namespace ImageProcessor.Web.Caching
         int BrowserMaxDays { get; set; }
 
         /// <summary>
+        /// Gets or sets the maximum number folder levels to nest the cached images.
+        /// </summary>
+        int FolderDepth { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to periodically trim the cache.
+        /// </summary>
+        bool TrimCache { get; set; }
+
+        /// <summary>
         /// Gets a value indicating whether the image is new or updated in an asynchronous manner.
         /// </summary>
         /// <returns>

--- a/src/ImageProcessor.Web/Caching/IImageCache.cs
+++ b/src/ImageProcessor.Web/Caching/IImageCache.cs
@@ -41,16 +41,6 @@ namespace ImageProcessor.Web.Caching
         int BrowserMaxDays { get; set; }
 
         /// <summary>
-        /// Gets or sets the maximum number folder levels to nest the cached images.
-        /// </summary>
-        int FolderDepth { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether to periodically trim the cache.
-        /// </summary>
-        bool TrimCache { get; set; }
-
-        /// <summary>
         /// Gets a value indicating whether the image is new or updated in an asynchronous manner.
         /// </summary>
         /// <returns>

--- a/src/ImageProcessor.Web/Caching/IImageCacheExtended.cs
+++ b/src/ImageProcessor.Web/Caching/IImageCacheExtended.cs
@@ -1,0 +1,28 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="IImageCacheExtended.cs" company="James Jackson-South">
+//   Copyright (c) James Jackson-South.
+//   Licensed under the Apache License, Version 2.0.
+// </copyright>
+// <summary>
+//   An extended image cache with additional configuration options.
+// </summary>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace ImageProcessor.Web.Caching
+{
+    /// <summary>
+    /// An extended image cache with additional configuration options.
+    /// </summary>
+    public interface IImageCacheExtended : IImageCache
+    {
+        /// <summary>
+        /// Gets or sets the maximum number folder levels to nest the cached images.
+        /// </summary>
+        int FolderDepth { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to periodically trim the cache.
+        /// </summary>
+        bool TrimCache { get; set; }
+    }
+}

--- a/src/ImageProcessor.Web/Caching/ImageCacheBase.cs
+++ b/src/ImageProcessor.Web/Caching/ImageCacheBase.cs
@@ -26,6 +26,16 @@ namespace ImageProcessor.Web.Caching
     public abstract class ImageCacheBase : IImageCache
     {
         /// <summary>
+        /// The object to lock against.
+        /// </summary>
+        private static readonly object Locker = new object();
+
+        /// <summary>
+        /// Whether the current cache is currently being trimmed.
+        /// </summary>
+        private static bool isTrimming;
+
+        /// <summary>
         /// The request path for the image.
         /// </summary>
         protected readonly string RequestPath;
@@ -64,6 +74,28 @@ namespace ImageProcessor.Web.Caching
             this.BrowserMaxDays = config.BrowserCacheMaxDays;
             this.TrimCache = config.TrimCache;
             this.FolderDepth = config.FolderDepth;
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whther wthe current cache is currently being trimmed.
+        /// </summary>
+        public static bool IsTrimming
+        {
+            get
+            {
+                lock (Locker)
+                {
+                    return isTrimming;
+                }
+            }
+
+            set
+            {
+                lock (Locker)
+                {
+                    isTrimming = value;
+                }
+            }
         }
 
         /// <summary>

--- a/src/ImageProcessor.Web/Caching/ImageCacheBase.cs
+++ b/src/ImageProcessor.Web/Caching/ImageCacheBase.cs
@@ -21,10 +21,10 @@ namespace ImageProcessor.Web.Caching
     using ImageProcessor.Web.Configuration;
 
     /// <summary>
-    /// The image cache base provides methods for implementing the <see cref="IImageCache"/> interface.
+    /// The image cache base provides methods for implementing the <see cref="IImageCacheExtended"/> interface.
     /// It is recommended that any implementations inherit from this class.
     /// </summary>
-    public abstract class ImageCacheBase : IImageCache
+    public abstract class ImageCacheBase : IImageCacheExtended
     {
         /// <summary>
         /// The semaphore to lock against.
@@ -130,7 +130,7 @@ namespace ImageProcessor.Web.Caching
         public abstract Task AddImageToCacheAsync(Stream stream, string contentType);
 
         /// <summary>
-        /// Trims the cache of any expired items in an asynchronous manner. 
+        /// Trims the cache of any expired items in an asynchronous manner.
         /// Call <see cref="M:DebounceTrimmerAsync"/> within your implementation to correctly debounce cache cleanup.
         /// </summary>
         /// <returns>
@@ -171,7 +171,7 @@ namespace ImageProcessor.Web.Caching
         }
 
         /// <summary>
-        /// Provides a means to augment the cache settings taken from the configuration in derived classes. 
+        /// Provides a means to augment the cache settings taken from the configuration in derived classes.
         /// This allows for configuration of cache objects outside the normal configuration files, for example
         /// by using app settings in the Azure platform.
         /// </summary>

--- a/src/ImageProcessor.Web/Caching/ImageCacheBase.cs
+++ b/src/ImageProcessor.Web/Caching/ImageCacheBase.cs
@@ -57,9 +57,13 @@ namespace ImageProcessor.Web.Caching
             this.RequestPath = requestPath;
             this.FullPath = fullPath;
             this.Querystring = querystring;
-            this.Settings = this.AugmentSettingsCore(ImageProcessorConfiguration.Instance.ImageCacheSettings);
-            this.MaxDays = ImageProcessorConfiguration.Instance.ImageCacheMaxDays;
-            this.BrowserMaxDays = ImageProcessorConfiguration.Instance.BrowserCacheMaxDays;
+
+            ImageProcessorConfiguration config = ImageProcessorConfiguration.Instance;
+            this.Settings = this.AugmentSettingsCore(config.ImageCacheSettings);
+            this.MaxDays = config.ImageCacheMaxDays;
+            this.BrowserMaxDays = config.BrowserCacheMaxDays;
+            this.TrimCache = config.TrimCache;
+            this.FolderDepth = config.FolderDepth;
         }
 
         /// <summary>
@@ -81,6 +85,16 @@ namespace ImageProcessor.Web.Caching
         /// Gets or sets the maximum number of days to cache the image in the browser.
         /// </summary>
         public int BrowserMaxDays { get; set; }
+
+        /// <summary>
+        /// Gets or sets the maximum number folder levels to nest the cached images.
+        /// </summary>
+        public int FolderDepth { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to periodically trim the cache.
+        /// </summary>
+        public bool TrimCache { get; set; }
 
         /// <summary>
         /// Gets a value indicating whether the image is new or updated in an asynchronous manner.

--- a/src/ImageProcessor.Web/Configuration/ImageCacheSection.cs
+++ b/src/ImageProcessor.Web/Configuration/ImageCacheSection.cs
@@ -127,7 +127,7 @@ namespace ImageProcessor.Web.Configuration
             }
 
             /// <summary>
-            /// Gets or sets whether the disk cache will apply file change monitors that can be used to invalidate the cache
+            /// Gets or sets a value indicating whether the cache will apply file change monitors that can be used to invalidate the cache
             /// </summary>
             /// <value>True or False to enable or disable this setting</value>
             /// <remarks>
@@ -168,6 +168,39 @@ namespace ImageProcessor.Web.Configuration
                 set
                 {
                     this["browserMaxDays"] = value;
+                }
+            }
+
+            /// <summary>
+            /// Gets or sets a value indicating whether to periodically trim the cache.
+            /// </summary>
+            /// <remarks>
+            /// Defaults to true.
+            /// </remarks>
+            [ConfigurationProperty("trimCache", DefaultValue = true, IsRequired = false)]
+            public bool TrimCache
+            {
+                get { return (bool)this["trimCache"]; }
+
+                set { this["trimCache"] = value; }
+            }
+
+            /// <summary>
+            /// Gets or sets the maximum number folder levels to nest the cached images.
+            /// </summary>
+            /// <remarks>Defaults to 6 if not set.</remarks>
+            [ConfigurationProperty("folderDepth", DefaultValue = "6", IsRequired = false)]
+            [IntegerValidator(ExcludeRange = false, MinValue = 0)]
+            public int FolderDepth
+            {
+                get
+                {
+                    return (int)this["folderDepth"];
+                }
+
+                set
+                {
+                    this["folderDepth"] = value;
                 }
             }
 

--- a/src/ImageProcessor.Web/Configuration/ImageCacheSection.cs
+++ b/src/ImageProcessor.Web/Configuration/ImageCacheSection.cs
@@ -67,9 +67,12 @@ namespace ImageProcessor.Web.Configuration
             }
 
             string section = ResourceHelpers.ResourceAsString("ImageProcessor.Web.Configuration.Resources.cache.config.transform");
-            XmlReader reader = new XmlTextReader(new StringReader(section));
-            imageCacheSection = new ImageCacheSection();
-            imageCacheSection.DeserializeSection(reader);
+
+            using (XmlReader reader = new XmlTextReader(new StringReader(section)))
+            {
+                imageCacheSection = new ImageCacheSection();
+                imageCacheSection.DeserializeSection(reader);
+            }
 
             return imageCacheSection;
         }

--- a/src/ImageProcessor.Web/Configuration/ImageProcessingSection.cs
+++ b/src/ImageProcessor.Web/Configuration/ImageProcessingSection.cs
@@ -98,9 +98,13 @@ namespace ImageProcessor.Web.Configuration
             }
 
             string section = ResourceHelpers.ResourceAsString("ImageProcessor.Web.Configuration.Resources.processing.config.transform");
-            XmlReader reader = new XmlTextReader(new StringReader(section));
-            imageProcessingSection = new ImageProcessingSection();
-            imageProcessingSection.DeserializeSection(reader);
+
+            using (XmlReader reader = new XmlTextReader(new StringReader(section)))
+            {
+                imageProcessingSection = new ImageProcessingSection();
+                imageProcessingSection.DeserializeSection(reader);
+            }
+
             return imageProcessingSection;
         }
 

--- a/src/ImageProcessor.Web/Configuration/ImageProcessorConfiguration.cs
+++ b/src/ImageProcessor.Web/Configuration/ImageProcessorConfiguration.cs
@@ -7,6 +7,7 @@
 //   Encapsulates methods to allow the retrieval of ImageProcessor settings.
 // </summary>
 // --------------------------------------------------------------------------------------------------------------------
+
 namespace ImageProcessor.Web.Configuration
 {
     using System;
@@ -100,6 +101,16 @@ namespace ImageProcessor.Web.Configuration
         /// Gets the browser cache max days.
         /// </summary>
         public int BrowserCacheMaxDays { get; private set; }
+
+        /// <summary>
+        /// Gets or sets the maximum number folder levels to nest the cached images.
+        /// </summary>
+        public int FolderDepth { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to periodically trim the cache.
+        /// </summary>
+        public bool TrimCache { get; set; }
 
         /// <summary>
         /// Gets the image cache settings.
@@ -395,18 +406,18 @@ namespace ImageProcessor.Web.Configuration
         {
             if (this.ImageCache == null)
             {
-                string curentCache = GetImageCacheSection().CurrentCache;
+                string currentCache = GetImageCacheSection().CurrentCache;
                 ImageCacheSection.CacheElementCollection caches = imageCacheSection.ImageCaches;
 
                 foreach (ImageCacheSection.CacheElement cache in caches)
                 {
-                    if (cache.Name == curentCache)
+                    if (cache.Name == currentCache)
                     {
                         Type type = Type.GetType(cache.Type);
 
                         if (type == null)
                         {
-                            string message = "Couldn't load IImageCache: " + cache.Type;
+                            string message = $"Couldn\'t load IImageCache: {cache.Type}";
                             ImageProcessorBootstrapper.Instance.Logger.Log<ImageProcessorConfiguration>(message);
                             throw new TypeLoadException(message);
                         }
@@ -415,6 +426,8 @@ namespace ImageProcessor.Web.Configuration
                         this.ImageCacheMaxDays = cache.MaxDays;
                         this.UseFileChangeMonitors = cache.UseFileChangeMonitors;
                         this.BrowserCacheMaxDays = cache.BrowserMaxDays;
+                        this.TrimCache = cache.TrimCache;
+                        this.FolderDepth = cache.FolderDepth;
                         this.ImageCacheSettings = cache.Settings
                                                        .Cast<SettingElement>()
                                                        .ToDictionary(setting => setting.Key, setting => setting.Value);

--- a/src/ImageProcessor.Web/Configuration/ImageSecuritySection.cs
+++ b/src/ImageProcessor.Web/Configuration/ImageSecuritySection.cs
@@ -70,9 +70,13 @@ namespace ImageProcessor.Web.Configuration
             }
 
             string section = ResourceHelpers.ResourceAsString("ImageProcessor.Web.Configuration.Resources.security.config.transform");
-            XmlReader reader = new XmlTextReader(new StringReader(section));
-            imageSecuritySection = new ImageSecuritySection();
-            imageSecuritySection.DeserializeSection(reader);
+
+            using (XmlReader reader = new XmlTextReader(new StringReader(section)))
+            {
+                imageSecuritySection = new ImageSecuritySection();
+                imageSecuritySection.DeserializeSection(reader);
+            }
+
             imageSecuritySection.AutoLoadServices = true;
             return imageSecuritySection;
         }

--- a/src/ImageProcessor.Web/Helpers/ImageHelpers.cs
+++ b/src/ImageProcessor.Web/Helpers/ImageHelpers.cs
@@ -84,14 +84,13 @@ namespace ImageProcessor.Web.Helpers
         }
 
         /// <summary>
-        /// Returns the correct file extension for the given string input
+        /// Returns the correct file extension for the given string input.
+        /// <remarks>
+        /// Falls back to jpeg if no extension is matched.
+        /// </remarks>
         /// </summary>
-        /// <param name="fullPath">
-        /// The string to parse.
-        /// </param>
-        /// <param name="queryString">
-        /// The querystring containing instructions.
-        /// </param>
+        /// <param name="fullPath">The string to parse.</param>
+        /// <param name="queryString">The querystring containing instructions.</param>
         /// <returns>
         /// The correct file extension for the given string input if it can find one; otherwise an empty string.
         /// </returns>
@@ -136,7 +135,8 @@ namespace ImageProcessor.Web.Helpers
                 return value;
             }
 
-            return string.Empty;
+            // Fall back to jpg
+            return "jpg";
         }
 
         /// <summary>

--- a/src/ImageProcessor.Web/HttpModules/ImageProcessingModule.cs
+++ b/src/ImageProcessor.Web/HttpModules/ImageProcessingModule.cs
@@ -212,6 +212,7 @@ namespace ImageProcessor.Web.HttpModules
 
             cache.SetExpires(DateTime.Now.ToUniversalTime().AddDays(maxDays));
             cache.SetMaxAge(new TimeSpan(maxDays, 0, 0, 0));
+            cache.SetRevalidation(HttpCacheRevalidation.AllCaches);
 
             AddCorsRequestHeaders(context);
         }

--- a/src/ImageProcessor.Web/HttpModules/ImageProcessingModule.cs
+++ b/src/ImageProcessor.Web/HttpModules/ImageProcessingModule.cs
@@ -677,8 +677,11 @@ namespace ImageProcessor.Web.HttpModules
                         context.ApplicationInstance.CompleteRequest();
                     }
 
-                    // Trim the cache.
-                    await this.imageCache.TrimCacheAsync();
+                    if (isNewOrUpdated)
+                    {
+                        // Trim the cache.
+                        await this.imageCache.TrimCacheAsync();
+                    }
                 }
             }
         }

--- a/src/ImageProcessor.Web/ImageProcessor.Web.csproj
+++ b/src/ImageProcessor.Web/ImageProcessor.Web.csproj
@@ -49,6 +49,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Caching\CachedImageHelper.cs" />
     <Compile Include="Caching\MemoryStreamPool.cs" />
     <Compile Include="Caching\CachedImage.cs" />
     <Compile Include="Caching\DiskCache.cs" />

--- a/src/ImageProcessor.Web/ImageProcessor.Web.csproj
+++ b/src/ImageProcessor.Web/ImageProcessor.Web.csproj
@@ -50,6 +50,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Caching\CachedImageHelper.cs" />
+    <Compile Include="Caching\IImageCacheExtended.cs" />
     <Compile Include="Caching\MemoryStreamPool.cs" />
     <Compile Include="Caching\CachedImage.cs" />
     <Compile Include="Caching\DiskCache.cs" />

--- a/tests/ImageProcessor.Web.UnitTests/Helpers/CachedImageHelperTests.cs
+++ b/tests/ImageProcessor.Web.UnitTests/Helpers/CachedImageHelperTests.cs
@@ -1,0 +1,48 @@
+﻿using ImageProcessor.Web.Caching;
+
+namespace ImageProcessor.Web.UnitTests.Helpers
+{
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Cached image helper tests
+    /// </summary>
+    [TestFixture]
+    public class CachedImageHelperTests
+    {
+        [Test]
+        [TestCase("/media/image.gif?", "", "13c47ee938933b64f863cc374f9fa042fad93672.gif")]
+        [TestCase("/media/image.gif?width=100&height=100", "width=100&height=100", "f6401f01522b35bf50e37550abdf75d3fb7c4f79.gif")]
+        [TestCase("/media/image.gif?width=100&height=100", "", "f6401f01522b35bf50e37550abdf75d3fb7c4f79.gif")]
+        [TestCase("/handler/123456?width=100&height=100", "width=100&height=100", "09b68b2b8b78f425706fe73bb58b1dc211759473.jpg")]
+        [TestCase("/handler/123456", "", "d45c279def9be4585a9e01925f4f7607ffe5114e.jpg")]
+        [TestCase("/some+path+with+plus/q_w-e+rty.jpeg?width=100&height=100&format=png", "width=100&height=100&format=png", "8df90f8b3bd2547bf1cb8a8828afb35b59434fea.png")]
+        [TestCase("/remote.axd/maps.googleapis.com/maps/api/staticmap?center=Albany,+NY&zoom=13&scale=false&size=800x500&maptype=roadmap&sensor=false&format=png&visual_refresh=true?width=401&format=bmp", "width=401&format=bmp", "7785eac6e1607f0222977f2845f7fd1ccfaebb94.bmp")]
+        [TestCase("/remote.axd/maps.googleapis.com/maps/api/staticmap?center=Albany,+NY&zoom=13&scale=false&size=800x500&maptype=roadmap&sensor=false&format=png&visual_refresh=true?width=401&format=bmp", "", "7785eac6e1607f0222977f2845f7fd1ccfaebb94.bmp")]
+        [TestCase("/remote.axd?http://maps.googleapis.com/maps/api/staticmap?center=Albany,+NY&zoom=13&scale=false&size=800x500&maptype=roadmap&sensor=false&format=png&visual_refresh=true?width=401&format=bmp", "width=401&format=bmp", "97d47d5d73ba4814f57434567c4141d37547ca11.bmp")]
+        [TestCase("/remote.axd?http://maps.googleapis.com/maps/api/staticmap?center=Albany,+NY&zoom=13&scale=false&size=800x500&maptype=roadmap&sensor=false&format=png&visual_refresh=true?width=401&format=bmp", "", "97d47d5d73ba4814f57434567c4141d37547ca11.bmp")]
+
+        public void TestCachedFileNameGenerated(string path, string query, string expected)
+        {
+            string result1 = CachedImageHelper.GetCachedImageFileName(path);
+            string result2 = CachedImageHelper.GetCachedImageFileName(path, query);
+
+            Assert.AreEqual(result1, result2);
+            Assert.AreEqual(result1, expected);
+        }
+
+        [Test]
+        [TestCase("~/App_Data/cache", "13c47ee938933b64f863cc374f9fa042fad93672.gif", true, 6, "~/App_Data/cache/1/3/c/4/7/e/13c47ee938933b64f863cc374f9fa042fad93672.gif")]
+        [TestCase("~/App_Data/cache", "13c47ee938933b64f863cc374f9fa042fad93672.gif", true, 3, "~/App_Data/cache/1/3/c/13c47ee938933b64f863cc374f9fa042fad93672.gif")]
+        [TestCase("~/App_Data/cache", "13c47ee938933b64f863cc374f9fa042fad93672.gif", true, 0, "~/App_Data/cache/13c47ee938933b64f863cc374f9fa042fad93672.gif")]
+        [TestCase("X:\\Projects\\ImageProcessor\\ImageProcessor\\tests\\OUTSIDE", "13c47ee938933b64f863cc374f9fa042fad93672.gif", false, 6, "X:\\Projects\\ImageProcessor\\ImageProcessor\\tests\\OUTSIDE\\1\\3\\c\\4\\7\\e\\13c47ee938933b64f863cc374f9fa042fad93672.gif")]
+        [TestCase("X:\\Projects\\ImageProcessor\\ImageProcessor\\tests\\OUTSIDE", "13c47ee938933b64f863cc374f9fa042fad93672.gif", false, 3, "X:\\Projects\\ImageProcessor\\ImageProcessor\\tests\\OUTSIDE\\1\\3\\c\\13c47ee938933b64f863cc374f9fa042fad93672.gif")]
+        [TestCase("X:\\Projects\\ImageProcessor\\ImageProcessor\\tests\\OUTSIDE", "13c47ee938933b64f863cc374f9fa042fad93672.gif", false, 0, "X:\\Projects\\ImageProcessor\\ImageProcessor\\tests\\OUTSIDE\\13c47ee938933b64f863cc374f9fa042fad93672.gif")]
+
+        public void TestCachedFilePathGenerated(string path, string filename, bool makeVirtual, int depth, string expected)
+        {
+            string result = CachedImageHelper.GetCachedPath(path, filename, makeVirtual, depth);
+            Assert.AreEqual(result, expected);
+        }
+    }
+}

--- a/tests/ImageProcessor.Web.UnitTests/Helpers/UrlParserUnitTests.cs
+++ b/tests/ImageProcessor.Web.UnitTests/Helpers/UrlParserUnitTests.cs
@@ -8,7 +8,7 @@
 // </summary>
 // --------------------------------------------------------------------------------------------------------------------
 
-namespace ImageProcessor.Web.UnitTests
+namespace ImageProcessor.Web.UnitTests.Helpers
 {
     using NUnit.Framework;
 
@@ -25,7 +25,7 @@ namespace ImageProcessor.Web.UnitTests
         public void TestLocalUrl(string url, string query)
         {
             string requestPath, queryString;
-            Helpers.UrlParser.ParseUrl(url + "?" + query, "", out requestPath, out queryString);
+            Web.Helpers.UrlParser.ParseUrl(url + "?" + query, "", out requestPath, out queryString);
             Assert.True(requestPath.Equals(url));
             Assert.True(queryString.Equals(query));
         }
@@ -42,14 +42,14 @@ namespace ImageProcessor.Web.UnitTests
 
             //Test url
             string url = baseUrl + "/" + prefix + "?" + path + "?" + query;
-            Helpers.UrlParser.ParseUrl(url, prefix, out requestPath, out queryString);
+            Web.Helpers.UrlParser.ParseUrl(url, prefix, out requestPath, out queryString);
             Assert.True(queryString.Equals(query));
             Assert.True(requestPath.Equals(path));
 
             //Test non legacy url
             path = path.Substring(7);
             string nonLegacyUrl = baseUrl + "/" + prefix + "/" + path + "?" + query;
-            Helpers.UrlParser.ParseUrl(nonLegacyUrl, prefix, out requestPath, out queryString);
+            Web.Helpers.UrlParser.ParseUrl(nonLegacyUrl, prefix, out requestPath, out queryString);
             Assert.True(queryString.Equals(query));
             Assert.True(requestPath.TrimStart('/').Equals(path));
         }
@@ -63,13 +63,13 @@ namespace ImageProcessor.Web.UnitTests
 
             //Test legacy url
             string legacyUrl = baseUrl + "/" + prefix + "?" + path + "?" + query;
-            Helpers.UrlParser.ParseUrl(legacyUrl, prefix, out requestPath, out queryString);
+            Web.Helpers.UrlParser.ParseUrl(legacyUrl, prefix, out requestPath, out queryString);
             Assert.True(queryString.Equals(query));
             Assert.False(requestPath.Equals(path));
 
             //Test non legacy url
             string nonLegacyUrl = baseUrl + "/" + prefix + "/" + path.Substring(7) + "?" + query;
-            Helpers.UrlParser.ParseUrl(legacyUrl, prefix, out requestPath, out queryString);
+            Web.Helpers.UrlParser.ParseUrl(legacyUrl, prefix, out requestPath, out queryString);
             Assert.True(queryString.Equals(query));
             Assert.False(requestPath.TrimStart('/').Equals(path));
         }
@@ -83,7 +83,7 @@ namespace ImageProcessor.Web.UnitTests
 
             //Test legacy url
             string legacyUrl = baseUrl + "/" + prefix + "?" + path + "?" + query;
-            Helpers.UrlParser.ParseUrl(legacyUrl, prefix, out requestPath, out queryString);
+            Web.Helpers.UrlParser.ParseUrl(legacyUrl, prefix, out requestPath, out queryString);
             Assert.True(queryString.Equals(query));
             Assert.True(requestPath.Equals(expectedPath));
 
@@ -99,7 +99,7 @@ namespace ImageProcessor.Web.UnitTests
 
             //Test legacy url
             string legacyUrl = baseUrl + "/" + prefix + "?" + path + "?" + query;
-            Helpers.UrlParser.ParseUrl(legacyUrl, prefix, out requestPath, out queryString);
+            Web.Helpers.UrlParser.ParseUrl(legacyUrl, prefix, out requestPath, out queryString);
             Assert.True(queryString.Equals(query));
             Assert.True(requestPath.Equals(expectedPath));
 
@@ -114,7 +114,7 @@ namespace ImageProcessor.Web.UnitTests
 
             //Test legacy url
             string legacyUrl = baseUrl + "/" + prefix + "?" + path;
-            Helpers.UrlParser.ParseUrl(legacyUrl, prefix, out requestPath, out queryString);
+            Web.Helpers.UrlParser.ParseUrl(legacyUrl, prefix, out requestPath, out queryString);
             Assert.True(queryString.Equals(expectedQuery));
             Assert.True(requestPath.Equals(expectedPath));
 

--- a/tests/ImageProcessor.Web.UnitTests/ImageProcessor.Web.UnitTests.csproj
+++ b/tests/ImageProcessor.Web.UnitTests/ImageProcessor.Web.UnitTests.csproj
@@ -50,10 +50,11 @@
     <Compile Include="ExtendedColorTypeConverterTests.cs" />
     <Compile Include="Extensions\DirectoryInfoExtensionsUnitTests.cs" />
     <Compile Include="Extensions\StringExtensionsUnitTests.cs" />
+    <Compile Include="Helpers\CachedImageHelperTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="QueryParamParserUnitTests.cs" />
     <Compile Include="RegularExpressionUnitTests.cs" />
-    <Compile Include="UrlParserUnitTests.cs" />
+    <Compile Include="Helpers\UrlParserUnitTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\ImageProcessor.Plugins.WebP\ImageProcessor.Plugins.WebP.csproj">


### PR DESCRIPTION
These changes vastly improve the caching mechanisms performance and testability. They also give us the ability to configure the caching mechanisms at a much greater level than ever before.

**Improvements**
- All caches now use a simple SHA1 hash of the request url via `CachedImageHelper`. File versioning is still supported but will now replace the existing cached file rather than create a new one. This reduces cache size. 
- Caches only perform trimming when a new image is cached. This was originally the case but somehow it got changed to per-request. (I don't know when)
- Caches can now be optionally configured to change the nested folder depth depending on requirements. This allows us to tweak performance of the trimming operation. (default to 6 for 12.92 million files)
- Trimming the cache is now optional (defaulting to true) 
- Only one trimming operation can run at a time. 

The only downside to all this is that the original cache from any prior installations is now invalid. I'll have to make this release **v4.8.0** in order to justify the changes.

I was originally going to operate on a one-in-one-out cleanup operation on the caches for performance (I still might) but that could lead to orphaned files. 

@dlemstra @nul800sebastiaan @Shazwazza @ZNS If you have the time I'd really appreciate your input on the changes. Especially on the one-in one-out approach. 

Cheers

James