### PR TITLE
Fix cast error when getting CORS whitelist

### DIFF
--- a/src/ImageProcessor.Web/HttpModules/ImageProcessingModule.cs
+++ b/src/ImageProcessor.Web/HttpModules/ImageProcessingModule.cs
@@ -268,8 +268,10 @@ namespace ImageProcessor.Web.HttpModules
 
             // Check for root or sub domain.
             bool validUrl = false;
-            foreach (Uri uri in origins.WhiteList)
+            foreach (ImageSecuritySection.SafeUrl safeUrl in origins.WhiteList)
             {
+                var uri = safeUrl.Url;
+
                 if (uri.ToString() == "*")
                 {
                     validUrl = true;


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/JimBobSquarePants/ImageProcessor/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practise as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [ ] I have provided test coverage for my change (where applicable)

### Description
This pull request fixes cast error (`Unable to cast object of type 'SafeUrl' to type 'System.Uri'`) when CORS whitelist section is used.