### PR TITLE
#669 - metadata stripped after image processed 

### DIFF
--- a/src/ImageProcessor.Web/HttpModules/ImageProcessingModule.cs
+++ b/src/ImageProcessor.Web/HttpModules/ImageProcessingModule.cs
@@ -624,7 +624,7 @@ namespace ImageProcessor.Web.HttpModules
                                 {
                                     // Process the image.
                                     bool exif = preserveExifMetaData != null && preserveExifMetaData.Value;
-                                    MetaDataMode metaMode = exif ? MetaDataMode.None : metaDataMode.Value;
+                                    MetaDataMode metaMode = !exif ? MetaDataMode.None : metaDataMode.Value;
                                     bool gamma = fixGamma != null && fixGamma.Value;
 
                                     using (ImageFactory imageFactory = new ImageFactory(metaMode, gamma) { AnimationProcessMode = mode })


### PR DESCRIPTION
ImageProessor.Web 4.9.2.19 whereby wrong MetaDataMode was being added in call to ImageFactory.

Reported in issue #669 
