### PR TITLE
Set 'prefix' config value for CloudImageService

### DIFF
--- a/src/ImageProcessor.Web/Configuration/Resources/security.config.transform
+++ b/src/ImageProcessor.Web/Configuration/Resources/security.config.transform
@@ -2,7 +2,7 @@
   <services>
     <service name="LocalFileImageService" type="ImageProcessor.Web.Services.LocalFileImageService, ImageProcessor.Web"/>
     <!--Disable the LocalFileImageService and enable this one when using virtual paths. -->
-    <!--<service name="CloudImageService" type="ImageProcessor.Web.Services.CloudImageService, ImageProcessor.Web">
+    <!--<service prefix="media/" name="CloudImageService" type="ImageProcessor.Web.Services.CloudImageService, ImageProcessor.Web">
       <settings>
         <setting key="Container" value=""/>
         <setting key="MaxBytes" value="8194304"/>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/JimBobSquarePants/ImageProcessor/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practise as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [ ] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
This commit sets a value for the prefix attribute in the CloudImageService-service element security.config file. The attribute is necessary for ImageProcessor to work and because files in Umbraco are always saved in the same Media directory we can safely provide a default value for this setting.

<!-- Thanks for contributing to ImageProcessor! -->
