### PR TITLE
add default value for GetExtension method

### DIFF
--- a/src/ImageProcessor.Web/Helpers/ImageHelpers.cs
+++ b/src/ImageProcessor.Web/Helpers/ImageHelpers.cs
@@ -91,10 +91,11 @@ namespace ImageProcessor.Web.Helpers
         /// </summary>
         /// <param name="fullPath">The string to parse.</param>
         /// <param name="queryString">The querystring containing instructions.</param>
+        /// <param name="defaultExtension">The default value to return.</param>
         /// <returns>
-        /// The correct file extension for the given string input if it can find one; otherwise an empty string.
+        /// The correct file extension for the given string input if it can find one; otherwise defaults to jpg.
         /// </returns>
-        public string GetExtension(string fullPath, string queryString)
+        public string GetExtension(string fullPath, string queryString, string defaultExtension = "jpg")
         {
             Match match = null;
 
@@ -135,8 +136,7 @@ namespace ImageProcessor.Web.Helpers
                 return value;
             }
 
-            // Fall back to jpg
-            return "jpg";
+            return defaultExtension;
         }
 
         /// <summary>


### PR DESCRIPTION
the inline documentation of GetExtension says default to "string.Empty", but the code returns "jpg".

In my opinion string.Empty actually sounds more feasible.

This commits add a parameter with default value "jpg" to make it easier to check if the requested input actually is supported or not by passing f.ex. null or string.Empty as default value.

### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/JimBobSquarePants/ImageProcessor/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practise as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [ ] I have provided test coverage for my change (where applicable)
