### PR TITLE
Replace HttpWebRequest with HttpResponseMessage. Fix #651

### DIFF
--- a/src/ImageProcessor.Web/Configuration/ImageProcessorConfiguration.cs
+++ b/src/ImageProcessor.Web/Configuration/ImageProcessorConfiguration.cs
@@ -310,7 +310,7 @@ namespace ImageProcessor.Web.Configuration
 
                 if (type == null)
                 {
-                    string message = $"Couldn\'t load IImageService: {config.Type}";
+                    string message = $"Couldn't load IImageService: {config.Type}";
                     ImageProcessorBootstrapper.Instance.Logger.Log<ImageProcessorConfiguration>(message);
                     throw new TypeLoadException(message);
                 }
@@ -357,7 +357,7 @@ namespace ImageProcessor.Web.Configuration
                     .ToDictionary(setting => setting.Key, setting => setting.Value);
 
                 // Override the config section settings with values found in the app.config / deployment slot settings
-                OverrideDefaultSettingsWithAppSettingsValue(settings, name);
+                this.OverrideDefaultSettingsWithAppSettingsValue(settings, name);
             }
             else
             {
@@ -429,7 +429,7 @@ namespace ImageProcessor.Web.Configuration
                         this.ImageCacheSettings = cache.Settings
                                                        .Cast<SettingElement>()
                                                        .ToDictionary(setting => setting.Key, setting => setting.Value);
-                        
+
                         //override the settings found with values found in the app.config / deployment slot settings
                         OverrideDefaultSettingsWithAppSettingsValue(this.ImageCacheSettings, currentCache);
 
@@ -451,12 +451,12 @@ namespace ImageProcessor.Web.Configuration
         {
 
             Dictionary<string, string> copyOfSettingsForEnumeration = new Dictionary<string, string>(defaultSettings);
-            
+
             // For each default setting found in the config section
             foreach (var setting in copyOfSettingsForEnumeration)
             {
                 // Check the app settings for a key in the specified format
-                string appSettingKeyName = string.Format("ImageProcessor.{0}.{1}", serviceOrPluginName, setting.Key);
+                string appSettingKeyName = $"ImageProcessor.{serviceOrPluginName}.{setting.Key}";
                 if (!String.IsNullOrEmpty(ConfigurationManager.AppSettings[appSettingKeyName]))
                 {
                     // If the key is found in app settings use the app settings value rather than the value in the config section
@@ -465,7 +465,7 @@ namespace ImageProcessor.Web.Configuration
             }
 
         }
-        
+
         #endregion
     }
 }

--- a/src/ImageProcessor.Web/Helpers/RemoteFile.cs
+++ b/src/ImageProcessor.Web/Helpers/RemoteFile.cs
@@ -8,19 +8,18 @@
 // </summary>
 // --------------------------------------------------------------------------------------------------------------------
 
+using System;
 using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Security;
+using System.Threading.Tasks;
+using System.Web;
+using ImageProcessor.Configuration;
+using ImageProcessor.Web.HttpModules;
 
 namespace ImageProcessor.Web.Helpers
 {
-    using System;
-    using System.Globalization;
-    using System.Net;
-    using System.Security;
-    using System.Threading.Tasks;
-    using System.Web;
-
-    using ImageProcessor.Configuration;
-
     /// <summary>
     /// Encapsulates methods used to download files from a website address.
     /// </summary>
@@ -33,234 +32,146 @@ namespace ImageProcessor.Web.Helpers
     /// For example, the ImageProcessingModule accepts off-server addresses as a path. An attacker could, for instance, pass the url
     /// to a file that's a few gigs in size, causing the server to get out-of-memory exceptions or some other errors. An attacker
     /// could also use this same method to use one application instance to hammer another site by, again, passing an off-server
-    /// address of the victims site to the ImageProcessingModule.
+    /// address of the victims site to the <see cref="ImageProcessingModule"/>.
     /// This class will not throw an exception if the Uri supplied points to a resource local to the running application instance.
     /// <para>
-    /// There shouldn't be any security issues there, as the internal WebRequest instance is still calling it remotely.
+    /// There shouldn't be any security issues there, as the internal <see cref="HttpClient"/> instance is still calling it remotely.
     /// Any local files that shouldn't be accessed by this won't be allowed by the remote call.
     /// </para>
-    /// Adapted from <see href="http://blogengine.codeplex.com">BlogEngine.Net</see>
     /// </remarks>
     internal sealed class RemoteFile
     {
-        #region Fields
-        /// <summary>
-        /// The maximum allowable download size in bytes.
-        /// </summary>
-        private int maxDownloadSize;
-
-        /// <summary>
-        /// The length of time, in milliseconds, that a remote file download attempt can last before timing out.
-        /// </summary>
-        private int timeoutLength;
-
-        /// <summary>
-        /// The <see cref="T:System.Net.WebResponse">WebResponse</see> object used internally for this RemoteFile instance.
-        /// </summary>
-        private WebRequest webRequest;
-
-        #endregion
-
-        #region Constructors
-        /// <summary>
-        /// Initializes a new instance of the <see cref="T:ImageProcessor.Web.Helpers.RemoteFile">RemoteFile</see> class.
-        /// </summary>
-        /// <param name="filePath">The url of the file to be downloaded.</param>
-        internal RemoteFile(Uri filePath)
+        private static readonly HttpClientHandler Handler = new HttpClientHandler()
         {
-            if (filePath == null)
-            {
-                throw new ArgumentNullException(nameof(filePath));
-            }
+            AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate,
+            Credentials = CredentialCache.DefaultNetworkCredentials
+        };
 
-            this.Uri = filePath;
+        private static readonly HttpClient Client = new HttpClient(Handler);
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RemoteFile"/> class.
+        /// </summary>
+        /// <param name="timeoutMilliseconds">The maximum time, in milliseconds, to wait before the request times out.</param>
+        /// <param name="maxDownloadSize">The maximum download size, in bytes, that a remote file download attempt can be.</param>
+        public RemoteFile(int timeoutMilliseconds, int maxDownloadSize)
+            : this(timeoutMilliseconds, maxDownloadSize, null)
+        {
         }
-        #endregion
-
-        #region Properties
-        /// <summary>
-        /// Gets the Uri of the remote file being downloaded.
-        /// </summary>
-        public Uri Uri { get; }
 
         /// <summary>
-        /// Gets or sets the length of time, in milliseconds, that a remote file download attempt can
-        /// last before timing out.
-        /// <remarks>
-        /// <para>
-        /// This value can only be set if the instance is supposed to ignore the remote download settings set
-        /// in the current application instance.
-        /// </para>
-        /// <para>
-        /// Set this value to 0 if there should be no timeout.
-        /// </para>
-        /// </remarks>
+        /// Initializes a new instance of the <see cref="RemoteFile"/> class.
         /// </summary>
-        public int TimeoutLength
+        /// <param name="timeoutMilliseconds">The maximum time, in milliseconds, to wait before the request times out.</param>
+        /// <param name="maxDownloadSize">The maximum download size, in bytes, that a remote file download attempt can be.</param>
+        /// <param name="userAgent">The User-Agent header to be passed when requesting the remote file.</param>
+        public RemoteFile(int timeoutMilliseconds, int maxDownloadSize, string userAgent)
         {
-            get
+            if (timeoutMilliseconds >= 0)
             {
-                return this.timeoutLength;
+                this.Timeout = TimeSpan.FromMilliseconds(timeoutMilliseconds);
             }
 
-            set
+            if (maxDownloadSize > 0)
             {
-                if (value < 0)
-                {
-                    // ReSharper disable once NotResolvedInText
-                    throw new ArgumentOutOfRangeException("TimeoutLength");
-                }
+                this.MaxDownloadSize = maxDownloadSize;
+            }
 
-                this.timeoutLength = value;
+            this.UserAgent = userAgent;
+
+            // We're reusing the same static HttpClient so we don't exhaust the number of sockets available under heavy loads.
+            // We're always using the same timeout, and user-agent values per all instances so it's ok to set the values here per instance.
+            Client.Timeout = this.Timeout;
+            var key = "User-Agent";
+            if (!string.IsNullOrWhiteSpace(this.UserAgent) && !Client.DefaultRequestHeaders.TryGetValues(key, out var _))
+            {
+                Client.DefaultRequestHeaders.Add(key, this.UserAgent);
             }
         }
 
         /// <summary>
-        /// Gets or sets the maximum download size, in bytes, that a remote file download attempt can be.
-        /// <remarks>
-        /// <para>
-        /// This value can only be set if the instance is supposed to ignore the remote download settings set
-        /// in the current application instance.
-        /// </para>
-        /// <para>
-        /// Set this value to 0 if there should be no max bytes.
-        /// </para>
-        /// </remarks>
+        /// Gets or sets the timespan to wait before the request times out.
         /// </summary>
-        public int MaxDownloadSize
-        {
-            get
-            {
-                return this.maxDownloadSize;
-            }
-
-            set
-            {
-                if (value < 0)
-                {
-                    // ReSharper disable once NotResolvedInText
-                    throw new ArgumentOutOfRangeException("MaxDownloadSize");
-                }
-
-                this.maxDownloadSize = value;
-            }
-        }
+        public TimeSpan Timeout { get; } = TimeSpan.FromSeconds(100.0);
 
         /// <summary>
-        /// Gets or sets the UserAgent header to be passed when requesting the remote file
+        /// Gets the maximum download size, in bytes, that a remote file download attempt can be.
         /// </summary>
-        public string UserAgent { get; set; }
+        public int MaxDownloadSize { get; } = int.MaxValue;
 
-        #endregion
-
-        #region Methods
-        #region Internal
         /// <summary>
-        /// Returns the <see cref="T:System.Net.WebResponse">WebResponse</see> used to download this file.
+        /// Gets the UserAgent header to be passed when requesting the remote file
+        /// </summary>
+        public string UserAgent { get; }
+
+        /// <summary>
+        /// Returns the <see cref="HttpResponseMessage"/> used to download this file.
         /// <remarks>
         /// <para>
-        /// This method is meant for outside users who need specific access to the WebResponse this class
+        /// This method is meant for outside users who need specific access to the HttpResponseMessage this class
         /// generates. They're responsible for disposing of it.
         /// </para>
         /// </remarks>
         /// </summary>
-        /// <returns>The <see cref="T:System.Net.WebResponse">WebResponse</see> used to download this file.</returns>
+        /// <returns>The <see cref="HttpResponseMessage"/> used to download this file.</returns>
         /// <returns>
         /// The <see cref="IEnumerable{T}"/>.
         /// </returns>
-        internal async Task<WebResponse> GetWebResponseAsync()
+        internal async Task<HttpResponseMessage> GetResponseAsync(Uri uri)
         {
-            WebResponse response;
+            void Log(HttpRequestException ex)
+            {
+                ImageProcessorBootstrapper.Instance.Logger.Log<RemoteFile>(ex.Message);
+            }
+
+            HttpResponseMessage response = null;
+            HttpStatusCode statusCode = HttpStatusCode.OK;
             try
             {
-                response = await this.GetWebRequest().GetResponseAsync().ConfigureAwait(false);
-            }
-            catch (WebException ex)
-            {
-                HttpWebResponse errorResponse = (HttpWebResponse)ex.Response;
-                if (errorResponse?.StatusCode == HttpStatusCode.NotFound || ex.Status == WebExceptionStatus.NameResolutionFailure)
-                {
-                    throw new HttpException((int)HttpStatusCode.NotFound, "No image exists at " + this.Uri, ex);
-                }
+                response = await Client.GetAsync(uri).ConfigureAwait(false);
+                statusCode = response.StatusCode;
+                response.EnsureSuccessStatusCode();
 
-                if (errorResponse?.StatusCode == HttpStatusCode.NotModified)
+                long? contentLength = response.Content.Headers.ContentLength;
+                if (contentLength.HasValue)
                 {
-                    response = errorResponse;
+                    if (contentLength > this.MaxDownloadSize)
+                    {
+                        response.Dispose();
+                        string message = "An attempt to download a remote file has been halted because the file is larger than allowed.";
+                        ImageProcessorBootstrapper.Instance.Logger.Log<RemoteFile>(message);
+                        throw new SecurityException(message);
+                    }
                 }
                 else
                 {
-                    throw;
+                    response.Dispose();
+                    throw new HttpException((int)HttpStatusCode.NotFound, $"No image exists at {uri}");
                 }
-            }
 
-            if (response != null)
+                return response;
+            }
+            catch (HttpRequestException ex)
             {
-                long contentLength = response.ContentLength;
-
-                // WebResponse.ContentLength doesn't always know the value, it returns -1 in this case.
-                if (contentLength == -1)
+                switch (statusCode)
                 {
-                    // Response headers may still have the Content-Length inside of it.
-                    string headerContentLength = response.Headers["Content-Length"];
+                    // No error, carry on.
+                    case HttpStatusCode.NotModified:
+                        break;
+                    case HttpStatusCode.NotFound:
 
-                    if (!string.IsNullOrWhiteSpace(headerContentLength))
-                    {
-                        contentLength = long.Parse(headerContentLength, CultureInfo.InvariantCulture);
-                    }
-                }
+                        // We want 404's to be handled by IIS so that other handlers/modules can still run.
+                        Log(ex);
+                        response?.Dispose();
+                        throw new HttpException((int)statusCode, $"No image exists at {uri}", ex);
 
-                // We don't need to check the url here since any external urls are available only from the web.config.
-                if ((this.MaxDownloadSize > 0) && (contentLength > this.MaxDownloadSize))
-                {
-                    response.Close();
-                    string message = "An attempt to download a remote file has been halted because the file is larger than allowed.";
-                    ImageProcessorBootstrapper.Instance.Logger.Log<RemoteFile>(message);
-                    throw new SecurityException(message);
+                    default:
+                        Log(ex);
+                        break;
                 }
             }
 
-            return response;
+            return null;
         }
-        #endregion
-
-        #region Private
-        /// <summary>
-        /// Creates the WebRequest object used internally for this RemoteFile instance.
-        /// </summary>
-        /// <returns>
-        /// <para>
-        /// The WebRequest should not be passed outside of this instance, as it will allow tampering. Anyone
-        /// that needs more fine control over the downloading process should probably be using the WebRequest
-        /// class on its own.
-        /// </para>
-        /// </returns>
-        private WebRequest GetWebRequest()
-        {
-            if (this.webRequest == null)
-            {
-                HttpWebRequest request = (HttpWebRequest)WebRequest.Create(this.Uri);
-                request.Headers["Accept-Encoding"] = "gzip";
-                request.Headers["Accept-Language"] = "en-us";
-
-                if (!string.IsNullOrEmpty(this.UserAgent))
-                {
-                    request.UserAgent = this.UserAgent;
-                }
-
-                request.Credentials = CredentialCache.DefaultNetworkCredentials;
-                request.AutomaticDecompression = DecompressionMethods.GZip;
-
-                if (this.TimeoutLength > 0)
-                {
-                    request.Timeout = this.TimeoutLength;
-                }
-
-                this.webRequest = request;
-            }
-
-            return this.webRequest;
-        }
-        #endregion
-        #endregion
     }
 }

--- a/src/ImageProcessor.Web/HttpModules/ImageProcessingModule.cs
+++ b/src/ImageProcessor.Web/HttpModules/ImageProcessingModule.cs
@@ -624,7 +624,7 @@ namespace ImageProcessor.Web.HttpModules
                                 }
                                 else
                                 {
-                                    // We're cachebusting. Allow the value to be cached
+                                    // We're cache-busting. Allow the value to be cached
                                     await inStream.CopyToAsync(outStream).ConfigureAwait(false);
                                     mimeType = FormatUtilities.GetFormat(outStream).MimeType;
                                 }

--- a/src/ImageProcessor.Web/ImageProcessor.Web.csproj
+++ b/src/ImageProcessor.Web/ImageProcessor.Web.csproj
@@ -42,6 +42,7 @@
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.Net.Http" />
     <Reference Include="System.Runtime.Caching" />
     <Reference Include="System.Web" />
     <Reference Include="System.Xml.Linq" />

--- a/src/ImageProcessor.Web/Services/RemoteImageService.cs
+++ b/src/ImageProcessor.Web/Services/RemoteImageService.cs
@@ -8,40 +8,30 @@
 // </summary>
 // --------------------------------------------------------------------------------------------------------------------
 
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Threading.Tasks;
+using ImageProcessor.Web.Caching;
+using ImageProcessor.Web.Helpers;
+using Microsoft.IO;
+
 namespace ImageProcessor.Web.Services
 {
-    using System;
-    using System.Collections.Generic;
-    using System.IO;
-    using System.Net;
-    using System.Threading.Tasks;
-    using System.Web;
-
-    using ImageProcessor.Web.Caching;
-    using ImageProcessor.Web.Helpers;
-
-    using Microsoft.IO;
-
     /// <summary>
     /// The remote image service.
     /// </summary>
     public class RemoteImageService : IImageService
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="RemoteImageService"/> class.
-        /// </summary>
-        public RemoteImageService()
+        private RemoteFile remoteFile;
+        private Dictionary<string, string> settings = new Dictionary<string, string>
         {
-            this.Settings = new Dictionary<string, string>
-            {
-                { "MaxBytes", "4194304" },
-                { "Timeout", "30000" },
-                { "Protocol", "http" },
-                { "UserAgent", string.Empty }
-            };
-
-            this.WhiteList = new Uri[] { };
-        }
+            { "MaxBytes", "4194304" },
+            { "Timeout", "30000" },
+            { "Protocol", "http" },
+            { "UserAgent", string.Empty }
+        };
 
         /// <summary>
         /// Gets or sets the prefix for the given implementation.
@@ -60,12 +50,20 @@ namespace ImageProcessor.Web.Services
         /// <summary>
         /// Gets or sets any additional settings required by the service.
         /// </summary>
-        public Dictionary<string, string> Settings { get; set; }
+        public Dictionary<string, string> Settings
+        {
+            get => this.settings;
+            set
+            {
+                this.settings = value;
+                this.InitRemoteFile();
+            }
+        }
 
         /// <summary>
         /// Gets or sets the white list of <see cref="System.Uri"/>.
         /// </summary>
-        public Uri[] WhiteList { get; set; }
+        public Uri[] WhiteList { get; set; } = { };
 
         /// <summary>
         /// Gets a value indicating whether the current request passes sanitizing rules.
@@ -108,59 +106,50 @@ namespace ImageProcessor.Web.Services
         /// <summary>
         /// Gets the image using the given identifier.
         /// </summary>
-        /// <param name="id">
-        /// The value identifying the image to fetch.
-        /// </param>
+        /// <param name="id">The value identifying the image to fetch.</param>
         /// <returns>
-        /// The <see cref="System.Byte"/> array containing the image data.
+        /// The <see cref="byte"/> array containing the image data.
         /// </returns>
         public virtual async Task<byte[]> GetImage(object id)
         {
-            Uri uri = new Uri(id.ToString());
-            RemoteFile remoteFile = new RemoteFile(uri)
-            {
-                MaxDownloadSize = int.Parse(this.Settings["MaxBytes"]),
-                TimeoutLength = int.Parse(this.Settings["Timeout"])
-            };
-
-            // Check for optional user agesnt.
-            if (this.Settings.ContainsKey("Useragent"))
-            {
-                if (!string.IsNullOrWhiteSpace(this.Settings["Useragent"]))
-                {
-                    remoteFile.UserAgent = this.Settings["Useragent"];
-                }
-            }
-
             byte[] buffer;
 
-            // Prevent response blocking.
-            WebResponse webResponse = await remoteFile.GetWebResponseAsync().ConfigureAwait(false);
+            if (this.remoteFile == null)
+            {
+                this.InitRemoteFile();
+            }
+
+            HttpResponseMessage httpResponse = await this.remoteFile.GetResponseAsync(new Uri(id.ToString())).ConfigureAwait(false);
+
+            if (httpResponse == null)
+            {
+                return null;
+            }
 
             using (RecyclableMemoryStream memoryStream = new RecyclableMemoryStream(MemoryStreamPool.Shared))
             {
-                using (WebResponse response = webResponse)
+                using (HttpResponseMessage response = httpResponse)
                 {
-                    using (Stream responseStream = response.GetResponseStream())
+                    using (Stream responseStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false))
                     {
-                        if (responseStream != null)
-                        {
-                            responseStream.CopyTo(memoryStream);
+                        responseStream.CopyTo(memoryStream);
 
-                            // Reset the position of the stream to ensure we're reading the correct part.
-                            memoryStream.Position = 0;
-
-                            buffer = memoryStream.GetBuffer();
-                        }
-                        else
-                        {
-                            throw new HttpException((int)HttpStatusCode.NotFound, $"No image exists at {uri}");
-                        }
+                        // Reset the position of the stream to ensure we're reading the correct part.
+                        memoryStream.Position = 0;
+                        buffer = memoryStream.GetBuffer();
                     }
                 }
             }
 
             return buffer;
+        }
+
+        private void InitRemoteFile()
+        {
+            int timeout = int.Parse(this.Settings["Timeout"]);
+            int maxDownloadSize = int.Parse(this.Settings["MaxBytes"]);
+            string userAgent = this.Settings["Useragent"];
+            this.remoteFile = new RemoteFile(timeout, maxDownloadSize, userAgent);
         }
     }
 }

--- a/src/ImageProcessor.Web/Services/RemoteImageService.cs
+++ b/src/ImageProcessor.Web/Services/RemoteImageService.cs
@@ -148,7 +148,8 @@ namespace ImageProcessor.Web.Services
         {
             int timeout = int.Parse(this.Settings["Timeout"]);
             int maxDownloadSize = int.Parse(this.Settings["MaxBytes"]);
-            string userAgent = this.Settings["Useragent"];
+
+            this.Settings.TryGetValue("Useragent", out string userAgent);
             this.remoteFile = new RemoteFile(timeout, maxDownloadSize, userAgent);
         }
     }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/JimBobSquarePants/ImageProcessor/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practise as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
Replace HttpWebRequest with HttpResponseMessage. Fixing #651 Requests are respect timeout property now.

RemoteImageService and CloudImageService now do less work per request also. 

<!-- Thanks for contributing to ImageProcessor! -->
