### PR TITLE
Adds missing Gamma processor to Web

### DIFF
--- a/src/ImageProcessor.Web/Configuration/Resources/processing.config.transform
+++ b/src/ImageProcessor.Web/Configuration/Resources/processing.config.transform
@@ -13,6 +13,7 @@
     <plugin name="Filter" type="ImageProcessor.Web.Processors.Filter, ImageProcessor.Web"/>
     <plugin name="Flip" type="ImageProcessor.Web.Processors.Flip, ImageProcessor.Web"/>
     <plugin name="Format" type="ImageProcessor.Web.Processors.Format, ImageProcessor.Web" enabled="true"/>
+    <plugin name="Gamma" type="ImageProcessor.Web.Processors.Gamma, ImageProcessor.Web" />
     <plugin name="GaussianBlur" type="ImageProcessor.Web.Processors.GaussianBlur, ImageProcessor.Web">
       <settings>
         <setting key="MaxSize" value="22"/>

--- a/src/ImageProcessor.Web/ImageProcessor.Web.csproj
+++ b/src/ImageProcessor.Web/ImageProcessor.Web.csproj
@@ -80,6 +80,7 @@
     <Compile Include="Helpers\ValidatingRequestEventArgs.cs" />
     <Compile Include="Processors\DetectEdges.cs" />
     <Compile Include="Processors\EntropyCrop.cs" />
+    <Compile Include="Processors\Gamma.cs" />
     <Compile Include="Processors\Halftone.cs" />
     <Compile Include="Processors\Hue.cs" />
     <Compile Include="Processors\Mask.cs" />

--- a/src/ImageProcessor.Web/Processors/Gamma.cs
+++ b/src/ImageProcessor.Web/Processors/Gamma.cs
@@ -1,0 +1,81 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="Gamma.cs" company="James Jackson-South">
+//   Copyright (c) James Jackson-South.
+//   Licensed under the Apache License, Version 2.0.
+// </copyright>
+// <summary>
+//   Encapsulates methods to change the alpha component of the image to effect its luminance.
+// </summary>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace ImageProcessor.Web.Processors
+{
+    using System.Collections.Specialized;
+    using System.Text.RegularExpressions;
+    using System.Web;
+
+    using ImageProcessor.Processors;
+    using ImageProcessor.Web.Helpers;
+
+    /// <summary>
+    /// Encapsulates methods to change the alpha component of the image to effect its luminance.
+    /// </summary>
+    public class Gamma : IWebGraphicsProcessor
+    {
+        /// <summary>
+        /// The regular expression to search strings for.
+        /// </summary>
+        private static readonly Regex QueryRegex = new Regex(@"gamma=[^&]", RegexOptions.Compiled);
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Gamma"/> class.
+        /// </summary>
+        public Gamma()
+        {
+            this.Processor = new ImageProcessor.Processors.Gamma();
+        }
+
+        /// <summary>
+        /// Gets the regular expression to search strings for.
+        /// </summary>
+        public Regex RegexPattern => QueryRegex;
+
+        /// <summary>
+        /// Gets the order in which this processor is to be used in a chain.
+        /// </summary>
+        public int SortOrder
+        {
+            get;
+            private set;
+        }
+
+        /// <summary>
+        /// Gets the associated graphics processor.
+        /// </summary>
+        public IGraphicsProcessor Processor { get; }
+
+        /// <summary>
+        /// The position in the original string where the first character of the captured substring was found.
+        /// </summary>
+        /// <param name="queryString">
+        /// The query string to search.
+        /// </param>
+        /// <returns>
+        /// The zero-based starting position in the original string where the captured substring was found.
+        /// </returns>
+        public int MatchRegexIndex(string queryString)
+        {
+            this.SortOrder = int.MaxValue;
+            Match match = this.RegexPattern.Match(queryString);
+
+            if (match.Success)
+            {
+                this.SortOrder = match.Index;
+                NameValueCollection queryCollection = HttpUtility.ParseQueryString(queryString);
+                this.Processor.DynamicParameter = QueryParamParser.Instance.ParseValue<float>(queryCollection["gamma"]);
+            }
+
+            return this.SortOrder;
+        }
+    }
+}

--- a/tests/ImageProcessor.Web.UnitTests/RegularExpressionUnitTests.cs
+++ b/tests/ImageProcessor.Web.UnitTests/RegularExpressionUnitTests.cs
@@ -45,6 +45,27 @@ namespace ImageProcessor.Web.UnitTests
         }
 
         /// <summary>
+        /// The gamma regex unit test.
+        /// </summary>
+        /// <param name="input">The input string.</param>
+        /// <param name="expected">The expected result.</param>
+        [Test]
+        [TestCase("gamma=0", 0F)]
+        [TestCase("gamma=270", 270F)]
+        [TestCase("gamma=-270", -270F)]
+        [TestCase("gamma=28", 28F)]
+        [TestCase("gamma=28.7", 28.7F)]
+        public void TestGammaRegex(string input, float expected)
+        {
+            Processors.Gamma rotate = new Processors.Gamma();
+            rotate.MatchRegexIndex(input);
+
+            float result = rotate.Processor.DynamicParameter;
+
+            Assert.AreEqual(expected, result);
+        }
+
+        /// <summary>
         /// The contrast regex unit test.
         /// </summary>
         /// <param name="input">The input string.</param>


### PR DESCRIPTION
### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have verified that there are no overlapping [pull-requests](https://github.com/JimBobSquarePants/ImageProcessor/pulls) open
- [X] I have verified that I am following matches the existing coding patterns and practise as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [X] I have provided test coverage for my change (where applicable)

### Description
ImageProcessor.Web is missing a Gamma IWebGrapicsProcessor implementation. The IGrapicsProcessor is there

<!-- Thanks for contributing to ImageProcessor! -->
