### PR TITLE
fix gif add watermark font bug

### DIFF
--- a/src/ImageProcessor/Processors/Watermark.cs
+++ b/src/ImageProcessor/Processors/Watermark.cs
@@ -206,9 +206,10 @@ namespace ImageProcessor.Processors
         {
             try
             {
-                using (fontFamily)
+				var f = new FontFamily(fontFamily.Name);
+                using (f)
                 {
-                    return new Font(fontFamily, fontSize, fontStyle, GraphicsUnit.Pixel);
+                    return new Font(f, fontSize, fontStyle, GraphicsUnit.Pixel);
                 }
             }
             catch


### PR DESCRIPTION
if gif image set watermark font will fail .
because FontFamily object is Dispose .

Thanks for contributing to ImageProcessor! 
