### PR TITLE
Update the Microsoft.IO.RecyclableMemoryStream dependency

### DIFF
--- a/build/NuSpecs/ImageProcessor.Web.nuspec
+++ b/build/NuSpecs/ImageProcessor.Web.nuspec
@@ -24,7 +24,7 @@ Feedback is always welcome</description>
     <dependencies>
       <group targetFramework=".NETFramework4.5">
         <dependency id="ImageProcessor" version="2.5.2.0" />
-        <dependency id="Microsoft.IO.RecyclableMemoryStream" version="1.2.0" />
+        <dependency id="Microsoft.IO.RecyclableMemoryStream" version="1.2.1" />
       </group>
     </dependencies>
   </metadata>

--- a/src/ImageProcessor.Web/ImageProcessor.Web.csproj
+++ b/src/ImageProcessor.Web/ImageProcessor.Web.csproj
@@ -33,7 +33,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.IO.RecyclableMemoryStream, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.IO.RecyclableMemoryStream.1.2.0\lib\net45\Microsoft.IO.RecyclableMemoryStream.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.IO.RecyclableMemoryStream.1.2.1\lib\net45\Microsoft.IO.RecyclableMemoryStream.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/ImageProcessor.Web/packages.config
+++ b/src/ImageProcessor.Web/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.IO.RecyclableMemoryStream" version="1.2.0" targetFramework="net45" />
+  <package id="Microsoft.IO.RecyclableMemoryStream" version="1.2.1" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Looks like a new nice fix in this version: https://github.com/Microsoft/Microsoft.IO.RecyclableMemoryStream/releases/tag/v1.2.1

### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/JimBobSquarePants/ImageProcessor/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practise as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [ ] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->

<!-- Thanks for contributing to ImageProcessor! -->
