### PR TITLE
Add support for regular expression as the ImageService prefix.

### DIFF
--- a/src/ImageProcessor.Web/Configuration/ImageProcessorConfiguration.cs
+++ b/src/ImageProcessor.Web/Configuration/ImageProcessorConfiguration.cs
@@ -307,6 +307,7 @@ namespace ImageProcessor.Web.Configuration
                 {
                     string name = config.Name ?? imageService.GetType().Name;
                     imageService.Prefix = config.Prefix;
+                    imageService.IsRegex = config.IsRegex;
                     imageService.Settings = this.GetServiceSettings(name);
                     imageService.WhiteList = this.GetServiceWhitelist(name);
                 }

--- a/src/ImageProcessor.Web/Configuration/ImageSecuritySection.cs
+++ b/src/ImageProcessor.Web/Configuration/ImageSecuritySection.cs
@@ -111,6 +111,18 @@ namespace ImageProcessor.Web.Configuration
             }
 
             /// <summary>
+            /// Gets or sets the value indicating whether the prefix is a regular expression.
+            /// </summary>
+            /// <value>Is the prefix of the service a regular expression.</value>
+            [ConfigurationProperty("isRegex", DefaultValue = false, IsRequired = false)]
+            public bool IsRegex
+            {
+                get { return (bool)this["isRegex"]; }
+
+                set { this["isRegex"] = value; }
+            }
+
+            /// <summary>
             /// Gets or sets the type of the service.
             /// </summary>
             /// <value>The full Type definition of the service</value>

--- a/src/ImageProcessor.Web/HttpModules/ImageProcessingModule.cs
+++ b/src/ImageProcessor.Web/HttpModules/ImageProcessingModule.cs
@@ -826,7 +826,10 @@ namespace ImageProcessor.Web.HttpModules
             foreach (IImageService service in services)
             {
                 string key = service.Prefix;
-                if (!string.IsNullOrWhiteSpace(key) && path.StartsWith(key, StringComparison.InvariantCultureIgnoreCase))
+                if (!string.IsNullOrWhiteSpace(key) 
+                    && (service.IsRegex 
+                        ? Regex.IsMatch(path, key, RegexOptions.IgnoreCase) 
+                        : path.StartsWith(key, StringComparison.InvariantCultureIgnoreCase)))
                 {
                     return service;
                 }

--- a/src/ImageProcessor.Web/Services/CloudImageService.cs
+++ b/src/ImageProcessor.Web/Services/CloudImageService.cs
@@ -49,6 +49,11 @@ namespace ImageProcessor.Web.Services
         public string Prefix { get; set; } = string.Empty;
 
         /// <summary>
+        /// Gets or sets a value indicating whether Prefix should be evaulated as a regular expression.
+        /// </summary>
+        public bool IsRegex { get; set; }
+
+        /// <summary>
         /// Gets a value indicating whether the image service requests files from
         /// the locally based file system.
         /// </summary>

--- a/src/ImageProcessor.Web/Services/IImageService.cs
+++ b/src/ImageProcessor.Web/Services/IImageService.cs
@@ -28,6 +28,11 @@ namespace ImageProcessor.Web.Services
         string Prefix { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether Prefix should be evaulated as a regular expression.
+        /// </summary>
+        bool IsRegex { get; set; }
+
+        /// <summary>
         /// Gets a value indicating whether the image service requests files from
         /// the locally based file system.
         /// </summary>

--- a/src/ImageProcessor.Web/Services/LocalFileImageService.cs
+++ b/src/ImageProcessor.Web/Services/LocalFileImageService.cs
@@ -33,6 +33,11 @@ namespace ImageProcessor.Web.Services
         public string Prefix { get; set; } = string.Empty;
 
         /// <summary>
+        /// Gets or sets a value indicating whether Prefix should be evaulated as a regular expression.
+        /// </summary>
+        public bool IsRegex { get; set; }
+
+        /// <summary>
         /// Gets a value indicating whether the image service requests files from
         /// the locally based file system.
         /// </summary>

--- a/src/ImageProcessor.Web/Services/RemoteImageService.cs
+++ b/src/ImageProcessor.Web/Services/RemoteImageService.cs
@@ -52,6 +52,11 @@ namespace ImageProcessor.Web.Services
         public string Prefix { get; set; } = "remote.axd";
 
         /// <summary>
+        /// Gets or sets a value indicating whether Prefix should be evaulated as a regular expression.
+        /// </summary>
+        public bool IsRegex { get; set; }
+
+        /// <summary>
         /// Gets a value indicating whether the image service requests files from
         /// the locally based file system.
         /// </summary>

--- a/tests/ImageProcessor.TestWebsite/ImageServices/AppDataImageService.cs
+++ b/tests/ImageProcessor.TestWebsite/ImageServices/AppDataImageService.cs
@@ -34,6 +34,11 @@ namespace ImageProcessor.TestWebsite.ImageServices
         public string Prefix { get; set; } = "appdata.axd";
 
         /// <summary>
+        /// Gets or sets a value indicating whether Prefix should be evaulated as a regular expression.
+        /// </summary>
+        public bool IsRegex { get; set; }
+
+        /// <summary>
         /// Gets a value indicating whether the image service requests files from
         /// the locally based file system.
         /// </summary>

--- a/tests/ImageProcessor.TestWebsite/ImageServices/DatabaseImageService.cs
+++ b/tests/ImageProcessor.TestWebsite/ImageServices/DatabaseImageService.cs
@@ -30,6 +30,11 @@ namespace ImageProcessor.TestWebsite.ImageServices
         public string Prefix { get; set; } = "database.axd";
 
         /// <summary>
+        /// Gets or sets a value indicating whether Prefix should be evaulated as a regular expression.
+        /// </summary>
+        public bool IsRegex { get; set; }
+
+        /// <summary>
         /// Gets a value indicating whether the image service requests files from
         /// the locally based file system.
         /// </summary>

--- a/tests/ImageProcessor.Web.UnitTests/Helpers/UrlParserUnitTests.cs
+++ b/tests/ImageProcessor.Web.UnitTests/Helpers/UrlParserUnitTests.cs
@@ -130,5 +130,17 @@ namespace ImageProcessor.Web.UnitTests.Helpers
             Web.Helpers.UrlParser.ParseUrl(url, prefix, out requestPath, out queryString);
             Assert.True(requestPath.Equals(expectedPath));
         }
+
+        [Test]
+        [TestCase("http://www.mydomain.com/MyPrefix/image.jpg", "myp[^/]*", "/image.jpg")]
+        [TestCase("http://www.mydomain.com/extramedia/image.jpg", "/.*?media", "/image.jpg")]
+        [TestCase("http://www.mydomain.com/SecondPrefix/image.jpg", "firstprefix|secondprefix|thirdprefix", "/image.jpg")]
+        [TestCase("http://www.mydomain.com/Multiple/Segments/2017/05/02/image.jpg", "/multiple/segments/[0-9]{4}/[0-9]{2}/[0-9]{2}", "/image.jpg")]
+        public void TestParseUrlPrefixIsRegex(string url, string prefix, string expectedPath)
+        {
+            string requestPath, queryString;
+            Web.Helpers.UrlParser.ParseUrl(url, prefix, out requestPath, out queryString);
+            Assert.True(requestPath.Equals(expectedPath));
+        }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/JimBobSquarePants/ImageProcessor/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practise as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [?] I have provided test coverage for my change (where applicable)

### Description
In some cases its useful to have the same ImageService instance handle multiple prefixes, or better still, a pattern for the prefix. This is particularly relevant for some .net CMSs that use different paths for different media buckets. This is becoming a pain in my current project - having five `<service ... >` elements in the security.config mapped to the same IImageService type.

Unfortunately, this change is breaking - as it adds another property to IImageService
`public bool IsRegex { get; set; }`

Thoughts?
