### PR TITLE
Add MetaDataMode. Fix #585

### DIFF
--- a/src/ImageProcessor.Web/Configuration/ImageProcessingSection.cs
+++ b/src/ImageProcessor.Web/Configuration/ImageProcessingSection.cs
@@ -29,8 +29,18 @@ namespace ImageProcessor.Web.Configuration
         [ConfigurationProperty("preserveExifMetaData", IsRequired = false, DefaultValue = false)]
         public bool PreserveExifMetaData
         {
-            get { return (bool)this["preserveExifMetaData"]; }
-            set { this["preserveExifMetaData"] = value; }
+            get => (bool)this["preserveExifMetaData"];
+            set => this["preserveExifMetaData"] = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the metadata mode to use when processing images.
+        /// </summary>
+        [ConfigurationProperty("metaDataMode", IsRequired = false, DefaultValue = MetaDataMode.None)]
+        public MetaDataMode MetaDataMode
+        {
+            get => (MetaDataMode)this["metaDataMode"];
+            set => this["metaDataMode"] = value;
         }
 
         /// <summary>
@@ -39,8 +49,8 @@ namespace ImageProcessor.Web.Configuration
         [ConfigurationProperty("allowCacheBuster", IsRequired = false, DefaultValue = true)]
         public bool AllowCacheBuster
         {
-            get { return (bool)this["allowCacheBuster"]; }
-            set { this["allowCacheBuster"] = value; }
+            get => (bool)this["allowCacheBuster"];
+            set => this["allowCacheBuster"] = value;
         }
 
         /// <summary>
@@ -50,8 +60,8 @@ namespace ImageProcessor.Web.Configuration
         [ConfigurationProperty("fixGamma", IsRequired = false, DefaultValue = false)]
         public bool FixGamma
         {
-            get { return (bool)this["fixGamma"]; }
-            set { this["fixGamma"] = value; }
+            get => (bool)this["fixGamma"];
+            set => this["fixGamma"] = value;
         }
 
         /// <summary>
@@ -61,8 +71,8 @@ namespace ImageProcessor.Web.Configuration
         [ConfigurationProperty("interceptAllRequests", IsRequired = false, DefaultValue = false)]
         public bool InterceptAllRequests
         {
-            get { return (bool)this["interceptAllRequests"]; }
-            set { this["interceptAllRequests"] = value; }
+            get => (bool)this["interceptAllRequests"];
+            set => this["interceptAllRequests"] = value;
         }
 
         /// <summary>
@@ -120,9 +130,9 @@ namespace ImageProcessor.Web.Configuration
             [ConfigurationProperty("name", DefaultValue = "", IsRequired = true)]
             public string Name
             {
-                get { return (string)this["name"]; }
+                get => (string)this["name"];
 
-                set { this["name"] = value; }
+                set => this["name"] = value;
             }
 
             /// <summary>
@@ -132,9 +142,9 @@ namespace ImageProcessor.Web.Configuration
             [ConfigurationProperty("value", DefaultValue = "", IsRequired = true)]
             public string Value
             {
-                get { return (string)this["value"]; }
+                get => (string)this["value"];
 
-                set { this["value"] = value; }
+                set => this["value"] = value;
             }
         }
 
@@ -172,10 +182,7 @@ namespace ImageProcessor.Web.Configuration
             /// </returns>
             public PresetElement this[int index]
             {
-                get
-                {
-                    return (PresetElement)BaseGet(index);
-                }
+                get => (PresetElement)BaseGet(index);
 
                 set
                 {
@@ -226,9 +233,9 @@ namespace ImageProcessor.Web.Configuration
             [ConfigurationProperty("name", DefaultValue = "", IsRequired = true)]
             public string Name
             {
-                get { return (string)this["name"]; }
+                get => (string)this["name"];
 
-                set { this["name"] = value; }
+                set => this["name"] = value;
             }
 
             /// <summary>
@@ -237,9 +244,9 @@ namespace ImageProcessor.Web.Configuration
             [ConfigurationProperty("type", DefaultValue = "", IsRequired = true)]
             public string Type
             {
-                get { return (string)this["type"]; }
+                get => (string)this["type"];
 
-                set { this["type"] = value; }
+                set => this["type"] = value;
             }
 
             /// <summary>
@@ -248,9 +255,9 @@ namespace ImageProcessor.Web.Configuration
             [ConfigurationProperty("enabled", DefaultValue = "false", IsRequired = false)]
             public bool Enabled
             {
-                get { return (bool)this["enabled"]; }
+                get => (bool)this["enabled"];
 
-                set { this["enabled"] = value; }
+                set => this["enabled"] = value;
             }
 
             /// <summary>
@@ -297,10 +304,7 @@ namespace ImageProcessor.Web.Configuration
             /// </returns>
             public PluginElement this[int index]
             {
-                get
-                {
-                    return (PluginElement)BaseGet(index);
-                }
+                get => (PluginElement)BaseGet(index);
 
                 set
                 {

--- a/src/ImageProcessor.Web/Configuration/ImageProcessingSection.cs
+++ b/src/ImageProcessor.Web/Configuration/ImageProcessingSection.cs
@@ -36,7 +36,7 @@ namespace ImageProcessor.Web.Configuration
         /// <summary>
         /// Gets or sets the metadata mode to use when processing images.
         /// </summary>
-        [ConfigurationProperty("metaDataMode", IsRequired = false, DefaultValue = MetaDataMode.None)]
+        [ConfigurationProperty("metaDataMode", IsRequired = false, DefaultValue = MetaDataMode.All)]
         public MetaDataMode MetaDataMode
         {
             get => (MetaDataMode)this["metaDataMode"];

--- a/src/ImageProcessor.Web/Configuration/ImageProcessorConfiguration.cs
+++ b/src/ImageProcessor.Web/Configuration/ImageProcessorConfiguration.cs
@@ -136,6 +136,11 @@ namespace ImageProcessor.Web.Configuration
         public bool PreserveExifMetaData => GetImageProcessingSection().PreserveExifMetaData;
 
         /// <summary>
+        /// Gets the metadata mode to use when when processing images.
+        /// </summary>
+        public MetaDataMode MetaDataMode => GetImageProcessingSection().MetaDataMode;
+
+        /// <summary>
         /// Gets a value indicating whether to allow known cachebusters.
         /// </summary>
         public bool AllowCacheBuster => GetImageProcessingSection().AllowCacheBuster;

--- a/src/ImageProcessor.Web/Configuration/Resources/processing.config.transform
+++ b/src/ImageProcessor.Web/Configuration/Resources/processing.config.transform
@@ -1,4 +1,4 @@
-<processing preserveExifMetaData="false" fixGamma="false" interceptAllRequests="false" allowCacheBuster="true">
+<processing preserveExifMetaData="false" metaDataMode="None" fixGamma="false" interceptAllRequests="false" allowCacheBuster="true">
   <presets>
   </presets>
   <plugins>

--- a/src/ImageProcessor.Web/HttpModules/ImageProcessingModule.cs
+++ b/src/ImageProcessor.Web/HttpModules/ImageProcessingModule.cs
@@ -85,6 +85,11 @@ namespace ImageProcessor.Web.HttpModules
         private static bool? preserveExifMetaData;
 
         /// <summary>
+        /// The meta data mode to use.
+        /// </summary>
+        private static MetaDataMode? metaDataMode;
+
+        /// <summary>
         /// Whether to perform gamma correction when performing processing.
         /// </summary>
         private static bool? fixGamma;
@@ -313,6 +318,11 @@ namespace ImageProcessor.Web.HttpModules
             if (preserveExifMetaData == null)
             {
                 preserveExifMetaData = ImageProcessorConfiguration.Instance.PreserveExifMetaData;
+            }
+
+            if (metaDataMode == null)
+            {
+                metaDataMode = ImageProcessorConfiguration.Instance.MetaDataMode;
             }
 
             if (allowCacheBuster == null)
@@ -614,9 +624,10 @@ namespace ImageProcessor.Web.HttpModules
                                 {
                                     // Process the image.
                                     bool exif = preserveExifMetaData != null && preserveExifMetaData.Value;
+                                    MetaDataMode metaMode = exif ? MetaDataMode.None : metaDataMode.Value;
                                     bool gamma = fixGamma != null && fixGamma.Value;
 
-                                    using (ImageFactory imageFactory = new ImageFactory(exif, gamma) { AnimationProcessMode = mode })
+                                    using (ImageFactory imageFactory = new ImageFactory(metaMode, gamma) { AnimationProcessMode = mode })
                                     {
                                         imageFactory.Load(inStream).AutoProcess(processors).Save(outStream);
                                         mimeType = imageFactory.CurrentImageFormat.MimeType;

--- a/src/ImageProcessor/ImageProcessor.csproj
+++ b/src/ImageProcessor/ImageProcessor.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-    <PropertyGroup>
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{3B5DD734-FB7A-487D-8CE6-55E7AF9AEA7E}</ProjectGuid>
@@ -106,6 +106,7 @@
     <Compile Include="Imaging\Helpers\ImageMaths.cs" />
     <Compile Include="Imaging\Helpers\PixelOperations.cs" />
     <Compile Include="Imaging\ImageLayer.cs" />
+    <Compile Include="Imaging\MetaData\ExifPropertyTagConstants.cs" />
     <Compile Include="Imaging\MetaData\Rational.cs" />
     <Compile Include="Imaging\MetaData\ExifBitConverter.cs" />
     <Compile Include="Imaging\MetaData\ImageFactoryMetaExtensions.cs" />
@@ -162,6 +163,7 @@
     <Compile Include="Imaging\Resizer.cs" />
     <Compile Include="Imaging\RoundedCornerLayer.cs" />
     <Compile Include="Imaging\TextLayer.cs" />
+    <Compile Include="MetaDataMode.cs" />
     <Compile Include="Processors\Background.cs" />
     <Compile Include="Processors\Resolution.cs" />
     <Compile Include="Processors\Gamma.cs" />

--- a/src/ImageProcessor/Imaging/MetaData/ExifPropertyTagConstants.cs
+++ b/src/ImageProcessor/Imaging/MetaData/ExifPropertyTagConstants.cs
@@ -1,0 +1,87 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="ExifPropertyTagConstants.cs" company="James Jackson-South">
+//   Copyright (c) James Jackson-South.
+//   Licensed under the Apache License, Version 2.0.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.Linq;
+
+namespace ImageProcessor.Imaging.MetaData
+{
+    /// <summary>
+    /// Contains constants grouping together common property items.
+    /// </summary>
+    public class ExifPropertyTagConstants
+    {
+        /// <summary>
+        /// Gets all required property items. The Gif format specifically requires these properties.
+        /// </summary>
+        public static readonly ExifPropertyTag[] RequiredPropertyItems = {
+            ExifPropertyTag.LoopCount, ExifPropertyTag.FrameDelay
+        };
+
+        /// <summary>
+        /// Gets all required property items plus geolocation specific property items. 
+        /// </summary>
+        public static readonly ExifPropertyTag[] GeolocationPropertyItems = RequiredPropertyItems.Union(new[]{
+            ExifPropertyTag.GpsAltitude,
+            ExifPropertyTag.GpsAltitudeRef,
+            ExifPropertyTag.GpsDestBear,
+            ExifPropertyTag.GpsDestBearRef,
+            ExifPropertyTag.GpsDestDist,
+            ExifPropertyTag.GpsDestDistRef,
+            ExifPropertyTag.GpsDestLat,
+            ExifPropertyTag.GpsDestLatRef,
+            ExifPropertyTag.GpsDestLong,
+            ExifPropertyTag.GpsDestLongRef,
+            ExifPropertyTag.GpsGpsDop,
+            ExifPropertyTag.GpsGpsMeasureMode,
+            ExifPropertyTag.GpsGpsSatellites,
+            ExifPropertyTag.GpsGpsStatus,
+            ExifPropertyTag.GpsGpsTime,
+            ExifPropertyTag.GpsIFD,
+            ExifPropertyTag.GpsImgDir,
+            ExifPropertyTag.GpsImgDirRef,
+            ExifPropertyTag.GpsLatitude,
+            ExifPropertyTag.GpsLatitudeRef,
+            ExifPropertyTag.GpsLongitude,
+            ExifPropertyTag.GpsLongitudeRef,
+            ExifPropertyTag.GpsMapDatum,
+            ExifPropertyTag.GpsSpeed,
+            ExifPropertyTag.GpsSpeedRef,
+            ExifPropertyTag.GpsTrack,
+            ExifPropertyTag.GpsTrackRef,
+            ExifPropertyTag.GpsVer
+        }).ToArray();
+
+        /// <summary>
+        /// Gets all required property items plus copyright and geolocation specific property items. 
+        /// </summary>
+        public static readonly ExifPropertyTag[] CopyrightPropertyItems = RequiredPropertyItems.Union(new[]{
+            ExifPropertyTag.Copyright,
+            ExifPropertyTag.Artist,
+            ExifPropertyTag.ImageTitle,
+            ExifPropertyTag.ImageDescription,
+            ExifPropertyTag.ExifUserComment,
+            ExifPropertyTag.EquipMake,
+            ExifPropertyTag.EquipModel,
+            ExifPropertyTag.ThumbnailArtist,
+            ExifPropertyTag.ThumbnailCopyRight,
+            ExifPropertyTag.ThumbnailImageDescription,
+            ExifPropertyTag.ThumbnailEquipMake,
+            ExifPropertyTag.ThumbnailEquipModel,
+        }).ToArray();
+
+        /// <summary>
+        /// Gets all required property items plus copyright and geolocation specific property items. 
+        /// </summary>
+        public static readonly ExifPropertyTag[] CopyrightAndGeolocationPropertyItems = GeolocationPropertyItems.Union(CopyrightPropertyItems).ToArray();
+
+        /// <summary>
+        /// Gets all known property items
+        /// </summary>
+        public static readonly ExifPropertyTag[] All = (ExifPropertyTag[])Enum.GetValues(typeof(ExifPropertyTag));
+    }
+}

--- a/src/ImageProcessor/Imaging/MetaData/ExifPropertyTagConstants.cs
+++ b/src/ImageProcessor/Imaging/MetaData/ExifPropertyTagConstants.cs
@@ -57,7 +57,7 @@ namespace ImageProcessor.Imaging.MetaData
         }).ToArray();
 
         /// <summary>
-        /// Gets all required property items plus copyright and geolocation specific property items. 
+        /// Gets all required property items plus copyright specific property items. 
         /// </summary>
         public static readonly ExifPropertyTag[] CopyrightPropertyItems = RequiredPropertyItems.Union(new[]{
             ExifPropertyTag.Copyright,

--- a/src/ImageProcessor/MetaDataMode.cs
+++ b/src/ImageProcessor/MetaDataMode.cs
@@ -1,0 +1,40 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="MetaDataMode.cs" company="James Jackson-South">
+//   Copyright (c) James Jackson-South.
+//   Licensed under the Apache License, Version 2.0.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace ImageProcessor
+{
+    /// <summary>
+    /// Enumerates the various metadata modes that control how much metadata information is stored on processing
+    /// </summary>
+    public enum MetaDataMode
+    {
+        /// <summary>
+        /// Store no metadata on processing
+        /// </summary>
+        None,
+
+        /// <summary>
+        /// Store copyright specific metadata on processing
+        /// </summary>
+        Copyright,
+
+        /// <summary>
+        /// Store geolocation specific metadata on processing
+        /// </summary>
+        Geolocation,
+
+        /// <summary>
+        /// Store copyright and geolocation specific metadata on processing
+        /// </summary>
+        CopyrightAndGeolocation,
+
+        /// <summary>
+        /// Store all metadata on processing
+        /// </summary>
+        All
+    }
+}

--- a/tests/ImageProcessor.Playground/Program.cs
+++ b/tests/ImageProcessor.Playground/Program.cs
@@ -67,7 +67,7 @@ namespace ImageProcessor.PlayGround
                     stopwatch.Start();
 
                     using (MemoryStream inStream = new MemoryStream(photoBytes))
-                    using (ImageFactory imageFactory = new ImageFactory() { AnimationProcessMode = AnimationProcessMode.All })
+                    using (ImageFactory imageFactory = new ImageFactory(MetaDataMode.CopyrightAndGeolocation) { AnimationProcessMode = AnimationProcessMode.All })
                     {
                         try
                         {

--- a/tests/ImageProcessor.TestWebsite/config/imageprocessor/processing.config
+++ b/tests/ImageProcessor.TestWebsite/config/imageprocessor/processing.config
@@ -1,4 +1,4 @@
-﻿<processing preserveExifMetaData="false" fixGamma="false" interceptAllRequests="true" allowCacheBuster="true">
+﻿<processing preserveExifMetaData="true" metaDataMode="Copyright" fixGamma="false" interceptAllRequests="true" allowCacheBuster="true">
   <presets>
   </presets>
   <plugins>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/JimBobSquarePants/ImageProcessor/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practise as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
Adds a new overload to `ImageFactory` that accept the `MetaDataMode` enum.

- None
- Copyright
- Geolocation
- CopyrightAndGeolocation
- All

Additionally the Web module `processing.config` now accepts a new optional property `metaDataMode` which when used in conjunction with the existing `preserveExifMetaData` property allows more fine grained control over what properties to preserve.

e.g
``` xml
<processing preserveExifMetaData="true" metaDataMode="Copyright" fixGamma="false" interceptAllRequests="true" allowCacheBuster="true">
```

All this is done in a fully backwards-compatible manner with both properties optional. 

@hartvig @Jeavon @drobar @PeteDuncanson @Matthew-Wise Please comment below with your thoughts. 

I think I've done enough to cover the basic requirements.
I don't want to add extreme customization as that allows the possibility for users to break things as `System.Drawing`s property items contain items other than EXIF metadata.

I'll do a PR to Umbraco to update version and config once this is merged and published.

<!-- Thanks for contributing to ImageProcessor! -->
