### PR TITLE
Allow `CachedRewritePathExpiry` to be passed as a config variable

### DIFF
--- a/src/ImageProcessor.Web/Caching/CacheIndexer.cs
+++ b/src/ImageProcessor.Web/Caching/CacheIndexer.cs
@@ -56,18 +56,21 @@ namespace ImageProcessor.Web.Caching
         }
 
         /// <summary>
-        /// Adds the specified key and value to the dictionary or returns the value if it exists.
+        /// Adds a <see cref="cachedImage"/> to the cache.
         /// </summary>
         /// <param name="cachedImage">
         /// The cached image to add.
         /// </param>
+        /// <param name="expiry">
+        /// The number of minutes to cache the image, defaults to 1.
+        /// </param>
         /// <returns>
         /// The value of the item to add or get.
         /// </returns>
-        public static CachedImage Add(CachedImage cachedImage)
+        public static CachedImage Add(CachedImage cachedImage, int expiry = 1)
         {
-            // Add the CachedImage with a sliding expiration of 1 minutes.
-            CacheItemPolicy policy = new CacheItemPolicy { SlidingExpiration = new TimeSpan(0, 1, 0) };
+            // Add the CachedImage with a sliding expiration of `expiry` minutes.
+            CacheItemPolicy policy = new CacheItemPolicy { SlidingExpiration = new TimeSpan(0, expiry, 0) };
 
             if (new Uri(cachedImage.Path).IsFile)
             {

--- a/src/ImageProcessor.Web/Caching/ImageCacheBase.cs
+++ b/src/ImageProcessor.Web/Caching/ImageCacheBase.cs
@@ -65,6 +65,7 @@ namespace ImageProcessor.Web.Caching
 
             ImageProcessorConfiguration config = ImageProcessorConfiguration.Instance;
             this.Settings = this.AugmentSettingsCore(config.ImageCacheSettings);
+            this.CachedPathExpiry = config.ImageCacheRewritePathExpiry;
             this.MaxDays = config.ImageCacheMaxDays;
             this.BrowserMaxDays = config.BrowserCacheMaxDays;
             this.TrimCache = config.TrimCache;
@@ -80,6 +81,11 @@ namespace ImageProcessor.Web.Caching
         /// Gets or sets the path to the cached image.
         /// </summary>
         public string CachedPath { get; set; }
+
+        /// <summary>
+        /// Gets or sets the expiry of the cached path to the cached image.
+        /// </summary>
+        public int CachedPathExpiry { get; set; }
 
         /// <summary>
         /// Gets or sets the maximum number of days to store the image.

--- a/src/ImageProcessor.Web/Configuration/ImageCacheSection.cs
+++ b/src/ImageProcessor.Web/Configuration/ImageCacheSection.cs
@@ -172,6 +172,26 @@ namespace ImageProcessor.Web.Configuration
             }
 
             /// <summary>
+            /// Gets or sets the number of minutes to store the rewritten CDN path in the cache
+            /// </summary>
+            /// <value>The number of minutes to store the rewritten CDN path in the cache</value>
+            /// <remarks>Defaults to 1 if not set.</remarks>
+            [ConfigurationProperty("cachedRewritePathExpiry", DefaultValue = "1", IsRequired = false)]
+            [IntegerValidator(ExcludeRange = false, MinValue = 1, MaxValue = 20)]
+            public int CachedRewritePathExpiry
+            {
+                get
+                {
+                    return (int)this["cachedRewritePathExpiry"];
+                }
+
+                set
+                {
+                    this["cachedRewritePathExpiry"] = value;
+                }
+            }
+
+            /// <summary>
             /// Gets or sets a value indicating whether to periodically trim the cache.
             /// </summary>
             /// <remarks>

--- a/src/ImageProcessor.Web/Configuration/ImageProcessorConfiguration.cs
+++ b/src/ImageProcessor.Web/Configuration/ImageProcessorConfiguration.cs
@@ -118,6 +118,11 @@ namespace ImageProcessor.Web.Configuration
         public Dictionary<string, string> ImageCacheSettings { get; private set; }
 
         /// <summary>
+        /// Gets the image cache rewrite path cache expiry.
+        /// </summary>
+        public int ImageCacheRewritePathExpiry { get; private set; }
+
+        /// <summary>
         /// Gets a value indicating whether to preserve exif meta data.
         /// </summary>
         public bool PreserveExifMetaData => GetImageProcessingSection().PreserveExifMetaData;
@@ -407,6 +412,7 @@ namespace ImageProcessor.Web.Configuration
                         this.BrowserCacheMaxDays = cache.BrowserMaxDays;
                         this.TrimCache = cache.TrimCache;
                         this.FolderDepth = cache.FolderDepth;
+                        this.ImageCacheRewritePathExpiry = cache.CachedRewritePathExpiry;
                         this.ImageCacheSettings = cache.Settings
                                                        .Cast<SettingElement>()
                                                        .ToDictionary(setting => setting.Key, setting => setting.Value);


### PR DESCRIPTION
### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have verified that there are no overlapping [pull-requests](https://github.com/JimBobSquarePants/ImageProcessor/pulls) open
- [X] I have verified that I am following matches the existing coding patterns and practise as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [ ] ~~I have provided test coverage for my change (where applicable)~~

### Description
I've added a new optional config property `ImageCacheSection.CachedRewritePathExpiry` and passed this in to `CacheIndexer.Add` with a default value matching the currently-hardcoded expiry time of 1 minute. This necessitates a new property `ImageCacheBase.CachedPathExpiry`.
