### PR TITLE
Amend `CachedRewritePathExpiry` to be passed as a `TimeSpan` (instead of `int`)

### DIFF
--- a/src/ImageProcessor.Web/Caching/CacheIndexer.cs
+++ b/src/ImageProcessor.Web/Caching/CacheIndexer.cs
@@ -56,21 +56,24 @@ namespace ImageProcessor.Web.Caching
         }
 
         /// <summary>
-        /// Adds a <see cref="cachedImage"/> to the cache.
+        /// Adds a <see cref="CachedImage"/> to the cache.
         /// </summary>
         /// <param name="cachedImage">
         /// The cached image to add.
         /// </param>
-        /// <param name="expiry">
-        /// The number of minutes to cache the image, defaults to 1.
+        /// <param name="expiration">
+        /// A <see cref="TimeSpan"/> defining the sliding expiration duration, defaults to zero
         /// </param>
         /// <returns>
         /// The value of the item to add or get.
         /// </returns>
-        public static CachedImage Add(CachedImage cachedImage, int expiry = 1)
+        public static CachedImage Add(CachedImage cachedImage, TimeSpan expiration = default(TimeSpan))
         {
+            if (expiration == default(TimeSpan) || expiration == TimeSpan.Zero)
+            { expiration = new TimeSpan(0, 1, 0); }
+
             // Add the CachedImage with a sliding expiration of `expiry` minutes.
-            CacheItemPolicy policy = new CacheItemPolicy { SlidingExpiration = new TimeSpan(0, expiry, 0) };
+            CacheItemPolicy policy = new CacheItemPolicy { SlidingExpiration = expiration };
 
             if (new Uri(cachedImage.Path).IsFile)
             {
@@ -104,5 +107,23 @@ namespace ImageProcessor.Web.Caching
 
             return cachedImage;
         }
+
+        /// <summary>
+        /// Adds a <see cref="CachedImage"/> to the cache.
+        /// </summary>
+        /// <param name="cachedImage">
+        /// The cached image to add.
+        /// </param>
+        /// <param name="expiry">
+        /// The number of minutes to cache the image, defaults to 1.
+        /// </param>
+        /// <returns>
+        /// The value of the item to add or get.
+        /// </returns>
+        public static CachedImage Add(CachedImage cachedImage, int expiry)
+        {
+            return Add(cachedImage, new TimeSpan(0, expiry, 0));
+        }
+    
     }
 }

--- a/src/ImageProcessor.Web/Caching/ImageCacheBase.cs
+++ b/src/ImageProcessor.Web/Caching/ImageCacheBase.cs
@@ -85,7 +85,7 @@ namespace ImageProcessor.Web.Caching
         /// <summary>
         /// Gets or sets the expiry of the cached path to the cached image.
         /// </summary>
-        public int CachedPathExpiry { get; set; }
+        public TimeSpan CachedPathExpiry { get; set; }
 
         /// <summary>
         /// Gets or sets the maximum number of days to store the image.

--- a/src/ImageProcessor.Web/Configuration/ImageCacheSection.cs
+++ b/src/ImageProcessor.Web/Configuration/ImageCacheSection.cs
@@ -10,10 +10,11 @@
 
 namespace ImageProcessor.Web.Configuration
 {
+    using System;
     using System.Configuration;
     using System.IO;
     using System.Xml;
-
+    
     using ImageProcessor.Web.Helpers;
 
     /// <summary>
@@ -175,14 +176,14 @@ namespace ImageProcessor.Web.Configuration
             /// Gets or sets the number of minutes to store the rewritten CDN path in the cache
             /// </summary>
             /// <value>The number of minutes to store the rewritten CDN path in the cache</value>
-            /// <remarks>Defaults to 1 if not set.</remarks>
-            [ConfigurationProperty("cachedRewritePathExpiry", DefaultValue = "1", IsRequired = false)]
-            [IntegerValidator(ExcludeRange = false, MinValue = 1, MaxValue = 20)]
-            public int CachedRewritePathExpiry
+            /// <remarks>Defaults to <c>0:1:0</c> if not set.</remarks>
+            [ConfigurationProperty("cachedRewritePathExpiry", DefaultValue = "0:1:0", IsRequired = false)]
+            [PositiveTimeSpanValidator]
+            public TimeSpan CachedRewritePathExpiry
             {
                 get
                 {
-                    return (int)this["cachedRewritePathExpiry"];
+                    return (TimeSpan)this["cachedRewritePathExpiry"];
                 }
 
                 set

--- a/src/ImageProcessor.Web/Configuration/ImageProcessorConfiguration.cs
+++ b/src/ImageProcessor.Web/Configuration/ImageProcessorConfiguration.cs
@@ -122,7 +122,7 @@ namespace ImageProcessor.Web.Configuration
         /// <summary>
         /// Gets the image cache rewrite path cache expiry.
         /// </summary>
-        public int ImageCacheRewritePathExpiry { get; private set; }
+        public TimeSpan ImageCacheRewritePathExpiry { get; private set; }
 
         /// <summary>
         /// Gets a value indicating whether to preserve exif meta data.


### PR DESCRIPTION
### Prerequisites
- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/JimBobSquarePants/ImageProcessor/pulls) open
- [x ] I have verified that I am following matches the existing coding patterns and practise as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [ ] ~~I have provided test coverage for my change (where applicable)~~

### Description
Amend `CachedRewritePathExpiry` to be passed as a `TimeSpan` (instead of `int`) as suggested by @dlemstra in pull request #640.

I've made the `TimeSpan` be the default, but added an overload to `CacheIndexer.Add` that takes an `int`, in case anyone has already started using the code from PR #640. The only potential **breaking change** is that I have changed the config property `ImageCacheSection.CachedRewritePathExpiry` (that I created in #640) to take a `TimeSpan` (and thus a `TimeSpan` literal like `0:1:0` for 1 minute) instead of an `int`. This uses a [`PositiveTimeSpanValidator`](https://msdn.microsoft.com/en-us/library/system.configuration.positivetimespanvalidatorattribute%28v=vs.110%29.aspx), so will presumably fail with a `ConfigurationErrorsException` if the config contains an integer literal.

**Note:** I have not been able to compile this to confirm, as the project has been upgraded to C# 7.0 with new-style [out variables](https://blogs.msdn.microsoft.com/dotnet/2017/03/09/new-features-in-c-7-0/), so will not build in Visual Studio 2015 and C# 6.0. I can confirm, however, that the only build errors are related to out variables, so the change should build correctly in Visual Studio 2017 and C# 7.0.