### PR TITLE
Changed Debug.WriteLine to Trace.WriteLine

### DIFF
--- a/src/ImageProcessor/Common/Exceptions/Logging/DefaultLogger.cs
+++ b/src/ImageProcessor/Common/Exceptions/Logging/DefaultLogger.cs
@@ -4,7 +4,7 @@
 //   Licensed under the Apache License, Version 2.0.
 // </copyright>
 // <summary>
-//   The default logger which logs messages to the debugger.
+//   The default logger which logs messages to the trace listeners.
 // </summary>
 // --------------------------------------------------------------------------------------------------------------------
 
@@ -45,14 +45,15 @@ namespace ImageProcessor.Common.Exceptions
             this.LogInternal(type, text, callerName, lineNumber);
         }
 
-        /// <summary>
-        /// Logs the specified message.
-        /// </summary>
-        /// <param name="type">The type calling the logger.</param>
-        /// <param name="text">The message to log.</param>
-        /// <param name="callerName">The property or method name calling the log.</param>
-        /// <param name="lineNumber">The line number where the method is called.</param>
-        private void LogInternal(Type type, string text, string callerName = null, int lineNumber = 0)
+		/// <summary>
+		/// Logs the specified message.
+		/// </summary>
+		/// <param name="type">The type calling the logger.</param>
+		/// <param name="text">The message to log.</param>
+		/// <param name="callerName">The property or method name calling the log.</param>
+		/// <param name="lineNumber">The line number where the method is called.</param>
+		[Conditional("TRACE")]
+		private void LogInternal(Type type, string text, string callerName = null, int lineNumber = 0)
         {
             string message = String.Format("{0} - {1}: {2} {3}:{4}", DateTime.UtcNow.ToString("s"), type.Name, callerName, lineNumber, text);
 


### PR DESCRIPTION
Allow logging messages without DEBUG constant or resorting to reflection using the built-in Trace class.
