### PR TITLE
fix Hue when not rotating

### DIFF
--- a/src/ImageProcessor/ImageFactory.cs
+++ b/src/ImageProcessor/ImageFactory.cs
@@ -1013,7 +1013,7 @@ namespace ImageProcessor
         public ImageFactory Hue(int degrees, bool rotate = false)
         {
             // Sanitize the input.
-            if (degrees > 360 || degrees < 0 || degrees == 0)
+            if (degrees > 360 || degrees < 0 || (degrees == 0 && rotate))
             {
                 return this;
             }

--- a/src/ImageProcessor/Processors/Hue.cs
+++ b/src/ImageProcessor/Processors/Hue.cs
@@ -58,13 +58,13 @@ namespace ImageProcessor.Processors
             {
                 Tuple<int, bool> parameters = this.DynamicParameter;
                 int degrees = parameters.Item1;
+                bool rotate = parameters.Item2;
 
-                if (degrees == 0)
+                if (degrees == 0 && rotate)
                 {
                     return image;
                 }
 
-                bool rotate = parameters.Item2;
                 int width = image.Width;
                 int height = image.Height;
                 using (FastBitmap fastBitmap = new FastBitmap(image))


### PR DESCRIPTION
If rotate is false it is not possible to set a hue of 0 as the function will return immediately.
This change will add a check if rotate is true and return only if so.

Fixes #665 