### PR TITLE
Adding in support for private blob storage in Azure

### DIFF
--- a/src/ImageProcessor.Web.Plugins.AmazonS3Cache/ImageProcessor.Web.Plugins.AmazonS3Cache.csproj
+++ b/src/ImageProcessor.Web.Plugins.AmazonS3Cache/ImageProcessor.Web.Plugins.AmazonS3Cache.csproj
@@ -60,6 +60,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/ImageProcessor.Web.Plugins.AzureBlobCache/app.config
+++ b/src/ImageProcessor.Web.Plugins.AzureBlobCache/app.config
@@ -18,6 +18,10 @@
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Spatial" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.6.4.0" newVersion="5.6.4.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/src/ImageProcessor.Web.Plugins.PostProcessor/ImageProcessor.Web.Plugins.PostProcessor.csproj
+++ b/src/ImageProcessor.Web.Plugins.PostProcessor/ImageProcessor.Web.Plugins.PostProcessor.csproj
@@ -49,6 +49,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="Resources\Unmanaged\README.txt" />
     <EmbeddedResource Include="Resources\Unmanaged\x86\png.cmd" />
   </ItemGroup>

--- a/src/ImageProcessor.Web/Configuration/Resources/security.config.transform
+++ b/src/ImageProcessor.Web/Configuration/Resources/security.config.transform
@@ -8,6 +8,7 @@
         <setting key="MaxBytes" value="8194304"/>
         <setting key="Timeout" value="30000"/>
         <setting key="Host" value="http://yourhost.com/"/>
+        <setting key="AzureConnectionString" value="YourAccountConnectionString"/> This is only required if you are using Azure blob storage and their access level is set to private.
       </settings>
     </service>-->
     <service prefix="remote.axd" name="RemoteImageService" type="ImageProcessor.Web.Services.RemoteImageService, ImageProcessor.Web">

--- a/src/ImageProcessor.Web/Configuration/Resources/security.config.transform
+++ b/src/ImageProcessor.Web/Configuration/Resources/security.config.transform
@@ -8,7 +8,7 @@
         <setting key="MaxBytes" value="8194304"/>
         <setting key="Timeout" value="30000"/>
         <setting key="Host" value="http://yourhost.com/"/>
-        <setting key="AzureConnectionString" value="YourAccountConnectionString"/> This is only required if you are using Azure blob storage and their access level is set to private.
+        <setting key="ConnectionString" value=""/> This is only required if you are using Azure blob storage and their access level is set to private.
       </settings>
     </service>-->
     <service prefix="remote.axd" name="RemoteImageService" type="ImageProcessor.Web.Services.RemoteImageService, ImageProcessor.Web">

--- a/src/ImageProcessor.Web/ImageProcessor.Web.csproj
+++ b/src/ImageProcessor.Web/ImageProcessor.Web.csproj
@@ -47,8 +47,9 @@
     <Reference Include="Microsoft.IO.RecyclableMemoryStream, Version=1.2.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.IO.RecyclableMemoryStream.1.2.2\lib\net45\Microsoft.IO.RecyclableMemoryStream.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.WindowsAzure.Storage, Version=8.1.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\WindowsAzure.Storage.8.1.4\lib\net45\Microsoft.WindowsAzure.Storage.dll</HintPath>
+    <Reference Include="Microsoft.WindowsAzure.Storage, Version=6.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\WindowsAzure.Storage.6.2.0\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
@@ -166,6 +167,7 @@
     <EmbeddedResource Include="Configuration\Resources\security.config.transform" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/ImageProcessor.Web/ImageProcessor.Web.csproj
+++ b/src/ImageProcessor.Web/ImageProcessor.Web.csproj
@@ -32,14 +32,36 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.Azure.KeyVault.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Azure.KeyVault.Core.1.0.0\lib\net40\Microsoft.Azure.KeyVault.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Data.Edm, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Data.Edm.5.8.2\lib\net40\Microsoft.Data.Edm.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Data.OData, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Data.OData.5.8.2\lib\net40\Microsoft.Data.OData.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Data.Services.Client, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Data.Services.Client.5.8.2\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.IO.RecyclableMemoryStream, Version=1.2.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.IO.RecyclableMemoryStream.1.2.2\lib\net45\Microsoft.IO.RecyclableMemoryStream.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.WindowsAzure.Storage, Version=8.1.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\WindowsAzure.Storage.8.1.4\lib\net45\Microsoft.WindowsAzure.Storage.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Runtime.Caching" />
+    <Reference Include="System.Spatial, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Spatial.5.8.2\lib\net40\System.Spatial.dll</HintPath>
+    </Reference>
     <Reference Include="System.Web" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/src/ImageProcessor.Web/Services/CloudImageService.cs
+++ b/src/ImageProcessor.Web/Services/CloudImageService.cs
@@ -38,7 +38,9 @@ namespace ImageProcessor.Web.Services
             {
                 { "MaxBytes", "4194304" },
                 { "Timeout", "30000" },
-                { "Host", string.Empty }
+                { "Host", string.Empty },
+                { "Container", string.Empty},
+                { "ConnectionString", string.Empty}
             };
         }
 
@@ -93,7 +95,7 @@ namespace ImageProcessor.Web.Services
         {
             string host = this.Settings["Host"];
             string container = this.Settings.ContainsKey("Container") ? this.Settings["Container"] : string.Empty;
-            string connectionString = this.Settings.ContainsKey("AzureConnectionString") ? this.Settings["ConnectionString"] : string.Empty;
+            string connectionString = this.Settings.ContainsKey("ConnectionString") ? this.Settings["ConnectionString"] : string.Empty;
 
             string relativeResourceUrl = id.ToString();
             if (!string.IsNullOrEmpty(container))

--- a/src/ImageProcessor.Web/packages.config
+++ b/src/ImageProcessor.Web/packages.config
@@ -11,5 +11,5 @@
   <package id="System.Linq.Queryable" version="4.0.0" targetFramework="net45" />
   <package id="System.Net.Requests" version="4.0.11" targetFramework="net45" />
   <package id="System.Spatial" version="5.8.2" targetFramework="net45" />
-  <package id="WindowsAzure.Storage" version="8.1.4" targetFramework="net45" />
+  <package id="WindowsAzure.Storage" version="6.2.0" targetFramework="net45" />
 </packages>

--- a/src/ImageProcessor.Web/packages.config
+++ b/src/ImageProcessor.Web/packages.config
@@ -1,4 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net45" />
+  <package id="Microsoft.Data.Edm" version="5.8.2" targetFramework="net45" />
+  <package id="Microsoft.Data.OData" version="5.8.2" targetFramework="net45" />
+  <package id="Microsoft.Data.Services.Client" version="5.8.2" targetFramework="net45" />
   <package id="Microsoft.IO.RecyclableMemoryStream" version="1.2.2" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
+  <package id="System.ComponentModel.EventBasedAsync" version="4.0.11" targetFramework="net45" />
+  <package id="System.Dynamic.Runtime" version="4.0.0" targetFramework="net45" />
+  <package id="System.Linq.Queryable" version="4.0.0" targetFramework="net45" />
+  <package id="System.Net.Requests" version="4.0.11" targetFramework="net45" />
+  <package id="System.Spatial" version="5.8.2" targetFramework="net45" />
+  <package id="WindowsAzure.Storage" version="8.1.4" targetFramework="net45" />
 </packages>

--- a/tests/ImageProcessor.TestWebsite/Web.config
+++ b/tests/ImageProcessor.TestWebsite/Web.config
@@ -57,6 +57,10 @@
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Spatial" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.6.4.0" newVersion="5.6.4.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
   <system.codedom>

--- a/tests/ImageProcessor.TestWebsite/config/imageprocessor/security.config
+++ b/tests/ImageProcessor.TestWebsite/config/imageprocessor/security.config
@@ -9,6 +9,7 @@
         <setting key="MaxBytes" value="8194304"/>
         <setting key="Timeout" value="30000"/>
         <setting key="Host" value="http://ipcache.blob.core.windows.net/"/>
+                <setting key="AzureConnectionString" value="YourAccountConnectionString"/> This is only required if you are using Azure blob storage and their access level is set to private.
       </settings>
     </service>-->
     <service prefix="remote.axd" name="RemoteImageService" type="ImageProcessor.Web.Services.RemoteImageService, ImageProcessor.Web">

--- a/tests/ImageProcessor.UnitTests/ImageProcessor.UnitTests.csproj
+++ b/tests/ImageProcessor.UnitTests/ImageProcessor.UnitTests.csproj
@@ -88,6 +88,7 @@
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
     <Content Include="Images\animated\animated-bird.gif">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/tests/ImageProcessor.Web.UnitTests/ImageProcessor.Web.UnitTests.csproj
+++ b/tests/ImageProcessor.Web.UnitTests/ImageProcessor.Web.UnitTests.csproj
@@ -74,6 +74,7 @@
     <Folder Include="Processors\" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have verified that there are no overlapping [pull-requests](https://github.com/JimBobSquarePants/ImageProcessor/pulls) open
- [X] I have verified that I am following matches the existing coding patterns and practise as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [X] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Added in a config value for an Azure connection string, added in the Azure Storage libraries. Added code to detect if a connection string is available in the config, and if so, use it to connect to the blob using the Azure Storage library. The code uses a config setup aligning with the Azure FSP. 
<!-- Thanks for contributing to ImageProcessor! -->
