### PR TITLE
Cleanup + fixes

### DIFF
--- a/src/ImageProcessor.Plugins.WebP/Imaging/Formats/NativeMethods.cs
+++ b/src/ImageProcessor.Plugins.WebP/Imaging/Formats/NativeMethods.cs
@@ -31,7 +31,7 @@ namespace ImageProcessor.Plugins.WebP.Imaging.Formats
             string name = string.Format("ImageProcessor.Plugins.WebP.Resources.Unmanaged.{0}.libwebp.dll", folder);
             using (Stream stream = Assembly.GetExecutingAssembly().GetManifestResourceStream(name))
             {
-                using (MemoryStream memoryStream = new MemoryStream())
+                using (var memoryStream = new MemoryStream())
                 {
                     if (stream != null)
                     {
@@ -42,7 +42,6 @@ namespace ImageProcessor.Plugins.WebP.Imaging.Formats
             }
         }
 
-        #region WebP
         /// <summary>
         /// Validate the WebP image header and retrieve the image height and width. Pointers *width and *height can be passed NULL if deemed irrelevant
         /// </summary>
@@ -150,6 +149,5 @@ namespace ImageProcessor.Plugins.WebP.Imaging.Formats
         /// </returns>
         [DllImport("libwebp", CallingConvention = CallingConvention.Cdecl, EntryPoint = "WebPFree")]
         public static extern int WebPFree(IntPtr pointer);
-        #endregion
     }
 }

--- a/src/ImageProcessor.Plugins.WebP/Imaging/Formats/WebPFormat.cs
+++ b/src/ImageProcessor.Plugins.WebP/Imaging/Formats/WebPFormat.cs
@@ -105,13 +105,11 @@ namespace ImageProcessor.Plugins.WebP.Imaging.Formats
         /// </returns>
         public override Image Save(Stream stream, Image image, long bitDepth)
         {
-            byte[] bytes;
-
             // Encode in webP format.
             // If Quality is 100, encode losslessly instead of lossily
-            if (this.Quality == 100 ? EncodeLosslessly((Bitmap)image, out bytes) : EncodeLossly((Bitmap)image, this.Quality, out bytes))
+            if (this.Quality == 100 ? EncodeLosslessly((Bitmap)image, out byte[] bytes) : EncodeLossly((Bitmap)image, this.Quality, out bytes))
             {
-                using (MemoryStream memoryStream = new MemoryStream(bytes))
+                using (var memoryStream = new MemoryStream(bytes))
                 {
                     memoryStream.CopyTo(stream);
                     memoryStream.Position = stream.Position = 0;
@@ -140,11 +138,9 @@ namespace ImageProcessor.Plugins.WebP.Imaging.Formats
         /// </returns>
         public override Image Save(string path, Image image, long bitDepth)
         {
-            byte[] bytes;
-
             // Encode in webP format.
             // If Quality is 100, encode losslessly instead of lossily
-            if (this.Quality == 100 ? EncodeLosslessly((Bitmap)image, out bytes) : EncodeLossly((Bitmap)image, this.Quality, out bytes))
+            if (this.Quality == 100 ? EncodeLosslessly((Bitmap)image, out byte[] bytes) : EncodeLossly((Bitmap)image, this.Quality, out bytes))
             {
                 File.WriteAllBytes(path, bytes);
             }
@@ -162,17 +158,15 @@ namespace ImageProcessor.Plugins.WebP.Imaging.Formats
         private static Bitmap Decode(byte[] webpData)
         {
             // Get the image width and height
-            GCHandle pinnedWebP = GCHandle.Alloc(webpData, GCHandleType.Pinned);
+            var pinnedWebP = GCHandle.Alloc(webpData, GCHandleType.Pinned);
             IntPtr ptrData = pinnedWebP.AddrOfPinnedObject();
             uint dataSize = (uint)webpData.Length;
 
             Bitmap bitmap = null;
             BitmapData bitmapData = null;
             IntPtr outputBuffer = IntPtr.Zero;
-            int width;
-            int height;
 
-            if (NativeMethods.WebPGetInfo(ptrData, dataSize, out width, out height) != 1)
+            if (NativeMethods.WebPGetInfo(ptrData, dataSize, out int width, out int height) != 1)
             {
                 throw new ImageFormatException("WebP image header is corrupted.");
             }

--- a/src/ImageProcessor.Web.Plugins.AzureBlobCache/AzureBlobCache.cs
+++ b/src/ImageProcessor.Web.Plugins.AzureBlobCache/AzureBlobCache.cs
@@ -97,7 +97,7 @@ namespace ImageProcessor.Web.Plugins.AzureBlobCache
             if (cloudCachedBlobClient == null)
             {
                 // Retrieve storage accounts from connection string.
-                CloudStorageAccount cloudCachedStorageAccount = CloudStorageAccount.Parse(this.Settings["CachedStorageAccount"]);
+                var cloudCachedStorageAccount = CloudStorageAccount.Parse(this.Settings["CachedStorageAccount"]);
 
                 // Create the blob clients.
                 cloudCachedBlobClient = cloudCachedStorageAccount.CreateCloudBlobClient();
@@ -118,7 +118,7 @@ namespace ImageProcessor.Web.Plugins.AzureBlobCache
                 // Repeat for source if it exists
                 if (!string.IsNullOrWhiteSpace(sourceAccount))
                 {
-                    CloudStorageAccount cloudSourceStorageAccount = CloudStorageAccount.Parse(this.Settings["SourceStorageAccount"]);
+                    var cloudSourceStorageAccount = CloudStorageAccount.Parse(this.Settings["SourceStorageAccount"]);
                     CloudBlobClient cloudSourceBlobClient = cloudSourceStorageAccount.CreateCloudBlobClient();
                     cloudSourceBlobContainer = cloudSourceBlobClient.GetContainerReference(this.Settings["SourceBlobContainer"]);
                 }
@@ -130,15 +130,14 @@ namespace ImageProcessor.Web.Plugins.AzureBlobCache
 
             if (this.Settings.ContainsKey("CachedCDNTimeout"))
             {
-                int t;
-                int.TryParse(this.Settings["CachedCDNTimeout"], out t);
+                int.TryParse(this.Settings["CachedCDNTimeout"], out int t);
                 this.timeout = t;
             }
 
             // This setting was added to facilitate streaming of the blob resource directly instead of a redirect. This is beneficial for CDN purposes
             // but caution should be taken if not used with a CDN as it will add quite a bit of overhead to the site.
             // See: https://github.com/JimBobSquarePants/ImageProcessor/issues/161
-            this.streamCachedImage = this.Settings.ContainsKey("StreamCachedImage") && this.Settings["StreamCachedImage"].ToLower() == "true";
+            this.streamCachedImage = this.Settings.ContainsKey("StreamCachedImage") && string.Equals(this.Settings["StreamCachedImage"], "true", StringComparison.OrdinalIgnoreCase);
         }
 
         /// <summary>
@@ -152,11 +151,11 @@ namespace ImageProcessor.Web.Plugins.AzureBlobCache
             // TODO: Before this check is performed it should be throttled. For example, only perform this check
             // if the last time it was checked is greater than 5 seconds. This would be much better for perf
             // if there is a high throughput of image requests.
-            string cachedFileName = await this.CreateCachedFileNameAsync();
+            string cachedFileName = await this.CreateCachedFileNameAsync().ConfigureAwait(false);
             this.CachedPath = CachedImageHelper.GetCachedPath(cloudCachedBlobContainer.Uri.ToString(), cachedFileName, true, this.FolderDepth);
 
             // Do we insert the cache container? This seems to break some setups.
-            bool useCachedContainerInUrl = this.Settings.ContainsKey("UseCachedContainerInUrl") && this.Settings["UseCachedContainerInUrl"].ToLower() != "false";
+            bool useCachedContainerInUrl = this.Settings.ContainsKey("UseCachedContainerInUrl") && !string.Equals(this.Settings["UseCachedContainerInUrl"], "false", StringComparison.OrdinalIgnoreCase);
 
             this.cachedRewritePath = CachedImageHelper.GetCachedPath(useCachedContainerInUrl ? Path.Combine(this.cachedCdnRoot, cloudCachedBlobContainer.Name) : this.cachedCdnRoot, cachedFileName, true, this.FolderDepth);
 
@@ -183,10 +182,10 @@ namespace ImageProcessor.Web.Plugins.AzureBlobCache
                 string blobPath = this.CachedPath.Substring(cloudCachedBlobContainer.Uri.ToString().Length + 1);
                 CloudBlockBlob blockBlob = cloudCachedBlobContainer.GetBlockBlobReference(blobPath);
 
-                if (await blockBlob.ExistsAsync())
+                if (await blockBlob.ExistsAsync().ConfigureAwait(false))
                 {
                     // Pull the latest info.
-                    await blockBlob.FetchAttributesAsync();
+                    await blockBlob.FetchAttributesAsync().ConfigureAwait(false);
 
                     if (blockBlob.Properties.LastModified.HasValue)
                     {
@@ -211,7 +210,7 @@ namespace ImageProcessor.Web.Plugins.AzureBlobCache
             {
                 // Check to see if the cached image is set to expire
                 // or a new file with the same name has replaced our current image
-                if (this.IsExpired(cachedImage.CreationTimeUtc) || await this.IsUpdatedAsync(cachedImage.CreationTimeUtc))
+                if (this.IsExpired(cachedImage.CreationTimeUtc) || await this.IsUpdatedAsync(cachedImage.CreationTimeUtc).ConfigureAwait(false))
                 {
                     CacheIndexer.Remove(this.CachedPath);
                     isUpdated = true;
@@ -238,14 +237,14 @@ namespace ImageProcessor.Web.Plugins.AzureBlobCache
             string blobPath = this.CachedPath.Substring(cloudCachedBlobContainer.Uri.ToString().Length + 1);
             CloudBlockBlob blockBlob = cloudCachedBlobContainer.GetBlockBlobReference(blobPath);
 
-            await blockBlob.UploadFromStreamAsync(stream);
+            await blockBlob.UploadFromStreamAsync(stream).ConfigureAwait(false);
 
             blockBlob.Properties.ContentType = contentType;
             blockBlob.Properties.CacheControl = $"public, max-age={this.BrowserMaxDays * 86400}";
-            await blockBlob.SetPropertiesAsync();
+            await blockBlob.SetPropertiesAsync().ConfigureAwait(false);
 
             blockBlob.Metadata.Add("ImageProcessedBy", "ImageProcessor.Web/" + AssemblyVersion);
-            await blockBlob.SetMetadataAsync();
+            await blockBlob.SetMetadataAsync().ConfigureAwait(false);
         }
 
         /// <summary>
@@ -268,28 +267,27 @@ namespace ImageProcessor.Web.Plugins.AzureBlobCache
 
                 if (this.FolderDepth > 0)
                 {
-                    Uri uri = new Uri(this.CachedPath);
+                    var uri = new Uri(this.CachedPath);
                     string path = uri.GetLeftPart(UriPartial.Path).Substring(cloudCachedBlobContainer.Uri.ToString().Length + 1);
                     parent = path.Substring(0, 2);
                 }
 
                 BlobContinuationToken continuationToken = null;
-                List<IListBlobItem> results = new List<IListBlobItem>();
+                var results = new List<IListBlobItem>();
 
                 // Loop through the all the files in a non blocking fashion.
                 do
                 {
-                    BlobResultSegment response = await cloudCachedBlobContainer.ListBlobsSegmentedAsync(parent, true, BlobListingDetails.Metadata, 5000, continuationToken, null, null, token);
+                    BlobResultSegment response = await cloudCachedBlobContainer.ListBlobsSegmentedAsync(parent, true, BlobListingDetails.Metadata, 5000, continuationToken, null, null, token).ConfigureAwait(false);
                     continuationToken = response.ContinuationToken;
                     results.AddRange(response.Results);
                 }
-                while (token.IsCancellationRequested == false && continuationToken != null);
+                while (!token.IsCancellationRequested && continuationToken != null);
 
                 // Now leap through and delete.
                 foreach (
                     CloudBlockBlob blob in
-                    results.Where((blobItem, type) => blobItem is CloudBlockBlob)
-                           .Cast<CloudBlockBlob>()
+                    results.OfType<CloudBlockBlob>()
                            .OrderBy(b => b.Properties.LastModified?.UtcDateTime ?? new DateTime()))
                 {
                     if (token.IsCancellationRequested || (blob.Properties.LastModified.HasValue && !this.IsExpired(blob.Properties.LastModified.Value.UtcDateTime)))
@@ -299,7 +297,7 @@ namespace ImageProcessor.Web.Plugins.AzureBlobCache
 
                     // Remove from the cache and delete each CachedImage.
                     CacheIndexer.Remove(blob.Name);
-                    await blob.DeleteAsync(token);
+                    await blob.DeleteAsync(token).ConfigureAwait(false);
                 }
             });
 
@@ -314,7 +312,7 @@ namespace ImageProcessor.Web.Plugins.AzureBlobCache
         /// </param>
         public override void RewritePath(HttpContext context)
         {
-            HttpWebRequest request = (HttpWebRequest)WebRequest.Create(this.cachedRewritePath);
+            var request = (HttpWebRequest)WebRequest.Create(this.cachedRewritePath);
 
             if (this.streamCachedImage)
             {
@@ -474,10 +472,10 @@ namespace ImageProcessor.Web.Plugins.AzureBlobCache
                     blobPath = blobPath.Replace(container, string.Empty).TrimStart('/');
                     CloudBlockBlob blockBlob = cloudSourceBlobContainer.GetBlockBlobReference(blobPath);
 
-                    if (await blockBlob.ExistsAsync())
+                    if (await blockBlob.ExistsAsync().ConfigureAwait(false))
                     {
                         // Pull the latest info.
-                        await blockBlob.FetchAttributesAsync();
+                        await blockBlob.FetchAttributesAsync().ConfigureAwait(false);
 
                         if (blockBlob.Properties.LastModified.HasValue)
                         {
@@ -488,10 +486,10 @@ namespace ImageProcessor.Web.Plugins.AzureBlobCache
                 else
                 {
                     // Try and get the headers for the file, this should allow cache busting for remote files.
-                    HttpWebRequest request = (HttpWebRequest)WebRequest.Create(this.RequestPath);
+                    var request = (HttpWebRequest)WebRequest.Create(this.RequestPath);
                     request.Method = "HEAD";
 
-                    using (HttpWebResponse response = (HttpWebResponse)await request.GetResponseAsync())
+                    using (var response = (HttpWebResponse)await request.GetResponseAsync().ConfigureAwait(false))
                     {
                         isUpdated = response.LastModified.ToUniversalTime() > creationDate;
                     }
@@ -514,17 +512,15 @@ namespace ImageProcessor.Web.Plugins.AzureBlobCache
         /// <param name="request">The current request</param>
         private static void TrySetIfModifiedSinceDate(HttpContext context, HttpWebRequest request)
         {
-            DateTime ifModifiedDate;
-
             string ifModifiedFromRequest = context.Request.Headers["If-Modified-Since"];
 
-            if (DateTime.TryParse(ifModifiedFromRequest, out ifModifiedDate))
+            if (DateTime.TryParse(ifModifiedFromRequest, out DateTime ifModifiedDate))
             {
                 request.IfModifiedSince = ifModifiedDate;
             }
             else
             {
-                if (ifModifiedFromRequest.ToLower().Contains("utc"))
+                if (ifModifiedFromRequest.IndexOf("utc", StringComparison.OrdinalIgnoreCase) >= 0)
                 {
                     ifModifiedFromRequest = ifModifiedFromRequest.ToLower().Replace("utc", string.Empty);
 

--- a/src/ImageProcessor.Web/Caching/AsyncKeyLock.cs
+++ b/src/ImageProcessor.Web/Caching/AsyncKeyLock.cs
@@ -78,10 +78,7 @@ namespace ImageProcessor.Web.Caching
             /// Initializes a new instance of the <see cref="Releaser"/> class.
             /// </summary>
             /// <param name="key">The key identifying the doorman that limits the number of threads.</param>
-            public Releaser(string key)
-            {
-                this.key = key;
-            }
+            public Releaser(string key) => this.key = key;
 
             /// <inheritdoc />
             public void Dispose()

--- a/src/ImageProcessor.Web/Caching/CacheIndexer.cs
+++ b/src/ImageProcessor.Web/Caching/CacheIndexer.cs
@@ -35,8 +35,7 @@ namespace ImageProcessor.Web.Caching
         public static CachedImage Get(string cachedPath)
         {
             string key = Path.GetFileNameWithoutExtension(cachedPath);
-            CachedImage cachedImage = (CachedImage)MemCache.GetItem(key);
-            return cachedImage;
+            return (CachedImage)MemCache.GetItem(key);
         }
 
         /// <summary>
@@ -73,7 +72,7 @@ namespace ImageProcessor.Web.Caching
             { expiration = new TimeSpan(0, 1, 0); }
 
             // Add the CachedImage with a sliding expiration of `expiry` minutes.
-            CacheItemPolicy policy = new CacheItemPolicy { SlidingExpiration = expiration };
+            var policy = new CacheItemPolicy { SlidingExpiration = expiration };
 
             if (new Uri(cachedImage.Path).IsFile)
             {
@@ -120,9 +119,6 @@ namespace ImageProcessor.Web.Caching
         /// <returns>
         /// The value of the item to add or get.
         /// </returns>
-        public static CachedImage Add(CachedImage cachedImage, int expiry)
-        {
-            return Add(cachedImage, new TimeSpan(0, expiry, 0));
-        }
+        public static CachedImage Add(CachedImage cachedImage, int expiry) => Add(cachedImage, new TimeSpan(0, expiry, 0));
     }
 }

--- a/src/ImageProcessor.Web/Caching/ImageCacheBase.cs
+++ b/src/ImageProcessor.Web/Caching/ImageCacheBase.cs
@@ -152,10 +152,7 @@ namespace ImageProcessor.Web.Caching
         /// <returns>
         /// The asynchronous <see cref="Task"/> returning the value.
         /// </returns>
-        public virtual async Task<string> CreateCachedFileNameAsync()
-        {
-            return await Task.FromResult(CachedImageHelper.GetCachedImageFileName(this.FullPath, this.Querystring)).ConfigureAwait(false);
-        }
+        public virtual Task<string> CreateCachedFileNameAsync() => Task.FromResult(CachedImageHelper.GetCachedImageFileName(this.FullPath, this.Querystring));
 
         /// <summary>
         /// Rewrites the path to point to the cached image.
@@ -173,10 +170,7 @@ namespace ImageProcessor.Web.Caching
         /// <returns>
         /// The true if the date is out with the limit, otherwise; false.
         /// </returns>
-        protected virtual bool IsExpired(DateTime creationDate)
-        {
-            return creationDate < DateTime.UtcNow.AddDays(-this.MaxDays);
-        }
+        protected virtual bool IsExpired(DateTime creationDate) => creationDate < DateTime.UtcNow.AddDays(-this.MaxDays);
 
         /// <summary>
         /// Provides a means to augment the cache settings taken from the configuration in derived classes.
@@ -198,7 +192,7 @@ namespace ImageProcessor.Web.Caching
         protected virtual Task DebounceTrimmerAsync(Func<Task> trimmer)
         {
             // Wrap new method
-            this.ScheduleCacheTrimmer(token => trimmer());
+            this.ScheduleCacheTrimmer(_ => trimmer());
             return Task.FromResult(0);
         }
 
@@ -207,10 +201,7 @@ namespace ImageProcessor.Web.Caching
         /// and that it is a quiet time to do so.
         /// </summary>
         /// <param name="trimmer">The cache trimming method.</param>
-        protected void ScheduleCacheTrimmer(Func<CancellationToken, Task> trimmer)
-        {
-            Trimmer.ScheduleTrimCache(trimmer);
-        }
+        protected void ScheduleCacheTrimmer(Func<CancellationToken, Task> trimmer) => Trimmer.ScheduleTrimCache(trimmer);
 
         /// <summary>
         /// Provides an entry point to augmentation of the <see cref="Settings"/> dictionary
@@ -261,10 +252,7 @@ namespace ImageProcessor.Web.Caching
             /// <summary>
             /// Initializes a new instance of the <see cref="CacheTrimmer"/> class.
             /// </summary>
-            public CacheTrimmer()
-            {
-                HostingEnvironment.RegisterObject(this);
-            }
+            public CacheTrimmer() => HostingEnvironment.RegisterObject(this);
 
             /// <summary>
             /// The sliding delay time
@@ -305,8 +293,8 @@ namespace ImageProcessor.Web.Caching
                         }
                         else if (
                             // Must be less than the max and less than the delay
-                            DateTime.Now - this.timestamp < TimeSpan.FromMilliseconds(MaxWaitMilliseconds) &&
-                            DateTime.Now - this.timestamp < TimeSpan.FromMilliseconds(WaitMilliseconds))
+                            DateTime.Now - this.timestamp < TimeSpan.FromMilliseconds(MaxWaitMilliseconds)
+                            && DateTime.Now - this.timestamp < TimeSpan.FromMilliseconds(WaitMilliseconds))
                         {
                             // Delay
                             this.timer.Change(WaitMilliseconds, 0);

--- a/src/ImageProcessor.Web/Caching/MemCache.cs
+++ b/src/ImageProcessor.Web/Caching/MemCache.cs
@@ -41,12 +41,8 @@ namespace ImageProcessor.Web.Caching
         /// <summary>
         /// Adds an item to the cache.
         /// </summary>
-        /// <param name="key">
-        /// A unique identifier for the cache entry.
-        /// </param>
-        /// <param name="value">
-        /// The object to insert.
-        /// </param>
+        /// <param name="key">A unique identifier for the cache entry.</param>
+        /// <param name="value">The object to insert.</param>
         /// <param name="policy">
         /// Optional. An <see cref="T:System.Runtime.Caching.CacheItemPolicy"/> object that contains eviction details for the cache entry. This object
         /// provides more options for eviction than a simple absolute expiration. The default value for the optional parameter
@@ -94,9 +90,7 @@ namespace ImageProcessor.Web.Caching
         /// <summary>
         /// Fetches an item matching the given key from the cache.
         /// </summary>
-        /// <param name="key">
-        /// A unique identifier for the cache entry.
-        /// </param>
+        /// <param name="key">A unique identifier for the cache entry.</param>
         /// <param name="regionName">
         /// Optional. A named region in the cache to which the cache entry can be added,
         /// if regions are implemented. The default value for the optional parameter
@@ -116,12 +110,8 @@ namespace ImageProcessor.Web.Caching
         /// <summary>
         /// Updates an item to the cache.
         /// </summary>
-        /// <param name="key">
-        /// A unique identifier for the cache entry.
-        /// </param>
-        /// <param name="value">
-        /// The object to insert.
-        /// </param>
+        /// <param name="key">A unique identifier for the cache entry.</param>
+        /// <param name="value">The object to insert.</param>
         /// <param name="policy">
         /// Optional. An <see cref="T:System.Runtime.Caching.CacheItemPolicy"/> object that contains eviction details for the cache entry. This object
         /// provides more options for eviction than a simple absolute expiration. The default value for the optional parameter
@@ -164,9 +154,7 @@ namespace ImageProcessor.Web.Caching
         /// <summary>
         /// Removes an item matching the given key from the cache.
         /// </summary>
-        /// <param name="key">
-        /// A unique identifier for the cache entry.
-        /// </param>
+        /// <param name="key">A unique identifier for the cache entry.</param>
         /// <param name="regionName">
         /// Optional. A named region in the cache to which the cache entry can be added,
         /// if regions are implemented. The default value for the optional parameter
@@ -186,8 +174,7 @@ namespace ImageProcessor.Web.Caching
 
                 if (isRemoved)
                 {
-                    string removedValue;
-                    CacheItems.TryRemove(key, out removedValue);
+                    CacheItems.TryRemove(key, out string removedValue);
                 }
             }
 
@@ -197,9 +184,7 @@ namespace ImageProcessor.Web.Caching
         /// <summary>
         /// Clears the cache.
         /// </summary>
-        /// <param name="regionName">
-        /// The region name.
-        /// </param>
+        /// <param name="regionName">The region name.</param>
         /// <returns>
         /// The <see cref="bool"/>.
         /// </returns>
@@ -211,20 +196,19 @@ namespace ImageProcessor.Web.Caching
             {
                 // You can't remove items from a collection whilst you are iterating over it so you need to
                 // create a collection to store the items to remove.
-                Dictionary<string, string> tempDictionary = new Dictionary<string, string>();
+                var tempDictionary = new Dictionary<string, string>();
 
                 foreach (KeyValuePair<string, string> cacheItem in CacheItems)
                 {
                     // Does the cached key come with a region.
-                    if ((cacheItem.Value == null) || (cacheItem.Value != null && cacheItem.Value.Equals(regionName, StringComparison.OrdinalIgnoreCase)))
+                    if ((cacheItem.Value == null) || (cacheItem.Value?.Equals(regionName, StringComparison.OrdinalIgnoreCase) == true))
                     {
                         isCleared = RemoveItem(cacheItem.Key, cacheItem.Value);
 
                         if (isCleared)
                         {
                             string key = cacheItem.Key;
-                            string value = cacheItem.Value;
-                            tempDictionary[key] = value;
+                            tempDictionary[key] = cacheItem.Value;
                         }
                     }
                 }
@@ -234,8 +218,7 @@ namespace ImageProcessor.Web.Caching
                     // Loop through and clear out the dictionary of cache keys.
                     foreach (KeyValuePair<string, string> cacheItem in tempDictionary)
                     {
-                        string removedValue;
-                        CacheItems.TryRemove(cacheItem.Key, out removedValue);
+                        CacheItems.TryRemove(cacheItem.Key, out string removedValue);
                     }
                 }
             }

--- a/src/ImageProcessor.Web/Configuration/ImageCacheSection.cs
+++ b/src/ImageProcessor.Web/Configuration/ImageCacheSection.cs
@@ -112,7 +112,7 @@ namespace ImageProcessor.Web.Configuration
 
                 set => this["maxDays"] = value;
             }
-            
+
             /// <summary>
             /// Gets or sets the maximum number of minutes to store a cached image reference in memory.
             /// </summary>
@@ -271,10 +271,7 @@ namespace ImageProcessor.Web.Configuration
             /// <returns>
             /// A new <see cref="ConfigurationElement"/>.
             /// </returns>
-            protected override ConfigurationElement CreateNewElement()
-            {
-                return new CacheElement();
-            }
+            protected override ConfigurationElement CreateNewElement() => new CacheElement();
 
             /// <summary>
             /// Gets the element key for a specified configuration element when overridden in a derived class.
@@ -283,10 +280,7 @@ namespace ImageProcessor.Web.Configuration
             /// An <see cref="T:System.Object"/> that acts as the key for the specified <see cref="ConfigurationElement"/>.
             /// </returns>
             /// <param name="element">The <see cref="ConfigurationElement"/> to return the key for. </param>
-            protected override object GetElementKey(ConfigurationElement element)
-            {
-                return ((CacheElement)element).Name;
-            }
+            protected override object GetElementKey(ConfigurationElement element) => ((CacheElement)element).Name;
         }
     }
 }

--- a/src/ImageProcessor.Web/Configuration/ImageProcessingSection.cs
+++ b/src/ImageProcessor.Web/Configuration/ImageProcessingSection.cs
@@ -99,10 +99,7 @@ namespace ImageProcessor.Web.Configuration
         /// <returns>The processing configuration section from the current application configuration. </returns>
         public static ImageProcessingSection GetConfiguration()
         {
-            ImageProcessingSection imageProcessingSection =
-                ConfigurationManager.GetSection("imageProcessor/processing") as ImageProcessingSection;
-
-            if (imageProcessingSection != null)
+            if (ConfigurationManager.GetSection("imageProcessor/processing") is ImageProcessingSection imageProcessingSection)
             {
                 return imageProcessingSection;
             }
@@ -182,7 +179,7 @@ namespace ImageProcessor.Web.Configuration
             /// </returns>
             public PresetElement this[int index]
             {
-                get => (PresetElement)BaseGet(index);
+                get => (PresetElement)this.BaseGet(index);
 
                 set
                 {
@@ -201,10 +198,7 @@ namespace ImageProcessor.Web.Configuration
             /// <returns>
             /// A new PluginConfig configuration element.
             /// </returns>
-            protected override ConfigurationElement CreateNewElement()
-            {
-                return new PresetElement();
-            }
+            protected override ConfigurationElement CreateNewElement() => new PresetElement();
 
             /// <summary>
             /// Gets the element key for a specified PluginElement configuration element.
@@ -216,10 +210,7 @@ namespace ImageProcessor.Web.Configuration
             /// <returns>
             /// The element key for a specified PluginElement configuration element.
             /// </returns>
-            protected override object GetElementKey(ConfigurationElement element)
-            {
-                return ((PresetElement)element).Name;
-            }
+            protected override object GetElementKey(ConfigurationElement element) => ((PresetElement)element).Name;
         }
 
         /// <summary>
@@ -304,7 +295,7 @@ namespace ImageProcessor.Web.Configuration
             /// </returns>
             public PluginElement this[int index]
             {
-                get => (PluginElement)BaseGet(index);
+                get => (PluginElement)this.BaseGet(index);
 
                 set
                 {
@@ -323,10 +314,7 @@ namespace ImageProcessor.Web.Configuration
             /// <returns>
             /// A new Plugin configuration element.
             /// </returns>
-            protected override ConfigurationElement CreateNewElement()
-            {
-                return new PluginElement();
-            }
+            protected override ConfigurationElement CreateNewElement() => new PluginElement();
 
             /// <summary>
             /// Gets the element key for a specified PluginElement configuration element.
@@ -338,10 +326,7 @@ namespace ImageProcessor.Web.Configuration
             /// <returns>
             /// The element key for a specified PluginElement configuration element.
             /// </returns>
-            protected override object GetElementKey(ConfigurationElement element)
-            {
-                return ((PluginElement)element).Name;
-            }
+            protected override object GetElementKey(ConfigurationElement element) => ((PluginElement)element).Name;
         }
     }
 }

--- a/src/ImageProcessor.Web/Configuration/ImageProcessorConfiguration.cs
+++ b/src/ImageProcessor.Web/Configuration/ImageProcessorConfiguration.cs
@@ -27,7 +27,6 @@ namespace ImageProcessor.Web.Configuration
     /// </summary>
     public sealed class ImageProcessorConfiguration
     {
-        #region Fields
         /// <summary>
         /// A new instance of the <see cref="T:ImageProcessor.Web.Config.ImageProcessorConfig"/> class.
         /// with lazy initialization.
@@ -55,9 +54,7 @@ namespace ImageProcessor.Web.Configuration
         /// The security configuration section from the current application configuration. 
         /// </summary>
         private static ImageSecuritySection imageSecuritySection;
-        #endregion
 
-        #region Constructors
         /// <summary>
         /// Prevents a default instance of the <see cref="ImageProcessorConfiguration"/> class from being created.
         /// </summary>
@@ -67,9 +64,7 @@ namespace ImageProcessor.Web.Configuration
             this.LoadImageServices();
             this.LoadImageCache();
         }
-        #endregion
 
-        #region Properties
         /// <summary>
         /// Gets the current instance of the <see cref="ImageProcessorConfiguration"/> class.
         /// </summary>
@@ -157,9 +152,6 @@ namespace ImageProcessor.Web.Configuration
         /// </summary>
         public bool InterceptAllRequests => GetImageProcessingSection().InterceptAllRequests;
 
-        #endregion
-
-        #region Methods
         /// <summary>
         /// Returns the processing instructions matching the preset defined in the configuration.
         /// </summary>
@@ -187,30 +179,20 @@ namespace ImageProcessor.Web.Configuration
         /// Retrieves the security configuration section from the current application configuration. 
         /// </summary>
         /// <returns>The security configuration section from the current application configuration. </returns>
-        internal ImageSecuritySection GetImageSecuritySection()
-        {
-            return imageSecuritySection ?? (imageSecuritySection = ImageSecuritySection.GetConfiguration());
-        }
+        internal ImageSecuritySection GetImageSecuritySection() => imageSecuritySection ?? (imageSecuritySection = ImageSecuritySection.GetConfiguration());
 
         /// <summary>
         /// Retrieves the processing configuration section from the current application configuration. 
         /// </summary>
         /// <returns>The processing configuration section from the current application configuration. </returns>
-        private static ImageProcessingSection GetImageProcessingSection()
-        {
-            return imageProcessingSection ?? (imageProcessingSection = ImageProcessingSection.GetConfiguration());
-        }
+        private static ImageProcessingSection GetImageProcessingSection() => imageProcessingSection ?? (imageProcessingSection = ImageProcessingSection.GetConfiguration());
 
         /// <summary>
         /// Retrieves the caching configuration section from the current application configuration. 
         /// </summary>
         /// <returns>The caching configuration section from the current application configuration. </returns>
-        private static ImageCacheSection GetImageCacheSection()
-        {
-            return imageCacheSection ?? (imageCacheSection = ImageCacheSection.GetConfiguration());
-        }
+        private static ImageCacheSection GetImageCacheSection() => imageCacheSection ?? (imageCacheSection = ImageCacheSection.GetConfiguration());
 
-        #region GraphicesProcessors
         /// <summary>
         /// Creates and returns a new collection of <see cref="IWebGraphicsProcessor"/> 
         /// <remarks>
@@ -222,11 +204,11 @@ namespace ImageProcessor.Web.Configuration
         /// <returns>The <see cref="T:IWebGraphicsProcessor[]"/></returns>
         public IWebGraphicsProcessor[] CreateWebGraphicsProcessors()
         {
-            List<IWebGraphicsProcessor> processors = new List<IWebGraphicsProcessor>();
+            var processors = new List<IWebGraphicsProcessor>();
 
             foreach (KeyValuePair<Type, Dictionary<string, string>> pair in this.AvailableWebGraphicsProcessors)
             {
-                IWebGraphicsProcessor processor = (IWebGraphicsProcessor)Activator.CreateInstance(pair.Key);
+                var processor = (IWebGraphicsProcessor)Activator.CreateInstance(pair.Key);
                 processor.Processor.Settings = pair.Value;
                 processors.Add(processor);
             }
@@ -248,7 +230,7 @@ namespace ImageProcessor.Web.Configuration
 
             foreach (ImageProcessingSection.PluginElement pluginConfig in pluginConfigs)
             {
-                Type type = Type.GetType(pluginConfig.Type);
+                var type = Type.GetType(pluginConfig.Type);
 
                 if (type == null)
                 {
@@ -291,8 +273,7 @@ namespace ImageProcessor.Web.Configuration
                     .ToDictionary(setting => setting.Key, setting => setting.Value);
 
                 // Override the settings found in config section with values in the app.config / deployment slot settings
-                OverrideDefaultSettingsWithAppSettingsValue(settings, name);
-
+                this.OverrideDefaultSettingsWithAppSettingsValue(settings, name);
             }
             else
             {
@@ -301,9 +282,7 @@ namespace ImageProcessor.Web.Configuration
 
             return settings;
         }
-        #endregion
 
-        #region ImageServices
         /// <summary>
         /// Loads image services from configuration.
         /// </summary>
@@ -316,7 +295,7 @@ namespace ImageProcessor.Web.Configuration
             this.ImageServices = new List<IImageService>();
             foreach (ImageSecuritySection.ServiceElement config in services)
             {
-                Type type = Type.GetType(config.Type);
+                var type = Type.GetType(config.Type);
 
                 if (type == null)
                 {
@@ -325,7 +304,7 @@ namespace ImageProcessor.Web.Configuration
                     throw new TypeLoadException(message);
                 }
 
-                IImageService imageService = Activator.CreateInstance(type) as IImageService;
+                var imageService = Activator.CreateInstance(type) as IImageService;
 
                 if (imageService != null)
                 {
@@ -335,10 +314,8 @@ namespace ImageProcessor.Web.Configuration
                     imageService.WhiteList = this.GetServiceWhitelist(name);
                 }
 
-
                 this.ImageServices.Add(imageService);
             }
-
         }
 
         /// <summary>
@@ -403,9 +380,7 @@ namespace ImageProcessor.Web.Configuration
 
             return whitelist;
         }
-        #endregion
 
-        #region ImageCaches
         /// <summary>
         /// Gets the currently assigned <see cref="IImageCache"/>.
         /// </summary>
@@ -420,7 +395,7 @@ namespace ImageProcessor.Web.Configuration
                 {
                     if (cache.Name == currentCache)
                     {
-                        Type type = Type.GetType(cache.Type);
+                        var type = Type.GetType(cache.Type);
 
                         if (type == null)
                         {
@@ -449,7 +424,6 @@ namespace ImageProcessor.Web.Configuration
                 }
             }
         }
-        #endregion
 
         /// <summary>
         /// Override the default settings discovered in the config sections, with settings stored in appsettings of app.config or deployment slot settings (if available)
@@ -460,23 +434,19 @@ namespace ImageProcessor.Web.Configuration
         /// <param name="serviceOrPluginName">The name of the section, used to construct the appSetting key name</param>
         private void OverrideDefaultSettingsWithAppSettingsValue(Dictionary<string, string> defaultSettings, string serviceOrPluginName)
         {
-
-            Dictionary<string, string> copyOfSettingsForEnumeration = new Dictionary<string, string>(defaultSettings);
+            var copyOfSettingsForEnumeration = new Dictionary<string, string>(defaultSettings);
 
             // For each default setting found in the config section
-            foreach (var setting in copyOfSettingsForEnumeration)
+            foreach (KeyValuePair<string, string> setting in copyOfSettingsForEnumeration)
             {
                 // Check the app settings for a key in the specified format
                 string appSettingKeyName = $"ImageProcessor.{serviceOrPluginName}.{setting.Key}";
-                if (!String.IsNullOrEmpty(ConfigurationManager.AppSettings[appSettingKeyName]))
+                if (!string.IsNullOrEmpty(ConfigurationManager.AppSettings[appSettingKeyName]))
                 {
                     // If the key is found in app settings use the app settings value rather than the value in the config section
                     defaultSettings[setting.Key] = ConfigurationManager.AppSettings[appSettingKeyName];
                 }
             }
-
         }
-
-        #endregion
     }
 }

--- a/src/ImageProcessor.Web/Configuration/ImageSecuritySection.cs
+++ b/src/ImageProcessor.Web/Configuration/ImageSecuritySection.cs
@@ -61,9 +61,7 @@ namespace ImageProcessor.Web.Configuration
         /// <returns>The cache configuration section from the current application configuration.</returns>
         public static ImageSecuritySection GetConfiguration()
         {
-            ImageSecuritySection imageSecuritySection = ConfigurationManager.GetSection("imageProcessor/security") as ImageSecuritySection;
-
-            if (imageSecuritySection != null)
+            if (ConfigurationManager.GetSection("imageProcessor/security") is ImageSecuritySection imageSecuritySection)
             {
                 imageSecuritySection.AutoLoadServices = false;
                 return imageSecuritySection;
@@ -93,9 +91,9 @@ namespace ImageProcessor.Web.Configuration
             [ConfigurationProperty("name", DefaultValue = "", IsRequired = true)]
             public string Name
             {
-                get { return (string)this["name"]; }
+                get => (string)this["name"];
 
-                set { this["name"] = value; }
+                set => this["name"] = value;
             }
 
             /// <summary>
@@ -105,9 +103,9 @@ namespace ImageProcessor.Web.Configuration
             [ConfigurationProperty("prefix", DefaultValue = "", IsRequired = false)]
             public string Prefix
             {
-                get { return (string)this["prefix"]; }
+                get => (string)this["prefix"];
 
-                set { this["prefix"] = value; }
+                set => this["prefix"] = value;
             }
 
             /// <summary>
@@ -117,9 +115,9 @@ namespace ImageProcessor.Web.Configuration
             [ConfigurationProperty("type", DefaultValue = "", IsRequired = true)]
             public string Type
             {
-                get { return (string)this["type"]; }
+                get => (string)this["type"];
 
-                set { this["type"] = value; }
+                set => this["type"] = value;
             }
 
             /// <summary>
@@ -173,10 +171,7 @@ namespace ImageProcessor.Web.Configuration
             /// </returns>
             public ServiceElement this[int index]
             {
-                get
-                {
-                    return (ServiceElement)this.BaseGet(index);
-                }
+                get => (ServiceElement)this.BaseGet(index);
 
                 set
                 {
@@ -195,10 +190,7 @@ namespace ImageProcessor.Web.Configuration
             /// <returns>
             /// A new <see cref="ConfigurationElement"/>.
             /// </returns>
-            protected override ConfigurationElement CreateNewElement()
-            {
-                return new ServiceElement();
-            }
+            protected override ConfigurationElement CreateNewElement() => new ServiceElement();
 
             /// <summary>
             /// Gets the element key for a specified configuration element when overridden in a derived class.
@@ -207,10 +199,7 @@ namespace ImageProcessor.Web.Configuration
             /// An <see cref="T:System.Object"/> that acts as the key for the specified <see cref="ConfigurationElement"/>.
             /// </returns>
             /// <param name="element">The <see cref="ConfigurationElement"/> to return the key for. </param>
-            protected override object GetElementKey(ConfigurationElement element)
-            {
-                return ((ServiceElement)element).Name;
-            }
+            protected override object GetElementKey(ConfigurationElement element) => ((ServiceElement)element).Name;
         }
 
         /// <summary>
@@ -240,10 +229,7 @@ namespace ImageProcessor.Web.Configuration
             /// <returns>The whitelist item at the given index.</returns>
             public SafeUrl this[int index]
             {
-                get
-                {
-                    return this.BaseGet(index) as SafeUrl;
-                }
+                get => this.BaseGet(index) as SafeUrl;
 
                 set
                 {
@@ -262,20 +248,14 @@ namespace ImageProcessor.Web.Configuration
             /// <returns>
             /// A new SafeURL configuration element.
             /// </returns>
-            protected override ConfigurationElement CreateNewElement()
-            {
-                return new SafeUrl();
-            }
+            protected override ConfigurationElement CreateNewElement() => new SafeUrl();
 
             /// <summary>
             /// Gets the element key for a specified whitelist configuration element.
             /// </summary>
             /// <param name="element">The <see cref="ConfigurationElement">ConfigurationElement</see> to return the key for.</param>
             /// <returns>The element key for a specified whitelist configuration element.</returns>
-            protected override object GetElementKey(ConfigurationElement element)
-            {
-                return ((SafeUrl)element).Url;
-            }
+            protected override object GetElementKey(ConfigurationElement element) => ((SafeUrl)element).Url;
         }
 
         /// <summary>
@@ -290,9 +270,9 @@ namespace ImageProcessor.Web.Configuration
             [ConfigurationProperty("url", DefaultValue = "", IsRequired = true)]
             public Uri Url
             {
-                get { return new Uri(this["url"].ToString(), UriKind.RelativeOrAbsolute); }
+                get => new Uri(this["url"].ToString(), UriKind.RelativeOrAbsolute);
 
-                set { this["url"] = value; }
+                set => this["url"] = value;
             }
         }
     }

--- a/src/ImageProcessor.Web/Configuration/Shared/SettingElement.cs
+++ b/src/ImageProcessor.Web/Configuration/Shared/SettingElement.cs
@@ -24,15 +24,9 @@ namespace ImageProcessor.Web.Configuration
         [ConfigurationProperty("key", IsRequired = true, IsKey = true)]
         public string Key
         {
-            get
-            {
-                return this["key"] as string;
-            }
+            get => this["key"] as string;
 
-            set
-            {
-                this["key"] = value;
-            }
+            set => this["key"] = value;
         }
 
         /// <summary>
@@ -42,15 +36,9 @@ namespace ImageProcessor.Web.Configuration
         [ConfigurationProperty("value", IsRequired = true)]
         public string Value
         {
-            get
-            {
-                return (string)this["value"];
-            }
+            get => (string)this["value"];
 
-            set
-            {
-                this["value"] = value;
-            }
+            set => this["value"] = value;
         }
     }
 }

--- a/src/ImageProcessor.Web/Configuration/Shared/SettingElementCollection.cs
+++ b/src/ImageProcessor.Web/Configuration/Shared/SettingElementCollection.cs
@@ -45,10 +45,7 @@ namespace ImageProcessor.Web.Configuration
         /// </returns>
         public SettingElement this[int index]
         {
-            get
-            {
-                return (SettingElement)BaseGet(index);
-            }
+            get => (SettingElement)this.BaseGet(index);
 
             set
             {
@@ -76,7 +73,7 @@ namespace ImageProcessor.Web.Configuration
         /// <returns>True if the collection contains the key; otherwise false.</returns>
         public bool ContainsKey(string key)
         {
-            object[] keys = BaseGetAllKeys();
+            object[] keys = this.BaseGetAllKeys();
 
             return keys.Any(obj => (string)obj == key);
         }
@@ -89,10 +86,7 @@ namespace ImageProcessor.Web.Configuration
         /// to return the key for.
         /// </param>
         /// <returns>The element key for a specified PluginElement configuration element.</returns>
-        protected override object GetElementKey(ConfigurationElement element)
-        {
-            return ((SettingElement)element).Key;
-        }
+        protected override object GetElementKey(ConfigurationElement element) => ((SettingElement)element).Key;
 
         /// <summary>
         /// Creates a new SettingElement configuration element.
@@ -100,9 +94,6 @@ namespace ImageProcessor.Web.Configuration
         /// <returns>
         /// A new SettingElement configuration element.
         /// </returns>
-        protected override ConfigurationElement CreateNewElement()
-        {
-            return new SettingElement();
-        }
+        protected override ConfigurationElement CreateNewElement() => new SettingElement();
     }
 }

--- a/src/ImageProcessor.Web/Extensions/DirectoryInfoExtensions.cs
+++ b/src/ImageProcessor.Web/Extensions/DirectoryInfoExtensions.cs
@@ -8,49 +8,17 @@
 // </summary>
 // --------------------------------------------------------------------------------------------------------------------
 
-using System;
-using System.ComponentModel;
-
 namespace ImageProcessor.Web.Extensions
 {
     using System.Collections.Generic;
     using System.IO;
     using System.Linq;
-    using System.Threading.Tasks;
 
     /// <summary>
     /// Provides extension methods to the <see cref="System.IO.DirectoryInfo"/> type.
     /// </summary>
     public static class DirectoryInfoExtensions
     {
-        /// <summary>
-        /// Returns an enumerable collection of directory information that matches a specified search pattern and search subdirectory option.
-        /// Will return an empty enumerable on exception. Quick and dirty but does what I need just now.
-        /// </summary>
-        /// <param name="directoryInfo">
-        /// The <see cref="System.IO.DirectoryInfo"/> that this method extends.
-        /// </param>
-        /// <param name="searchPattern">
-        /// The search string to match against the names of directories. This parameter can contain a combination of valid literal path 
-        /// and wildcard (* and ?) characters (see Remarks), but doesn't support regular expressions. The default pattern is "*", which returns all files.
-        /// </param>
-        /// <param name="searchOption">
-        /// One of the enumeration values that specifies whether the search operation should include only 
-        /// the current directory or all subdirectories. The default value is TopDirectoryOnly.
-        /// </param>
-        /// <returns>
-        /// An enumerable collection of directories that matches searchPattern and searchOption.
-        /// </returns>
-        [Obsolete("This method should not be used, it doesn't actually perform an async IO operation")]
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public static Task<IEnumerable<DirectoryInfo>> SafeEnumerateDirectoriesAsync(
-            this DirectoryInfo directoryInfo,
-            string searchPattern = "*",
-            SearchOption searchOption = SearchOption.AllDirectories)
-        {
-            return Task.FromResult(SafeEnumerateDirectories(directoryInfo, searchPattern, searchOption));
-        }
-
         /// <summary>
         /// Returns an enumerable collection of directory information that matches a specified search pattern and search subdirectory option.
         /// Will return an empty enumerable on exception. Quick and dirty but does what I need just now.

--- a/src/ImageProcessor.Web/Extensions/ObjectExtensions.cs
+++ b/src/ImageProcessor.Web/Extensions/ObjectExtensions.cs
@@ -20,9 +20,6 @@ namespace ImageProcessor.Web.Extensions
         /// </summary>
         /// <param name="value">The object to test against.</param>
         /// <returns>True; if the value is null or an empty string; otherwise; false.</returns>
-        public static bool IsNullOrEmptyString(this object value)
-        {
-            return value == null || value as string == string.Empty;
-        }
+        public static bool IsNullOrEmptyString(this object value) => value == null || (value as string)?.Length == 0;
     }
 }

--- a/src/ImageProcessor.Web/Extensions/StringExtensions.cs
+++ b/src/ImageProcessor.Web/Extensions/StringExtensions.cs
@@ -22,7 +22,6 @@ namespace ImageProcessor.Web.Extensions
     /// </summary>
     public static class StringExtensions
     {
-        #region Cryptography
         /// <summary>
         /// Creates an MD5 fingerprint of the String.
         /// </summary>
@@ -32,7 +31,7 @@ namespace ImageProcessor.Web.Extensions
         {
             byte[] bytes = Encoding.Unicode.GetBytes(expression.ToCharArray());
 
-            using (MD5CryptoServiceProvider md5 = new MD5CryptoServiceProvider())
+            using (var md5 = new MD5CryptoServiceProvider())
             {
                 byte[] hash = md5.ComputeHash(bytes);
 
@@ -53,7 +52,7 @@ namespace ImageProcessor.Web.Extensions
         {
             byte[] bytes = Encoding.ASCII.GetBytes(expression.ToCharArray());
 
-            using (SHA1CryptoServiceProvider sha1 = new SHA1CryptoServiceProvider())
+            using (var sha1 = new SHA1CryptoServiceProvider())
             {
                 byte[] hash = sha1.ComputeHash(bytes);
 
@@ -64,9 +63,7 @@ namespace ImageProcessor.Web.Extensions
                     .ToString().ToLowerInvariant();
             }
         }
-        #endregion
 
-        #region Numbers
         /// <summary>
         /// Creates an array of integers scraped from the String.
         /// </summary>
@@ -79,7 +76,7 @@ namespace ImageProcessor.Web.Extensions
                 throw new ArgumentNullException(nameof(expression));
             }
 
-            Regex regex = new Regex(@"[\d+]+(?=[,-])|[\d+]+(?![,-])", RegexOptions.Compiled);
+            var regex = new Regex(@"[\d+]+(?=[,-])|[\d+]+(?![,-])", RegexOptions.Compiled);
 
             MatchCollection matchCollection = regex.Matches(expression);
 
@@ -108,7 +105,7 @@ namespace ImageProcessor.Web.Extensions
                 throw new ArgumentNullException(nameof(expression));
             }
 
-            Regex regex = new Regex(@"[\d+\.]+(?=[,-])|[\d+\.]+(?![,-])", RegexOptions.Compiled);
+            var regex = new Regex(@"[\d+\.]+(?=[,-])|[\d+\.]+(?![,-])", RegexOptions.Compiled);
 
             MatchCollection matchCollection = regex.Matches(expression);
 
@@ -124,21 +121,13 @@ namespace ImageProcessor.Web.Extensions
 
             return matches;
         }
-        #endregion
 
-        #region Files and Paths
         /// <summary>
         /// Checks the string to see whether the value is a valid virtual path name.
         /// </summary>
         /// <param name="expression">The <see cref="T:System.String">String</see> instance that this method extends.</param>
         /// <returns>True if the given string is a valid virtual path name</returns>
-        public static bool IsValidVirtualPathName(this string expression)
-        {
-            Uri uri;
-
-            return Uri.TryCreate(expression, UriKind.Relative, out uri) && uri.IsWellFormedOriginalString();
-        }
-        #endregion
+        public static bool IsValidVirtualPathName(this string expression) => Uri.TryCreate(expression, UriKind.Relative, out Uri uri) && uri.IsWellFormedOriginalString();
 
         /// <summary>
         /// Trims a specified string from the start of another string.

--- a/src/ImageProcessor.Web/Extensions/TypeInferenceExtensions.cs
+++ b/src/ImageProcessor.Web/Extensions/TypeInferenceExtensions.cs
@@ -40,20 +40,14 @@ namespace ImageProcessor.Web.Extensions
         /// </summary>
         /// <param name="type">The type.</param>
         /// <returns>True if the type is a collection type otherwise; false.</returns>
-        public static bool IsCollectionType(this Type type)
-        {
-            return type.TryGetElementType(typeof(ICollection<>)) != null;
-        }
+        public static bool IsCollectionType(this Type type) => type.TryGetElementType(typeof(ICollection<>)) != null;
 
         /// <summary>
         /// Determines whether the specified type is an enumerable type.
         /// </summary>
         /// <param name="type">The type.</param>
         /// <returns>True if the type is an enumerable type otherwise; false.</returns>
-        public static bool IsEnumerableType(this Type type)
-        {
-            return type.TryGetElementType(typeof(IEnumerable<>)) != null;
-        }
+        public static bool IsEnumerableType(this Type type) => type.TryGetElementType(typeof(IEnumerable<>)) != null;
 
         /// <summary>
         /// Determines whether the specified type is an enumerable type containing a 
@@ -69,10 +63,10 @@ namespace ImageProcessor.Web.Extensions
         /// pair otherwise; false.</returns>
         public static bool IsEnumerableOfKeyValueType(this Type type)
         {
-            return type.TryGetElementType(typeof(IDictionary<,>)) != null ||
-                (type.IsEnumerableType() && type.IsGenericType && type.GenericTypeArguments.Any()
-                 && type.GenericTypeArguments[0].IsGenericType
-                 && type.GenericTypeArguments[0].GetGenericTypeDefinition() == typeof(KeyValuePair<,>));
+            return type.TryGetElementType(typeof(IDictionary<,>)) != null
+                || (type.IsEnumerableType() && type.IsGenericType && type.GenericTypeArguments.Length > 0
+                && type.GenericTypeArguments[0].IsGenericType
+                && type.GenericTypeArguments[0].GetGenericTypeDefinition() == typeof(KeyValuePair<,>));
         }
 
         /// <summary>
@@ -89,7 +83,7 @@ namespace ImageProcessor.Web.Extensions
             // String, though enumerable have no generic arguments.
             // Types with more than one generic argument cnnot be cast. 
             // Dictionary, though enumerable, requires linq to convert and shouldn't be attempted anyway.
-            return type.IsEnumerableType() && type.GenericTypeArguments.Any()
+            return type.IsEnumerableType() && type.GenericTypeArguments.Length > 0
                     && type.GenericTypeArguments.Length == 1
                     && type.TryGetElementType(typeof(IDictionary<,>)) == null;
         }
@@ -161,7 +155,7 @@ namespace ImageProcessor.Web.Extensions
         /// <returns>The type of the enumerable.</returns>
         public static Type GetEnumerableType(this Type type)
         {
-            List<Type> interfaces = type.GetInterfaces().ToList();
+            var interfaces = type.GetInterfaces().ToList();
             if (type.IsInterface && interfaces.All(i => i != type))
             {
                 interfaces.Add(type);

--- a/src/ImageProcessor.Web/Extensions/TypeInitializationExtensions.cs
+++ b/src/ImageProcessor.Web/Extensions/TypeInitializationExtensions.cs
@@ -43,10 +43,7 @@ namespace ImageProcessor.Web.Extensions
         /// <param name="type">The type on which the method was invoked.</param>
         /// <param name="argument">The argument to pass to the constructor.</param>
         /// <returns>An instance of the given <paramref name="type"/>.</returns>
-        public static object GetInstance<TArg>(this Type type, TArg argument)
-        {
-            return GetInstance<TArg, TypeToIgnore>(type, argument, null);
-        }
+        public static object GetInstance<TArg>(this Type type, TArg argument) => GetInstance<TArg, TypeToIgnore>(type, argument, null);
 
         /// <summary>
         /// Returns an instance of the <paramref name="type"/> on which the method is invoked.
@@ -57,10 +54,7 @@ namespace ImageProcessor.Web.Extensions
         /// <param name="argument1">The first argument to pass to the constructor.</param>
         /// <param name="argument2">The second argument to pass to the constructor.</param>
         /// <returns>An instance of the given <paramref name="type"/>.</returns>
-        public static object GetInstance<TArg1, TArg2>(this Type type, TArg1 argument1, TArg2 argument2)
-        {
-            return GetInstance<TArg1, TArg2, TypeToIgnore>(type, argument1, argument2, null);
-        }
+        public static object GetInstance<TArg1, TArg2>(this Type type, TArg1 argument1, TArg2 argument2) => GetInstance<TArg1, TArg2, TypeToIgnore>(type, argument1, argument2, null);
 
         /// <summary>
         /// Returns an instance of the <paramref name="type"/> on which the method is invoked.
@@ -124,8 +118,7 @@ namespace ImageProcessor.Web.Extensions
             private static void CacheInstanceCreationMethodIfRequired(Type type)
             {
                 // Bail out if we've already cached the instance creation method:
-                Func<TArg1, TArg2, TArg3, object> cached;
-                if (InstanceCreationMethods.TryGetValue(type, out cached))
+                if (InstanceCreationMethods.TryGetValue(type, out Func<TArg1, TArg2, TArg3, object> cached))
                 {
                     return;
                 }

--- a/src/ImageProcessor.Web/Helpers/CommonParameterParserUtility.cs
+++ b/src/ImageProcessor.Web/Helpers/CommonParameterParserUtility.cs
@@ -34,12 +34,12 @@ namespace ImageProcessor.Web.Helpers
         /// <summary>
         /// The regular expression to search strings for angles.
         /// </summary>
-        private static readonly Regex AngleRegex = new Regex(@"(^(rotate(bounded)?|angle)|[^.](&,)?rotate(bounded)?|angle)(=|-)[^&|,]+", RegexOptions.Compiled);
+        private static readonly Regex AngleRegex = new Regex("(^(rotate(bounded)?|angle)|[^.](&,)?rotate(bounded)?|angle)(=|-)[^&|,]+", RegexOptions.Compiled);
 
         /// <summary>
         /// The regular expression to search strings for values between 1 and 100.
         /// </summary>
-        private static readonly Regex In100RangeRegex = new Regex(@"(-?0*(?:100|[1-9][0-9]?))", RegexOptions.Compiled);
+        private static readonly Regex In100RangeRegex = new Regex("(-?0*(?:100|[1-9][0-9]?))", RegexOptions.Compiled);
 
         /// <summary>
         /// Returns the correct <see cref="T:System.Int32"/> containing the angle for the given string.
@@ -55,13 +55,12 @@ namespace ImageProcessor.Web.Helpers
             foreach (Match match in AngleRegex.Matches(input))
             {
                 // Split on angle
-                float angle;
                 string value = match.Value;
-                value = match.Value.ToUpperInvariant().Contains("ANGLE")
+                value = match.Value.IndexOf("ANGLE", StringComparison.InvariantCultureIgnoreCase) >= 0
                     ? value.Substring(value.IndexOf("-", StringComparison.Ordinal) + 1)
                     : match.Value.Split('=')[1];
 
-                float.TryParse(value, NumberStyles.Any, CultureInfo.InvariantCulture, out angle);
+                float.TryParse(value, NumberStyles.Any, CultureInfo.InvariantCulture, out float angle);
                 return angle;
             }
 
@@ -135,10 +134,10 @@ namespace ImageProcessor.Web.Helpers
         /// </returns>
         private static Regex BuildColorRegex()
         {
-            StringBuilder stringBuilder = new StringBuilder();
+            var stringBuilder = new StringBuilder();
             stringBuilder.Append(@"(\d+,\d+,\d+,\d+|([0-9a-fA-F]{3}){1,2}|(");
 
-            KnownColor[] knownColors = (KnownColor[])Enum.GetValues(typeof(KnownColor));
+            var knownColors = (KnownColor[])Enum.GetValues(typeof(KnownColor));
 
             for (int i = 0; i < knownColors.Length; i++)
             {

--- a/src/ImageProcessor.Web/Helpers/ImageHelpers.cs
+++ b/src/ImageProcessor.Web/Helpers/ImageHelpers.cs
@@ -78,10 +78,7 @@ namespace ImageProcessor.Web.Helpers
         /// </summary>
         /// <param name="fileName">The string containing the filename to check.</param>
         /// <returns>True the value contains a valid image extension, otherwise false.</returns>
-        public static bool IsValidImageExtension(string fileName)
-        {
-            return EndFormatRegex.IsMatch(fileName);
-        }
+        public static bool IsValidImageExtension(string fileName) => EndFormatRegex.IsMatch(fileName);
 
         /// <summary>
         /// Returns the correct file extension for the given string input. Falls back to <value>jpg</value> if no extension is matched.
@@ -91,10 +88,7 @@ namespace ImageProcessor.Web.Helpers
         /// <returns>
         /// The correct file extension for the given string input if it can find one; otherwise defaults to <value>jpg</value>.
         /// </returns>
-        public string GetExtension(string fullPath, string queryString)
-        {
-            return this.GetExtension(fullPath, queryString, "jpg");
-        }
+        public string GetExtension(string fullPath, string queryString) => this.GetExtension(fullPath, queryString, "jpg");
 
         /// <summary>
         /// Returns the correct file extension for the given string input.
@@ -114,7 +108,7 @@ namespace ImageProcessor.Web.Helpers
                 match = this.formatProcessor.RegexPattern.Match(queryString);
             }
 
-            if (match == null || !match.Success)
+            if (match?.Success != true)
             {
                 // Test against the path minus the querystring so any other
                 // processors don't interere.
@@ -138,7 +132,7 @@ namespace ImageProcessor.Web.Helpers
                 }
 
                 // Ah the enigma that is the png file.
-                if (value.ToLowerInvariant().EndsWith("png8"))
+                if (value.EndsWith("png8", StringComparison.InvariantCultureIgnoreCase))
                 {
                     return "png";
                 }
@@ -185,7 +179,7 @@ namespace ImageProcessor.Web.Helpers
         /// </returns>
         private static string BuildExtensionRegexPattern()
         {
-            StringBuilder stringBuilder = new StringBuilder();
+            var stringBuilder = new StringBuilder();
             stringBuilder.Append("(");
             int counter = 0;
             foreach (ISupportedImageFormat imageFormat in ImageProcessorBootstrapper.Instance.SupportedImageFormats)

--- a/src/ImageProcessor.Web/Helpers/NativeMethods.cs
+++ b/src/ImageProcessor.Web/Helpers/NativeMethods.cs
@@ -16,7 +16,7 @@ namespace ImageProcessor.Web.Helpers
     /// <summary>
     /// Provides access to unmanaged native methods.
     /// </summary>
-    internal class NativeMethods
+    internal static class NativeMethods
     {
         /// <summary>
         /// Loads the specified module into the address space of the calling process. 

--- a/src/ImageProcessor.Web/Helpers/ResourceHelpers.cs
+++ b/src/ImageProcessor.Web/Helpers/ResourceHelpers.cs
@@ -16,12 +16,10 @@ namespace ImageProcessor.Web.Helpers
 
     using ImageProcessor.Web.Caching;
 
-    using Microsoft.IO;
-
     /// <summary>
     /// Provides helper methods for working with resources.
     /// </summary>
-    public class ResourceHelpers
+    public static class ResourceHelpers
     {
         /// <summary>
         /// Converts an assembly resource into a string.

--- a/src/ImageProcessor.Web/Helpers/UrlParser.cs
+++ b/src/ImageProcessor.Web/Helpers/UrlParser.cs
@@ -20,7 +20,7 @@ namespace ImageProcessor.Web.Helpers
     /// <summary>
     /// A helper class for decoding and parsing request URLs.
     /// </summary>
-    public class UrlParser
+    public static class UrlParser
     {
         /// <summary>
         /// Parses the given URL adjusting the request path to a value that can then be interpreted by an  image service.
@@ -62,7 +62,7 @@ namespace ImageProcessor.Web.Helpers
             // Certain Facebook requests require ony the first part to be decoded.
             if (hasMultiParams)
             {
-                StringBuilder sb = new StringBuilder(requestPath);
+                var sb = new StringBuilder(requestPath);
                 for (int i = 1; i < splitPath.Length - 1; i++)
                 {
                     sb.AppendFormat("?{0}", splitPath[i]);

--- a/src/ImageProcessor.Web/Helpers/ValidatingRequestEventArgs.cs
+++ b/src/ImageProcessor.Web/Helpers/ValidatingRequestEventArgs.cs
@@ -36,7 +36,7 @@ namespace ImageProcessor.Web.Helpers
         /// <summary>
         /// Gets the current http context.
         /// </summary>
-        public HttpContextBase Context { get; private set; }
+        public HttpContextBase Context { get; }
 
         /// <summary>
         /// Gets or sets the query string

--- a/src/ImageProcessor.Web/Processors/Alpha.cs
+++ b/src/ImageProcessor.Web/Processors/Alpha.cs
@@ -31,10 +31,7 @@ namespace ImageProcessor.Web.Processors
         /// <summary>
         /// Initializes a new instance of the <see cref="Alpha"/> class.
         /// </summary>
-        public Alpha()
-        {
-            this.Processor = new ImageProcessor.Processors.Alpha();
-        }
+        public Alpha() => this.Processor = new ImageProcessor.Processors.Alpha();
 
         /// <summary>
         /// Gets the regular expression to search strings for.

--- a/src/ImageProcessor.Web/Processors/AutoRotate.cs
+++ b/src/ImageProcessor.Web/Processors/AutoRotate.cs
@@ -23,15 +23,12 @@ namespace ImageProcessor.Web.Processors
         /// <summary>
         /// The regular expression to search strings for.
         /// </summary>
-        private static readonly Regex QueryRegex = new Regex(@"autorotate=true", RegexOptions.Compiled);
+        private static readonly Regex QueryRegex = new Regex("autorotate=true", RegexOptions.Compiled);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AutoRotate"/> class.
         /// </summary>
-        public AutoRotate()
-        {
-            this.Processor = new ImageProcessor.Processors.AutoRotate();
-        }
+        public AutoRotate() => this.Processor = new ImageProcessor.Processors.AutoRotate();
 
         /// <summary>
         /// Gets the regular expression to search strings for.

--- a/src/ImageProcessor.Web/Processors/Background.cs
+++ b/src/ImageProcessor.Web/Processors/Background.cs
@@ -37,10 +37,7 @@ namespace ImageProcessor.Web.Processors
         /// <summary>
         /// Initializes a new instance of the <see cref="Background"/> class.
         /// </summary>
-        public Background()
-        {
-            this.Processor = new ImageProcessor.Processors.Background();
-        }
+        public Background() => this.Processor = new ImageProcessor.Processors.Background();
 
         /// <summary>
         /// Gets the regular expression to search strings for.
@@ -77,8 +74,8 @@ namespace ImageProcessor.Web.Processors
 
                 Point? position = queryCollection["background.position"] != null
                       ? QueryParamParser.Instance.ParseValue<Point>(queryCollection["background.position"])
-                      : (Point?)null; 
-                
+                      : (Point?)null;
+
                 int opacity = queryCollection["background.opacity"] != null
                                   ? QueryParamParser.Instance.ParseValue<int>(queryCollection["background.opacity"])
                                   : 100;
@@ -110,8 +107,7 @@ namespace ImageProcessor.Web.Processors
             Image image = null;
 
             // Correctly parse the path.
-            string path;
-            this.Processor.Settings.TryGetValue("VirtualPath", out path);
+            this.Processor.Settings.TryGetValue("VirtualPath", out string path);
 
             if (!string.IsNullOrWhiteSpace(path) && path.StartsWith("~/"))
             {
@@ -121,7 +117,7 @@ namespace ImageProcessor.Web.Processors
                     imagePath = Path.Combine(imagePath, input);
                     try
                     {
-                        using (ImageFactory factory = new ImageFactory())
+                        using (var factory = new ImageFactory())
                         {
                             factory.Load(imagePath);
                             image = new Bitmap(factory.Image);

--- a/src/ImageProcessor.Web/Processors/BackgroundColor.cs
+++ b/src/ImageProcessor.Web/Processors/BackgroundColor.cs
@@ -26,15 +26,12 @@ namespace ImageProcessor.Web.Processors
         /// <summary>
         /// The regular expression to search strings for.
         /// </summary>
-        private static readonly Regex QueryRegex = new Regex(@"bgcolor=[^&]", RegexOptions.Compiled);
+        private static readonly Regex QueryRegex = new Regex("bgcolor=[^&]", RegexOptions.Compiled);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="BackgroundColor"/> class.
         /// </summary>
-        public BackgroundColor()
-        {
-            this.Processor = new ImageProcessor.Processors.BackgroundColor();
-        }
+        public BackgroundColor() => this.Processor = new ImageProcessor.Processors.BackgroundColor();
 
         /// <summary>
         /// Gets the regular expression to search strings for.
@@ -67,8 +64,7 @@ namespace ImageProcessor.Web.Processors
             {
                 this.SortOrder = match.Index;
                 NameValueCollection queryCollection = HttpUtility.ParseQueryString(queryString);
-                Color color = QueryParamParser.Instance.ParseValue<Color>(queryCollection["bgcolor"]);
-                this.Processor.DynamicParameter = color;
+                this.Processor.DynamicParameter = (Color)QueryParamParser.Instance.ParseValue<Color>(queryCollection["bgcolor"]);
             }
 
             return this.SortOrder;

--- a/src/ImageProcessor.Web/Processors/Brightness.cs
+++ b/src/ImageProcessor.Web/Processors/Brightness.cs
@@ -31,10 +31,7 @@ namespace ImageProcessor.Web.Processors
         /// <summary>
         /// Initializes a new instance of the <see cref="Brightness"/> class.
         /// </summary>
-        public Brightness()
-        {
-            this.Processor = new ImageProcessor.Processors.Brightness();
-        }
+        public Brightness() => this.Processor = new ImageProcessor.Processors.Brightness();
 
         /// <summary>
         /// Gets the regular expression to search strings for.

--- a/src/ImageProcessor.Web/Processors/Contrast.cs
+++ b/src/ImageProcessor.Web/Processors/Contrast.cs
@@ -31,10 +31,7 @@ namespace ImageProcessor.Web.Processors
         /// <summary>
         /// Initializes a new instance of the <see cref="Contrast"/> class.
         /// </summary>
-        public Contrast()
-        {
-            this.Processor = new ImageProcessor.Processors.Contrast();
-        }
+        public Contrast() => this.Processor = new ImageProcessor.Processors.Contrast();
 
         /// <summary>
         /// Gets the regular expression to search strings for.

--- a/src/ImageProcessor.Web/Processors/Crop.cs
+++ b/src/ImageProcessor.Web/Processors/Crop.cs
@@ -31,10 +31,7 @@ namespace ImageProcessor.Web.Processors
         /// <summary>
         /// Initializes a new instance of the <see cref="Crop"/> class.
         /// </summary>
-        public Crop()
-        {
-            this.Processor = new ImageProcessor.Processors.Crop();
-        }
+        public Crop() => this.Processor = new ImageProcessor.Processors.Crop();
 
         /// <summary>
         /// Gets the regular expression to search strings for.
@@ -73,8 +70,7 @@ namespace ImageProcessor.Web.Processors
 
                 // Default CropMode.Pixels will be returned.
                 CropMode cropMode = QueryParamParser.Instance.ParseValue<CropMode>(queryCollection["cropmode"]);
-                CropLayer cropLayer = new CropLayer(coordinates[0], coordinates[1], coordinates[2], coordinates[3], cropMode);
-                this.Processor.DynamicParameter = cropLayer;
+                this.Processor.DynamicParameter = (CropLayer)new CropLayer(coordinates[0], coordinates[1], coordinates[2], coordinates[3], cropMode);
             }
 
             return this.SortOrder;

--- a/src/ImageProcessor.Web/Processors/DetectEdges.cs
+++ b/src/ImageProcessor.Web/Processors/DetectEdges.cs
@@ -43,10 +43,7 @@ namespace ImageProcessor.Web.Processors
         /// <summary>
         /// Initializes a new instance of the <see cref="DetectEdges"/> class.
         /// </summary>
-        public DetectEdges()
-        {
-            this.Processor = new ImageProcessor.Processors.DetectEdges();
-        }
+        public DetectEdges() => this.Processor = new ImageProcessor.Processors.DetectEdges();
 
         /// <summary>
         /// Gets the regular expression to search strings for.
@@ -84,7 +81,7 @@ namespace ImageProcessor.Web.Processors
             {
                 this.SortOrder = match.Index;
                 NameValueCollection queryCollection = HttpUtility.ParseQueryString(queryString);
-                IEdgeFilter filter = (IEdgeFilter)detectors[QueryParamParser.Instance.ParseValue<string>(queryCollection["detectedges"])];
+                var filter = (IEdgeFilter)detectors[QueryParamParser.Instance.ParseValue<string>(queryCollection["detectedges"])];
                 bool greyscale = QueryParamParser.Instance.ParseValue<bool>(queryCollection["greyscale"]);
                 this.Processor.DynamicParameter = new Tuple<IEdgeFilter, bool>(filter, greyscale);
             }
@@ -100,7 +97,7 @@ namespace ImageProcessor.Web.Processors
         /// </returns>
         private static Regex BuildRegex()
         {
-            StringBuilder stringBuilder = new StringBuilder();
+            var stringBuilder = new StringBuilder();
 
             stringBuilder.Append("detectedges=(");
 

--- a/src/ImageProcessor.Web/Processors/EntropyCrop.cs
+++ b/src/ImageProcessor.Web/Processors/EntropyCrop.cs
@@ -25,15 +25,12 @@ namespace ImageProcessor.Web.Processors
         /// <summary>
         /// The regular expression to search strings for.
         /// </summary>
-        private static readonly Regex QueryRegex = new Regex(@"entropycrop(=)?[^&]*", RegexOptions.Compiled);
+        private static readonly Regex QueryRegex = new Regex("entropycrop(=)?[^&]*", RegexOptions.Compiled);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="EntropyCrop"/> class.
         /// </summary>
-        public EntropyCrop()
-        {
-            this.Processor = new ImageProcessor.Processors.EntropyCrop();
-        }
+        public EntropyCrop() => this.Processor = new ImageProcessor.Processors.EntropyCrop();
 
         /// <summary>
         /// Gets the regular expression to search strings for.
@@ -70,7 +67,7 @@ namespace ImageProcessor.Web.Processors
                 byte threshold = QueryParamParser.Instance.ParseValue<byte>(queryCollection["entropycrop"]);
 
                 // Fallback to the default if 0.
-                this.Processor.DynamicParameter = threshold > 0 ? threshold : (byte)128;
+                this.Processor.DynamicParameter = threshold > 0 ? threshold : 128;
             }
 
             return this.SortOrder;

--- a/src/ImageProcessor.Web/Processors/Filter.cs
+++ b/src/ImageProcessor.Web/Processors/Filter.cs
@@ -39,10 +39,7 @@ namespace ImageProcessor.Web.Processors
         /// <summary>
         /// Initializes a new instance of the <see cref="Filter"/> class.
         /// </summary>
-        public Filter()
-        {
-            this.Processor = new ImageProcessor.Processors.Filter();
-        }
+        public Filter() => this.Processor = new ImageProcessor.Processors.Filter();
 
         /// <summary>
         /// Gets the regular expression to search strings for.
@@ -99,7 +96,7 @@ namespace ImageProcessor.Web.Processors
                               .Where(p => p.PropertyType.IsAssignableFrom(typeof(IMatrixFilter)))
                               .ToList();
 
-            StringBuilder stringBuilder = new StringBuilder();
+            var stringBuilder = new StringBuilder();
             stringBuilder.Append("filter=(");
             int counter = 0;
 
@@ -142,7 +139,7 @@ namespace ImageProcessor.Web.Processors
                     PropertyInfo filter =
                         type.GetProperties(Flags)
                             .Where(p => p.PropertyType.IsAssignableFrom(typeof(IMatrixFilter)))
-                            .First(p => p.Name.Equals(identifier, StringComparison.InvariantCultureIgnoreCase));
+                            .First(p => p.Name.Equals(f, StringComparison.InvariantCultureIgnoreCase));
 
                     return filter.GetValue(null, null) as IMatrixFilter;
                 });

--- a/src/ImageProcessor.Web/Processors/Flip.cs
+++ b/src/ImageProcessor.Web/Processors/Flip.cs
@@ -22,15 +22,12 @@ namespace ImageProcessor.Web.Processors
         /// <summary>
         /// The regular expression to search strings for.
         /// </summary>
-        private static readonly Regex QueryRegex = new Regex(@"flip=(horizontal|vertical|both)", RegexOptions.Compiled);
+        private static readonly Regex QueryRegex = new Regex("flip=(horizontal|vertical|both)", RegexOptions.Compiled);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Flip"/> class.
         /// </summary>
-        public Flip()
-        {
-            this.Processor = new ImageProcessor.Processors.Flip();
-        }
+        public Flip() => this.Processor = new ImageProcessor.Processors.Flip();
 
         /// <summary>
         /// Gets the regular expression to search strings for.
@@ -66,9 +63,7 @@ namespace ImageProcessor.Web.Processors
                 this.SortOrder = match.Index;
 
                 // We do not use the full enum so use switch.
-                string direction = match.Value.Split('=')[1];
-
-                switch (direction)
+                switch (match.Value.Split('=')[1])
                 {
                     case "horizontal":
                         this.Processor.DynamicParameter = RotateFlipType.RotateNoneFlipX;

--- a/src/ImageProcessor.Web/Processors/Format.cs
+++ b/src/ImageProcessor.Web/Processors/Format.cs
@@ -11,7 +11,6 @@
 namespace ImageProcessor.Web.Processors
 {
     using System;
-    using System.Collections.Generic;
     using System.Linq;
     using System.Text;
     using System.Text.RegularExpressions;
@@ -33,10 +32,7 @@ namespace ImageProcessor.Web.Processors
         /// <summary>
         /// Initializes a new instance of the <see cref="Format"/> class.
         /// </summary>
-        public Format()
-        {
-            this.Processor = new ImageProcessor.Processors.Format();
-        }
+        public Format() => this.Processor = new ImageProcessor.Processors.Format();
 
         /// <summary>
         /// Gets the regular expression to search strings for.
@@ -88,7 +84,7 @@ namespace ImageProcessor.Web.Processors
         /// </returns>
         private static Regex BuildRegex()
         {
-            StringBuilder stringBuilder = new StringBuilder();
+            var stringBuilder = new StringBuilder();
 
             // png8 is a special case for determining indexed png's.
             stringBuilder.Append("format=(png8");
@@ -119,8 +115,8 @@ namespace ImageProcessor.Web.Processors
             identifier = identifier.ToLowerInvariant();
             string finalIdentifier = identifier.Equals("png8") ? "png" : identifier;
             ISupportedImageFormat newFormat = null;
-            List<ISupportedImageFormat> formats = ImageProcessorBootstrapper.Instance.SupportedImageFormats.ToList();
-            ISupportedImageFormat format = formats.FirstOrDefault(f => f.FileExtensions.Any(e => e.Equals(finalIdentifier, StringComparison.InvariantCultureIgnoreCase)));
+            var formats = ImageProcessorBootstrapper.Instance.SupportedImageFormats.ToList();
+            ISupportedImageFormat format = formats.Find(f => f.FileExtensions.Any(e => e.Equals(finalIdentifier, StringComparison.InvariantCultureIgnoreCase)));
 
             if (format != null)
             {

--- a/src/ImageProcessor.Web/Processors/Gamma.cs
+++ b/src/ImageProcessor.Web/Processors/Gamma.cs
@@ -25,15 +25,12 @@ namespace ImageProcessor.Web.Processors
         /// <summary>
         /// The regular expression to search strings for.
         /// </summary>
-        private static readonly Regex QueryRegex = new Regex(@"gamma=[^&]", RegexOptions.Compiled);
+        private static readonly Regex QueryRegex = new Regex("gamma=[^&]", RegexOptions.Compiled);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Gamma"/> class.
         /// </summary>
-        public Gamma()
-        {
-            this.Processor = new ImageProcessor.Processors.Gamma();
-        }
+        public Gamma() => this.Processor = new ImageProcessor.Processors.Gamma();
 
         /// <summary>
         /// Gets the regular expression to search strings for.

--- a/src/ImageProcessor.Web/Processors/GaussianBlur.cs
+++ b/src/ImageProcessor.Web/Processors/GaussianBlur.cs
@@ -33,10 +33,7 @@ namespace ImageProcessor.Web.Processors
         /// <summary>
         /// Initializes a new instance of the <see cref="GaussianBlur"/> class.
         /// </summary>
-        public GaussianBlur()
-        {
-            this.Processor = new ImageProcessor.Processors.GaussianBlur();
-        }
+        public GaussianBlur() => this.Processor = new ImageProcessor.Processors.GaussianBlur();
 
         /// <summary>
         /// Gets the regular expression to search strings for.
@@ -70,13 +67,9 @@ namespace ImageProcessor.Web.Processors
             {
                 this.SortOrder = match.Index;
 
-                int maxSize;
-                double maxSigma;
-                int maxThreshold;
-
-                int.TryParse(this.Processor.Settings["MaxSize"], NumberStyles.Any, CultureInfo.InvariantCulture, out maxSize);
-                double.TryParse(this.Processor.Settings["MaxSigma"], NumberStyles.Any, CultureInfo.InvariantCulture, out maxSigma);
-                int.TryParse(this.Processor.Settings["MaxThreshold"], NumberStyles.Any, CultureInfo.InvariantCulture, out maxThreshold);
+                int.TryParse(this.Processor.Settings["MaxSize"], NumberStyles.Any, CultureInfo.InvariantCulture, out int maxSize);
+                double.TryParse(this.Processor.Settings["MaxSigma"], NumberStyles.Any, CultureInfo.InvariantCulture, out double maxSigma);
+                int.TryParse(this.Processor.Settings["MaxThreshold"], NumberStyles.Any, CultureInfo.InvariantCulture, out int maxThreshold);
 
                 NameValueCollection queryCollection = HttpUtility.ParseQueryString(queryString);
                 int size = QueryParamParser.Instance.ParseValue<int>(queryCollection["blur"]);

--- a/src/ImageProcessor.Web/Processors/GaussianSharpen.cs
+++ b/src/ImageProcessor.Web/Processors/GaussianSharpen.cs
@@ -33,10 +33,7 @@ namespace ImageProcessor.Web.Processors
         /// <summary>
         /// Initializes a new instance of the <see cref="GaussianSharpen"/> class.
         /// </summary>
-        public GaussianSharpen()
-        {
-            this.Processor = new ImageProcessor.Processors.GaussianSharpen();
-        }
+        public GaussianSharpen() => this.Processor = new ImageProcessor.Processors.GaussianSharpen();
 
         /// <summary>
         /// Gets the regular expression to search strings for.
@@ -70,13 +67,9 @@ namespace ImageProcessor.Web.Processors
             {
                 this.SortOrder = match.Index;
 
-                int maxSize;
-                double maxSigma;
-                int maxThreshold;
-
-                int.TryParse(this.Processor.Settings["MaxSize"], NumberStyles.Any, CultureInfo.InvariantCulture, out maxSize);
-                double.TryParse(this.Processor.Settings["MaxSigma"], NumberStyles.Any, CultureInfo.InvariantCulture, out maxSigma);
-                int.TryParse(this.Processor.Settings["MaxThreshold"], NumberStyles.Any, CultureInfo.InvariantCulture, out maxThreshold);
+                int.TryParse(this.Processor.Settings["MaxSize"], NumberStyles.Any, CultureInfo.InvariantCulture, out int maxSize);
+                double.TryParse(this.Processor.Settings["MaxSigma"], NumberStyles.Any, CultureInfo.InvariantCulture, out double maxSigma);
+                int.TryParse(this.Processor.Settings["MaxThreshold"], NumberStyles.Any, CultureInfo.InvariantCulture, out int maxThreshold);
 
                 NameValueCollection queryCollection = HttpUtility.ParseQueryString(queryString);
                 int size = QueryParamParser.Instance.ParseValue<int>(queryCollection["sharpen"]);

--- a/src/ImageProcessor.Web/Processors/Halftone.cs
+++ b/src/ImageProcessor.Web/Processors/Halftone.cs
@@ -22,15 +22,12 @@ namespace ImageProcessor.Web.Processors
         /// <summary>
         /// The regular expression to search strings for.
         /// </summary>
-        private static readonly Regex QueryRegex = new Regex(@"halftone(=comic)?", RegexOptions.Compiled);
+        private static readonly Regex QueryRegex = new Regex("halftone(=comic)?", RegexOptions.Compiled);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Halftone"/> class.
         /// </summary>
-        public Halftone()
-        {
-            this.Processor = new ImageProcessor.Processors.Halftone();
-        }
+        public Halftone() => this.Processor = new ImageProcessor.Processors.Halftone();
 
         /// <summary>
         /// Gets the regular expression to search strings for.
@@ -62,8 +59,7 @@ namespace ImageProcessor.Web.Processors
             if (match.Success)
             {
                 this.SortOrder = match.Index;
-                bool comicMode = match.Value.Contains("comic");
-                this.Processor.DynamicParameter = comicMode;
+                this.Processor.DynamicParameter = (bool)match.Value.Contains("comic");
             }
 
             return this.SortOrder;

--- a/src/ImageProcessor.Web/Processors/Hue.cs
+++ b/src/ImageProcessor.Web/Processors/Hue.cs
@@ -32,10 +32,7 @@ namespace ImageProcessor.Web.Processors
         /// <summary>
         /// Initializes a new instance of the <see cref="Hue"/> class.
         /// </summary>
-        public Hue()
-        {
-            this.Processor = new ImageProcessor.Processors.Hue();
-        }
+        public Hue() => this.Processor = new ImageProcessor.Processors.Hue();
 
         /// <summary>
         /// Gets the regular expression to search strings for.

--- a/src/ImageProcessor.Web/Processors/IWebGraphicsProcessor.cs
+++ b/src/ImageProcessor.Web/Processors/IWebGraphicsProcessor.cs
@@ -18,7 +18,6 @@ namespace ImageProcessor.Web.Processors
     /// </summary>
     public interface IWebGraphicsProcessor
     {
-        #region Properties
         /// <summary>
         /// Gets the regular expression to search strings for.
         /// </summary>
@@ -33,19 +32,14 @@ namespace ImageProcessor.Web.Processors
         /// Gets the associated graphics processor.
         /// </summary>
         IGraphicsProcessor Processor { get; }
-        #endregion
 
-        #region Methods
         /// <summary>
         /// The position in the original string where the first character of the captured substring was found.
         /// </summary>
-        /// <param name="queryString">
-        /// The query string to search.
-        /// </param>
+        /// <param name="queryString">The query string to search.</param>
         /// <returns>
         /// The zero-based starting position in the original string where the captured substring was found.
         /// </returns>
         int MatchRegexIndex(string queryString);
-        #endregion
     }
 }

--- a/src/ImageProcessor.Web/Processors/Mask.cs
+++ b/src/ImageProcessor.Web/Processors/Mask.cs
@@ -11,7 +11,6 @@
 
 namespace ImageProcessor.Web.Processors
 {
-    using System;
     using System.Collections.Specialized;
     using System.Drawing;
     using System.IO;
@@ -38,10 +37,7 @@ namespace ImageProcessor.Web.Processors
         /// <summary>
         /// Initializes a new instance of the <see cref="Mask"/> class.
         /// </summary>
-        public Mask()
-        {
-            this.Processor = new ImageProcessor.Processors.Mask();
-        }
+        public Mask() => this.Processor = new ImageProcessor.Processors.Mask();
 
         /// <summary>
         /// Gets the regular expression to search strings for.
@@ -99,8 +95,7 @@ namespace ImageProcessor.Web.Processors
             Image image = null;
 
             // Correctly parse the path.
-            string path;
-            this.Processor.Settings.TryGetValue("VirtualPath", out path);
+            this.Processor.Settings.TryGetValue("VirtualPath", out string path);
 
             if (!string.IsNullOrWhiteSpace(path) && path.StartsWith("~/"))
             {
@@ -110,7 +105,7 @@ namespace ImageProcessor.Web.Processors
                     imagePath = Path.Combine(imagePath, input);
                     try
                     {
-                        using (ImageFactory factory = new ImageFactory())
+                        using (var factory = new ImageFactory())
                         {
                             factory.Load(imagePath);
                             image = new Bitmap(factory.Image);

--- a/src/ImageProcessor.Web/Processors/Meta.cs
+++ b/src/ImageProcessor.Web/Processors/Meta.cs
@@ -21,15 +21,12 @@ namespace ImageProcessor.Web.Processors
         /// <summary>
         /// The regular expression to search strings for.
         /// </summary>
-        private static readonly Regex QueryRegex = new Regex(@"meta=(true|false)", RegexOptions.Compiled);
+        private static readonly Regex QueryRegex = new Regex("meta=(true|false)", RegexOptions.Compiled);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Meta"/> class.
         /// </summary>
-        public Meta()
-        {
-            this.Processor = new ImageProcessor.Processors.Meta();
-        }
+        public Meta() => this.Processor = new ImageProcessor.Processors.Meta();
 
         /// <summary>
         /// Gets the regular expression to search strings for.
@@ -62,8 +59,7 @@ namespace ImageProcessor.Web.Processors
             if (match.Success)
             {
                 this.SortOrder = match.Index;
-                bool preserve = bool.Parse(match.Value.Split('=')[1]);
-                this.Processor.DynamicParameter = preserve;
+                this.Processor.DynamicParameter = (bool)bool.Parse(match.Value.Split('=')[1]);
             }
 
             return this.SortOrder;

--- a/src/ImageProcessor.Web/Processors/Overlay.cs
+++ b/src/ImageProcessor.Web/Processors/Overlay.cs
@@ -37,10 +37,7 @@ namespace ImageProcessor.Web.Processors
         /// <summary>
         /// Initializes a new instance of the <see cref="Overlay"/> class.
         /// </summary>
-        public Overlay()
-        {
-            this.Processor = new ImageProcessor.Processors.Overlay();
-        }
+        public Overlay() => this.Processor = new ImageProcessor.Processors.Overlay();
 
         /// <summary>
         /// Gets the regular expression to search strings for.
@@ -77,8 +74,8 @@ namespace ImageProcessor.Web.Processors
 
                 Point? position = queryCollection["overlay.position"] != null
                       ? QueryParamParser.Instance.ParseValue<Point>(queryCollection["overlay.position"])
-                      : (Point?)null; 
-                
+                      : (Point?)null;
+
                 int opacity = queryCollection["overlay.opacity"] != null
                                   ? QueryParamParser.Instance.ParseValue<int>(queryCollection["overlay.opacity"])
                                   : 100;
@@ -110,8 +107,7 @@ namespace ImageProcessor.Web.Processors
             Image image = null;
 
             // Correctly parse the path.
-            string path;
-            this.Processor.Settings.TryGetValue("VirtualPath", out path);
+            this.Processor.Settings.TryGetValue("VirtualPath", out string path);
 
             if (!string.IsNullOrWhiteSpace(path) && path.StartsWith("~/"))
             {
@@ -121,7 +117,7 @@ namespace ImageProcessor.Web.Processors
                     imagePath = Path.Combine(imagePath, input);
                     try
                     {
-                        using (ImageFactory factory = new ImageFactory())
+                        using (var factory = new ImageFactory())
                         {
                             factory.Load(imagePath);
                             image = new Bitmap(factory.Image);

--- a/src/ImageProcessor.Web/Processors/Pixelate.cs
+++ b/src/ImageProcessor.Web/Processors/Pixelate.cs
@@ -13,13 +13,10 @@ namespace ImageProcessor.Web.Processors
     using System;
     using System.Collections.Specialized;
     using System.Drawing;
-    using System.Globalization;
-    using System.Text;
     using System.Text.RegularExpressions;
     using System.Web;
 
     using ImageProcessor.Processors;
-    using ImageProcessor.Web.Extensions;
     using ImageProcessor.Web.Helpers;
 
     /// <summary>
@@ -30,25 +27,12 @@ namespace ImageProcessor.Web.Processors
         /// <summary>
         /// The regular expression to search strings for.
         /// </summary>
-        private static readonly Regex QueryRegex = new Regex(@"pixelate=[^&]", RegexOptions.Compiled);
-
-        /// <summary>
-        /// The pixel regex.
-        /// </summary>
-        private static readonly Regex PixelRegex = new Regex(@"pixelate=\d+", RegexOptions.Compiled);
-
-        /// <summary>
-        /// The rectangle regex.
-        /// </summary>
-        private static readonly Regex RectangleRegex = new Regex(@"pixelrect=\d+,\d+,\d+,\d+", RegexOptions.Compiled);
+        private static readonly Regex QueryRegex = new Regex("pixelate=[^&]", RegexOptions.Compiled);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Pixelate"/> class.
         /// </summary>
-        public Pixelate()
-        {
-            this.Processor = new ImageProcessor.Processors.Pixelate();
-        }
+        public Pixelate() => this.Processor = new ImageProcessor.Processors.Pixelate();
 
         /// <summary>
         /// Gets the regular expression to search strings for.
@@ -85,59 +69,12 @@ namespace ImageProcessor.Web.Processors
 
                 Rectangle? rectangle = queryCollection["pixelrect"] != null
                       ? QueryParamParser.Instance.ParseValue<Rectangle>(queryCollection["pixelrect"])
-                      : (Rectangle?)null; 
+                      : (Rectangle?)null;
 
                 this.Processor.DynamicParameter = new Tuple<int, Rectangle?>(size, rectangle);
             }
 
             return this.SortOrder;
-        }
-
-        /// <summary>
-        /// Returns the correct size of pixels.
-        /// </summary>
-        /// <param name="input">
-        /// The input containing the value to parse.
-        /// </param>
-        /// <returns>
-        /// The <see cref="int"/> representing the pixel size.
-        /// </returns>
-        public int ParseSize(string input)
-        {
-            int size = 0;
-
-            foreach (Match match in PixelRegex.Matches(input))
-            {
-                size = int.Parse(match.Value.Split('=')[1], CultureInfo.InvariantCulture);
-            }
-
-            return size;
-        }
-
-        /// <summary>
-        /// Returns the correct <see cref="Nullable{Rectange}"/> for the given string.
-        /// </summary>
-        /// <param name="input">
-        /// The input string containing the value to parse.
-        /// </param>
-        /// <returns>
-        /// The correct <see cref="Nullable{Rectange}"/>
-        /// </returns>
-        private Rectangle? ParseRectangle(string input)
-        {
-            int[] dimensions = { };
-
-            foreach (Match match in RectangleRegex.Matches(input))
-            {
-                dimensions = match.Value.ToPositiveIntegerArray();
-            }
-
-            if (dimensions.Length == 4)
-            {
-                return new Rectangle(dimensions[0], dimensions[1], dimensions[2], dimensions[3]);
-            }
-
-            return null;
         }
     }
 }

--- a/src/ImageProcessor.Web/Processors/Quality.cs
+++ b/src/ImageProcessor.Web/Processors/Quality.cs
@@ -31,10 +31,7 @@ namespace ImageProcessor.Web.Processors
         /// <summary>
         /// Initializes a new instance of the <see cref="Quality"/> class.
         /// </summary>
-        public Quality()
-        {
-            this.Processor = new ImageProcessor.Processors.Quality();
-        }
+        public Quality() => this.Processor = new ImageProcessor.Processors.Quality();
 
         /// <summary>
         /// Gets the regular expression to search strings for.

--- a/src/ImageProcessor.Web/Processors/ReplaceColor.cs
+++ b/src/ImageProcessor.Web/Processors/ReplaceColor.cs
@@ -28,15 +28,12 @@ namespace ImageProcessor.Web.Processors
         /// <summary>
         /// The regular expression to search strings for.
         /// </summary>
-        private static readonly Regex QueryRegex = new Regex(@"replace=[^&]", RegexOptions.Compiled);
+        private static readonly Regex QueryRegex = new Regex("replace=[^&]", RegexOptions.Compiled);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ReplaceColor"/> class.
         /// </summary>
-        public ReplaceColor()
-        {
-            this.Processor = new ImageProcessor.Processors.ReplaceColor();
-        }
+        public ReplaceColor() => this.Processor = new ImageProcessor.Processors.ReplaceColor();
 
         /// <summary>
         /// Gets the regular expression to search strings for.

--- a/src/ImageProcessor.Web/Processors/Resize.cs
+++ b/src/ImageProcessor.Web/Processors/Resize.cs
@@ -36,10 +36,7 @@ namespace ImageProcessor.Web.Processors
         /// <summary>
         /// Initializes a new instance of the <see cref="Resize"/> class.
         /// </summary>
-        public Resize()
-        {
-            this.Processor = new ImageProcessor.Processors.Resize();
-        }
+        public Resize() => this.Processor = new ImageProcessor.Processors.Resize();
 
         /// <summary>
         /// Gets the regular expression to search strings for.
@@ -82,7 +79,7 @@ namespace ImageProcessor.Web.Processors
                                     ? QueryParamParser.Instance.ParseValue<float[]>(queryCollection["center"]) :
                                     new float[] { };
 
-                ResizeLayer resizeLayer = new ResizeLayer(size)
+                this.Processor.DynamicParameter = (ResizeLayer)new ResizeLayer(size)
                 {
                     ResizeMode = mode,
                     AnchorPosition = position,
@@ -90,15 +87,12 @@ namespace ImageProcessor.Web.Processors
                     CenterCoordinates = center
                 };
 
-                this.Processor.DynamicParameter = resizeLayer;
-
                 // Correctly parse any restrictions.
-                string restrictions;
-                this.Processor.Settings.TryGetValue("RestrictTo", out restrictions);
+                this.Processor.Settings.TryGetValue("RestrictTo", out string restrictions);
 
                 List<Size> restrictedSizes = this.ParseRestrictions(restrictions);
 
-                if (restrictedSizes != null && restrictedSizes.Any())
+                if (restrictedSizes?.Count > 0)
                 {
                     bool reject = true;
                     foreach (Size restrictedSize in restrictedSizes)
@@ -143,7 +137,7 @@ namespace ImageProcessor.Web.Processors
             string height = queryCollection["height"];
             string widthRatio = queryCollection["widthratio"];
             string heightRatio = queryCollection["heightratio"];
-            Size size = new Size();
+            var size = new Size();
 
             // Umbraco calls the API incorrectly so we have to deal with floats.
             // We round up so that single pixel lines are not produced.
@@ -202,7 +196,7 @@ namespace ImageProcessor.Web.Processors
         /// </returns>
         private List<Size> ParseRestrictions(string input)
         {
-            List<Size> sizes = new List<Size>();
+            var sizes = new List<Size>();
 
             if (!string.IsNullOrWhiteSpace(input))
             {

--- a/src/ImageProcessor.Web/Processors/Rotate.cs
+++ b/src/ImageProcessor.Web/Processors/Rotate.cs
@@ -25,15 +25,12 @@ namespace ImageProcessor.Web.Processors
         /// <summary>
         /// The regular expression to search strings for.
         /// </summary>
-        private static readonly Regex QueryRegex = new Regex(@"rotate=[^&]", RegexOptions.Compiled);
+        private static readonly Regex QueryRegex = new Regex("rotate=[^&]", RegexOptions.Compiled);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Rotate"/> class.
         /// </summary>
-        public Rotate()
-        {
-            this.Processor = new ImageProcessor.Processors.Rotate();
-        }
+        public Rotate() => this.Processor = new ImageProcessor.Processors.Rotate();
 
         /// <summary>
         /// Gets the regular expression to search strings for.

--- a/src/ImageProcessor.Web/Processors/RotateBounded.cs
+++ b/src/ImageProcessor.Web/Processors/RotateBounded.cs
@@ -26,20 +26,17 @@ namespace ImageProcessor.Web.Processors
         /// <summary>
         /// The regular expression to search strings for.
         /// </summary>
-        private static readonly Regex QueryRegex = new Regex(@"rotatebounded=[^&]", RegexOptions.Compiled);
+        private static readonly Regex QueryRegex = new Regex("rotatebounded=[^&]", RegexOptions.Compiled);
 
         /// <summary>
         /// The regular expression to search for.
         /// </summary>
-        private static readonly Regex BoundRegex = new Regex(@"rotatebounded.keepsize=true", RegexOptions.Compiled);
+        private static readonly Regex BoundRegex = new Regex("rotatebounded.keepsize=true", RegexOptions.Compiled);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RotateBounded"/> class.
         /// </summary>
-        public RotateBounded()
-        {
-            this.Processor = new ImageProcessor.Processors.RotateBounded();
-        }
+        public RotateBounded() => this.Processor = new ImageProcessor.Processors.RotateBounded();
 
         /// <summary>
         /// Gets the regular expression to search strings for.

--- a/src/ImageProcessor.Web/Processors/RoundedCorners.cs
+++ b/src/ImageProcessor.Web/Processors/RoundedCorners.cs
@@ -31,10 +31,7 @@ namespace ImageProcessor.Web.Processors
         /// <summary>
         /// Initializes a new instance of the <see cref="RoundedCorners"/> class.
         /// </summary>
-        public RoundedCorners()
-        {
-            this.Processor = new ImageProcessor.Processors.RoundedCorners();
-        }
+        public RoundedCorners() => this.Processor = new ImageProcessor.Processors.RoundedCorners();
 
         /// <summary>
         /// Gets the regular expression to search strings for.
@@ -68,14 +65,12 @@ namespace ImageProcessor.Web.Processors
                 this.SortOrder = match.Index;
                 NameValueCollection queryCollection = HttpUtility.ParseQueryString(queryString);
 
-                RoundedCornerLayer roundedCornerLayer = new RoundedCornerLayer(
+                this.Processor.DynamicParameter = (RoundedCornerLayer)new RoundedCornerLayer(
                     QueryParamParser.Instance.ParseValue<int>(queryCollection["roundedcorners"]),
                     this.ParseCorner(queryCollection, "tl"),
                     this.ParseCorner(queryCollection, "tr"),
                     this.ParseCorner(queryCollection, "bl"),
                     this.ParseCorner(queryCollection, "br"));
-
-                this.Processor.DynamicParameter = roundedCornerLayer;
             }
 
             return this.SortOrder;
@@ -93,9 +88,6 @@ namespace ImageProcessor.Web.Processors
         /// <returns>
         /// The correct <see cref="T:System.Boolean"/> true or false.
         /// </returns>
-        private bool ParseCorner(NameValueCollection queryCollection, string key)
-        {
-            return queryCollection[key] == null || QueryParamParser.Instance.ParseValue<bool>(queryCollection[key]);
-        }
+        private bool ParseCorner(NameValueCollection queryCollection, string key) => queryCollection[key] == null || QueryParamParser.Instance.ParseValue<bool>(queryCollection[key]);
     }
 }

--- a/src/ImageProcessor.Web/Processors/Saturation.cs
+++ b/src/ImageProcessor.Web/Processors/Saturation.cs
@@ -31,10 +31,7 @@ namespace ImageProcessor.Web.Processors
         /// <summary>
         /// Initializes a new instance of the <see cref="Saturation"/> class.
         /// </summary>
-        public Saturation()
-        {
-            this.Processor = new ImageProcessor.Processors.Saturation();
-        }
+        public Saturation() => this.Processor = new ImageProcessor.Processors.Saturation();
 
         /// <summary>
         /// Gets the regular expression to search strings for.

--- a/src/ImageProcessor.Web/Processors/Tint.cs
+++ b/src/ImageProcessor.Web/Processors/Tint.cs
@@ -26,15 +26,12 @@ namespace ImageProcessor.Web.Processors
         /// <summary>
         /// The regular expression to search strings for.
         /// </summary>
-        private static readonly Regex QueryRegex = new Regex(@"tint=[^&]", RegexOptions.Compiled);
+        private static readonly Regex QueryRegex = new Regex("tint=[^&]", RegexOptions.Compiled);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Tint"/> class.
         /// </summary>
-        public Tint()
-        {
-            this.Processor = new ImageProcessor.Processors.Tint();
-        }
+        public Tint() => this.Processor = new ImageProcessor.Processors.Tint();
 
         /// <summary>
         /// Gets the regular expression to search strings for.

--- a/src/ImageProcessor.Web/Processors/Vignette.cs
+++ b/src/ImageProcessor.Web/Processors/Vignette.cs
@@ -26,15 +26,12 @@ namespace ImageProcessor.Web.Processors
         /// <summary>
         /// The regular expression to search strings for.
         /// </summary>
-        private static readonly Regex QueryRegex = new Regex(@"vignette(=true)?[^&]+", RegexOptions.Compiled);
+        private static readonly Regex QueryRegex = new Regex("vignette(=true)?[^&]+", RegexOptions.Compiled);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Vignette"/> class.
         /// </summary>
-        public Vignette()
-        {
-            this.Processor = new ImageProcessor.Processors.Vignette();
-        }
+        public Vignette() => this.Processor = new ImageProcessor.Processors.Vignette();
 
         /// <summary>
         /// Gets the regular expression to search strings for.

--- a/src/ImageProcessor.Web/Processors/Watermark.cs
+++ b/src/ImageProcessor.Web/Processors/Watermark.cs
@@ -28,15 +28,12 @@ namespace ImageProcessor.Web.Processors
         /// <summary>
         /// The regular expression to search strings for.
         /// </summary>
-        private static readonly Regex QueryRegex = new Regex(@"watermark=", RegexOptions.Compiled);
+        private static readonly Regex QueryRegex = new Regex("watermark=", RegexOptions.Compiled);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Watermark"/> class.
         /// </summary>
-        public Watermark()
-        {
-            this.Processor = new ImageProcessor.Processors.Watermark();
-        }
+        public Watermark() => this.Processor = new ImageProcessor.Processors.Watermark();
 
         /// <summary>
         /// Gets the regular expression to search strings for.
@@ -71,7 +68,7 @@ namespace ImageProcessor.Web.Processors
             {
                 this.SortOrder = match.Index;
                 NameValueCollection queryCollection = HttpUtility.ParseQueryString(queryString);
-                TextLayer textLayer = new TextLayer
+                var textLayer = new TextLayer
                 {
                     Text = this.ParseText(queryCollection),
                     Position = this.ParsePosition(queryCollection),
@@ -92,7 +89,6 @@ namespace ImageProcessor.Web.Processors
             return this.SortOrder;
         }
 
-        #region Private Methods
         /// <summary>
         /// Returns the correct <see cref="T:System.String"/> for the given parameter collection.
         /// </summary>
@@ -102,10 +98,7 @@ namespace ImageProcessor.Web.Processors
         /// <returns>
         /// The correct <see cref="T:System.String"/>.
         /// </returns>
-        private string ParseText(NameValueCollection queryCollection)
-        {
-            return QueryParamParser.Instance.ParseValue<string>(queryCollection["watermark"]);
-        }
+        private string ParseText(NameValueCollection queryCollection) => QueryParamParser.Instance.ParseValue<string>(queryCollection["watermark"]);
 
         /// <summary>
         /// Returns the correct <see cref="T:System.Drawing.Point"/> for the given parameter collection.
@@ -196,10 +189,7 @@ namespace ImageProcessor.Web.Processors
         /// <returns>
         /// True if the watermark is to have a shadow; otherwise false.
         /// </returns>
-        private bool ParseDropShadow(NameValueCollection queryCollection)
-        {
-            return QueryParamParser.Instance.ParseValue<bool>(queryCollection["dropshadow"]);
-        }
+        private bool ParseDropShadow(NameValueCollection queryCollection) => QueryParamParser.Instance.ParseValue<bool>(queryCollection["dropshadow"]);
 
         /// <summary>
         /// Returns the correct <see cref="T:System.Int32"/> containing the opacity for the parameter collection.
@@ -234,10 +224,7 @@ namespace ImageProcessor.Web.Processors
         /// <returns>
         /// True if the watermark is to be written right to left; otherwise false.
         /// </returns>
-        private bool ParseRightToLeft(NameValueCollection queryCollection)
-        {
-            return QueryParamParser.Instance.ParseValue<bool>(queryCollection["rtl"]);
-        }
+        private bool ParseRightToLeft(NameValueCollection queryCollection) => QueryParamParser.Instance.ParseValue<bool>(queryCollection["rtl"]);
 
         /// <summary>
         /// Returns a value indicating whether the watermark is to be written vertically.
@@ -248,10 +235,6 @@ namespace ImageProcessor.Web.Processors
         /// <returns>
         /// True if the watermark is to be written vertically; otherwise false.
         /// </returns>
-        private bool ParseVertical(NameValueCollection queryCollection)
-        {
-            return QueryParamParser.Instance.ParseValue<bool>(queryCollection["vertical"]);
-        }
-        #endregion
+        private bool ParseVertical(NameValueCollection queryCollection) => QueryParamParser.Instance.ParseValue<bool>(queryCollection["vertical"]);
     }
 }

--- a/src/ImageProcessor.Web/Services/LocalFileImageService.cs
+++ b/src/ImageProcessor.Web/Services/LocalFileImageService.cs
@@ -57,10 +57,7 @@ namespace ImageProcessor.Web.Services
         /// <returns>
         /// <c>True</c> if the request is valid; otherwise, <c>False</c>.
         /// </returns>
-        public virtual bool IsValidRequest(string path)
-        {
-            return ImageHelpers.IsValidImageExtension(path);
-        }
+        public virtual bool IsValidRequest(string path) => ImageHelpers.IsValidImageExtension(path);
 
         /// <summary>
         /// Gets the image using the given identifier.
@@ -82,7 +79,7 @@ namespace ImageProcessor.Web.Services
                 throw new HttpException((int)HttpStatusCode.NotFound, $"No image exists at {path}");
             }
 
-            using (FileStream file = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read, 4096, true))
+            using (var file = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read, 4096, true))
             {
                 buffer = new byte[file.Length];
                 await file.ReadAsync(buffer, 0, (int)file.Length).ConfigureAwait(false);

--- a/src/ImageProcessor/Common/Exceptions/ImageFormatException.cs
+++ b/src/ImageProcessor/Common/Exceptions/ImageFormatException.cs
@@ -11,6 +11,7 @@
 namespace ImageProcessor.Common.Exceptions
 {
     using System;
+    using System.Runtime.Serialization;
 
     /// <summary>
     /// The exception that is thrown when loading the supported image format types has failed.
@@ -34,6 +35,25 @@ namespace ImageProcessor.Common.Exceptions
         /// <param name="innerException">The exception that is the cause of the current exception, or a null reference (Nothing in Visual Basic) if no inner exception is specified.</param>
         public ImageFormatException(string message, Exception innerException)
             : base(message, innerException)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ImageFormatException" /> class.
+        /// </summary>
+        public ImageFormatException()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ImageFormatException" /> class with serialized data.
+        /// </summary>
+        /// <param name="info">The <see cref="SerializationInfo" /> that holds the serialized object data about the exception being thrown. </param>
+        /// <param name="context">The <see cref="StreamingContext" /> that contains contextual information about the source or destination. </param>
+        /// <exception cref="ArgumentNullException">The <paramref name="info" /> parameter is null. </exception>
+        /// <exception cref="SerializationException">The class name is null or <see cref="P:System.Exception.HResult" /> is zero (0). </exception>
+        private ImageFormatException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
         {
         }
     }

--- a/src/ImageProcessor/Common/Exceptions/ImageProcessingException.cs
+++ b/src/ImageProcessor/Common/Exceptions/ImageProcessingException.cs
@@ -11,6 +11,7 @@
 namespace ImageProcessor.Common.Exceptions
 {
     using System;
+    using System.Runtime.Serialization;
 
     /// <summary>
     /// The exception that is thrown when processing an image has failed.
@@ -34,6 +35,25 @@ namespace ImageProcessor.Common.Exceptions
         /// <param name="innerException">The exception that is the cause of the current exception, or a null reference (Nothing in Visual Basic) if no inner exception is specified.</param>
         public ImageProcessingException(string message, Exception innerException)
             : base(message, innerException)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ImageProcessingException" /> class.
+        /// </summary>
+        public ImageProcessingException()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ImageProcessingException" /> class with serialized data.
+        /// </summary>
+        /// <param name="info">The <see cref="SerializationInfo" /> that holds the serialized object data about the exception being thrown. </param>
+        /// <param name="context">The <see cref="StreamingContext" /> that contains contextual information about the source or destination. </param>
+        /// <exception cref="ArgumentNullException">The <paramref name="info" /> parameter is null. </exception>
+        /// <exception cref="SerializationException">The class name is null or <see cref="P:System.Exception.HResult" /> is zero (0). </exception>
+        private ImageProcessingException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
         {
         }
     }

--- a/src/ImageProcessor/Common/Exceptions/Logging/DefaultLogger.cs
+++ b/src/ImageProcessor/Common/Exceptions/Logging/DefaultLogger.cs
@@ -27,10 +27,7 @@ namespace ImageProcessor.Common.Exceptions
         /// <param name="text">The message to log.</param>
         /// <param name="callerName">The property or method name calling the log.</param>
         /// <param name="lineNumber">The line number where the method is called.</param>
-        public void Log<T>(string text, [CallerMemberName] string callerName = null, [CallerLineNumber] int lineNumber = 0)
-        {
-            this.LogInternal(typeof(T), text, callerName, lineNumber);
-        }
+        public void Log<T>(string text, [CallerMemberName] string callerName = null, [CallerLineNumber] int lineNumber = 0) => this.LogInternal(typeof(T), text, callerName, lineNumber);
 
         /// <summary>
         /// Logs the specified message.
@@ -39,22 +36,19 @@ namespace ImageProcessor.Common.Exceptions
         /// <param name="text">The message to log.</param>
         /// <param name="callerName">The property or method name calling the log.</param>
         /// <param name="lineNumber">The line number where the method is called.</param>
-        public void Log(Type type, string text, [CallerMemberName] string callerName = null, [CallerLineNumber] int lineNumber = 0)
-        {
-            this.LogInternal(type, text, callerName, lineNumber);
-        }
+        public void Log(Type type, string text, [CallerMemberName] string callerName = null, [CallerLineNumber] int lineNumber = 0) => this.LogInternal(type, text, callerName, lineNumber);
 
-		/// <summary>
-		/// Logs the specified message.
-		/// </summary>
-		/// <param name="type">The type calling the logger.</param>
-		/// <param name="text">The message to log.</param>
-		/// <param name="callerName">The property or method name calling the log.</param>
-		/// <param name="lineNumber">The line number where the method is called.</param>
-		[Conditional("TRACE")]
-		private void LogInternal(Type type, string text, string callerName = null, int lineNumber = 0)
+        /// <summary>
+        /// Logs the specified message.
+        /// </summary>
+        /// <param name="type">The type calling the logger.</param>
+        /// <param name="text">The message to log.</param>
+        /// <param name="callerName">The property or method name calling the log.</param>
+        /// <param name="lineNumber">The line number where the method is called.</param>
+        [Conditional("TRACE")]
+        private void LogInternal(Type type, string text, string callerName = null, int lineNumber = 0)
         {
-            string message = String.Format("{0} - {1}: {2} {3}:{4}", DateTime.UtcNow.ToString("s"), type.Name, callerName, lineNumber, text);
+            string message = string.Format("{0} - {1}: {2} {3}:{4}", DateTime.UtcNow.ToString("s"), type.Name, callerName, lineNumber, text);
 
             Trace.WriteLine(message);
         }

--- a/src/ImageProcessor/Common/Exceptions/QuantizationException.cs
+++ b/src/ImageProcessor/Common/Exceptions/QuantizationException.cs
@@ -11,6 +11,7 @@
 namespace ImageProcessor.Common.Exceptions
 {
     using System;
+    using System.Runtime.Serialization;
 
     /// <summary>
     /// The exception that is thrown when quantizing an image has failed.
@@ -36,6 +37,25 @@ namespace ImageProcessor.Common.Exceptions
         /// <param name="innerException">The exception that is the cause of the current exception, or a null reference (Nothing in Visual Basic) if no inner exception is specified.</param>
         public QuantizationException(string message, Exception innerException)
             : base(message, innerException)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="QuantizationException" /> class.
+        /// </summary>
+        public QuantizationException()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="QuantizationException" /> class with serialized data.
+        /// </summary>
+        /// <param name="info">The <see cref="SerializationInfo" /> that holds the serialized object data about the exception being thrown. </param>
+        /// <param name="context">The <see cref="StreamingContext" /> that contains contextual information about the source or destination. </param>
+        /// <exception cref="ArgumentNullException">The <paramref name="info" /> parameter is null. </exception>
+        /// <exception cref="SerializationException">The class name is null or <see cref="P:System.Exception.HResult" /> is zero (0). </exception>
+        private QuantizationException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
         {
         }
     }

--- a/src/ImageProcessor/Common/Extensions/AssemblyExtensions.cs
+++ b/src/ImageProcessor/Common/Extensions/AssemblyExtensions.cs
@@ -68,7 +68,7 @@ namespace ImageProcessor.Common.Extensions
         {
             encoding = encoding ?? Encoding.UTF8;
 
-            using (MemoryStream ms = new MemoryStream())
+            using (var ms = new MemoryStream())
             {
                 using (Stream manifestResourceStream = assembly.GetManifestResourceStream(resource))
                 {
@@ -89,7 +89,7 @@ namespace ImageProcessor.Common.Extensions
         public static FileInfo GetAssemblyFile(this Assembly assembly)
         {
             string codeBase = assembly.CodeBase;
-            Uri uri = new Uri(codeBase);
+            var uri = new Uri(codeBase);
             string path = uri.LocalPath;
             return new FileInfo(path);
         }
@@ -104,7 +104,7 @@ namespace ImageProcessor.Common.Extensions
         public static FileInfo GetAssemblyFile(this AssemblyName assemblyName)
         {
             string codeBase = assemblyName.CodeBase;
-            Uri uri = new Uri(codeBase);
+            var uri = new Uri(codeBase);
             string path = uri.LocalPath;
             return new FileInfo(path);
         }

--- a/src/ImageProcessor/Common/Extensions/DoubleExtensions.cs
+++ b/src/ImageProcessor/Common/Extensions/DoubleExtensions.cs
@@ -32,9 +32,6 @@ namespace ImageProcessor.Common.Extensions
         /// <returns>
         /// The <see cref="T:System.Byte"/>.
         /// </returns>
-        public static byte ToByte(this double value)
-        {
-            return Convert.ToByte(ImageMaths.Clamp(value, 0, 255));
-        }
+        public static byte ToByte(this double value) => Convert.ToByte(ImageMaths.Clamp(value, 0, 255));
     }
 }

--- a/src/ImageProcessor/Common/Extensions/EnumerableExtensions.cs
+++ b/src/ImageProcessor/Common/Extensions/EnumerableExtensions.cs
@@ -33,7 +33,7 @@ namespace ImageProcessor.Common.Extensions
         /// <returns>
         /// The <see cref="IEnumerable{Int32}"/> that contains a range of sequential integral numbers.
         /// </returns>
-        public static IEnumerable<int> SteppedRange(int fromInclusive, int toExclusive, int step)
+        public static IEnumerable<int> SteppedRange(this int fromInclusive, int toExclusive, int step)
         {
             // Borrowed from Enumerable.Range
             long num = (fromInclusive + toExclusive) - 1L;
@@ -60,10 +60,7 @@ namespace ImageProcessor.Common.Extensions
         /// <returns>
         /// The <see cref="IEnumerable{Int32}"/> that contains a range of sequential integral numbers.
         /// </returns>
-        public static IEnumerable<int> SteppedRange(int fromInclusive, Func<int, bool> toDelegate, int step)
-        {
-            return RangeIterator(fromInclusive, toDelegate, step);
-        }
+        public static IEnumerable<int> SteppedRange(this int fromInclusive, Func<int, bool> toDelegate, int step) => RangeIterator(fromInclusive, toDelegate, step);
 
         /// <summary>
         /// Generates a sequence of integral numbers within a specified range.

--- a/src/ImageProcessor/Common/Extensions/FloatExtensions.cs
+++ b/src/ImageProcessor/Common/Extensions/FloatExtensions.cs
@@ -32,9 +32,6 @@ namespace ImageProcessor.Common.Extensions
         /// <returns>
         /// The <see cref="T:System.Byte"/>.
         /// </returns>
-        public static byte ToByte(this float value)
-        {
-            return Convert.ToByte(ImageMaths.Clamp(value, 0, 255));
-        }
+        public static byte ToByte(this float value) => Convert.ToByte(ImageMaths.Clamp(value, 0, 255));
     }
 }

--- a/src/ImageProcessor/Common/Extensions/ImageExtensions.cs
+++ b/src/ImageProcessor/Common/Extensions/ImageExtensions.cs
@@ -42,11 +42,11 @@ namespace ImageProcessor.Common.Extensions
             {
                 // Read from the correct first frame when performing additional processing
                 source.SelectActiveFrame(FrameDimension.Time, 0);
-                GifDecoder decoder = new GifDecoder(source, animationProcessMode);
-                GifEncoder encoder = new GifEncoder(null, null, decoder.LoopCount);
+                var decoder = new GifDecoder(source, animationProcessMode);
+                var encoder = new GifEncoder(null, null, decoder.LoopCount);
 
                 // Have to use Octree here, there's no way to inject it.
-                OctreeQuantizer quantizer = new OctreeQuantizer();
+                var quantizer = new OctreeQuantizer();
                 for (int i = 0; i < decoder.FrameCount; i++)
                 {
                     GifFrame frame = decoder.GetFrame(source, i);
@@ -59,9 +59,9 @@ namespace ImageProcessor.Common.Extensions
             }
 
             // Create a new image and copy it's pixels.
-            Bitmap copy = new Bitmap(source.Width, source.Height, format);
+            var copy = new Bitmap(source.Width, source.Height, format);
             copy.SetResolution(source.HorizontalResolution, source.VerticalResolution);
-            using (Graphics graphics = Graphics.FromImage(copy))
+            using (var graphics = Graphics.FromImage(copy))
             {
                 graphics.DrawImageUnscaled(source, 0, 0);
             }
@@ -89,9 +89,6 @@ namespace ImageProcessor.Common.Extensions
         /// <returns>
         /// The <see cref="Image"/>.
         /// </returns>
-        public static Image Copy(this Image source, PixelFormat format = PixelFormat.Format32bppPArgb)
-        {
-            return Copy(source, AnimationProcessMode.All, format);
-        }
+        public static Image Copy(this Image source, PixelFormat format = PixelFormat.Format32bppPArgb) => Copy(source, AnimationProcessMode.All, format);
     }
 }

--- a/src/ImageProcessor/Common/Extensions/IntegerExtensions.cs
+++ b/src/ImageProcessor/Common/Extensions/IntegerExtensions.cs
@@ -11,7 +11,6 @@
 namespace ImageProcessor.Common.Extensions
 {
     using System;
-    using System.Globalization;
 
     using ImageProcessor.Imaging.Helpers;
 
@@ -33,21 +32,6 @@ namespace ImageProcessor.Common.Extensions
         /// <returns>
         /// The <see cref="T:System.Byte"/>.
         /// </returns>
-        public static byte ToByte(this int value)
-        {
-            return Convert.ToByte(ImageMaths.Clamp(value, 0, 255));
-        }
-
-        /// <summary>
-        /// Converts the string representation of a number in a specified culture-specific format to its 
-        /// 32-bit signed integer equivalent using invariant culture.
-        /// </summary>
-        /// <param name="value">The integer.</param>
-        /// <param name="toParse">A string containing a number to convert.</param>
-        /// <returns>A 32-bit signed integer equivalent to the number specified in toParse.</returns>
-        public static int ParseInvariant(this int value, string toParse)
-        {
-            return int.Parse(toParse, CultureInfo.InvariantCulture);
-        }
+        public static byte ToByte(this int value) => Convert.ToByte(ImageMaths.Clamp(value, 0, 255));
     }
 }

--- a/src/ImageProcessor/Common/Extensions/RectangleExtensions.cs
+++ b/src/ImageProcessor/Common/Extensions/RectangleExtensions.cs
@@ -29,10 +29,10 @@ namespace ImageProcessor.Common.Extensions
         /// </returns>
         public static bool IsEqual(this Rectangle first, Rectangle second, int threshold)
         {
-            return (Math.Abs(first.X - second.X) < threshold) &&
-                   (Math.Abs(first.Y - second.Y) < threshold) &&
-                   (Math.Abs(first.Width - second.Width) < threshold) &&
-                   (Math.Abs(first.Height - second.Height) < threshold);
+            return (Math.Abs(first.X - second.X) < threshold)
+                   && (Math.Abs(first.Y - second.Y) < threshold)
+                   && (Math.Abs(first.Width - second.Width) < threshold)
+                   && (Math.Abs(first.Height - second.Height) < threshold);
         }
     }
 }

--- a/src/ImageProcessor/Common/Helpers/IOHelper.cs
+++ b/src/ImageProcessor/Common/Helpers/IOHelper.cs
@@ -26,7 +26,7 @@ namespace ImageProcessor.Common.Helpers
     /// Adapted from identically named class within <see href="https://github.com/umbraco/Umbraco-CMS"/>
     /// </remarks>
     /// </summary>
-    internal class IOHelper
+    internal static class IOHelper
     {
         /// <summary>
         /// The root directory.
@@ -111,13 +111,13 @@ namespace ImageProcessor.Common.Helpers
         /// The <see cref="string"/> representing the root path of the currently running application.</returns>
         internal static string GetRootDirectorySafe()
         {
-            if (string.IsNullOrEmpty(rootDirectory) == false)
+            if (!string.IsNullOrEmpty(rootDirectory))
             {
                 return rootDirectory;
             }
 
             string codeBase = Assembly.GetExecutingAssembly().CodeBase;
-            Uri uri = new Uri(codeBase);
+            var uri = new Uri(codeBase);
             string path = uri.LocalPath;
             string baseDirectory = Path.GetDirectoryName(path);
             if (string.IsNullOrEmpty(baseDirectory))

--- a/src/ImageProcessor/Configuration/ImageProcessorBootstrapper.cs
+++ b/src/ImageProcessor/Configuration/ImageProcessorBootstrapper.cs
@@ -22,7 +22,7 @@ namespace ImageProcessor.Configuration
     /// <summary>
     /// The ImageProcessor bootstrapper containing initialization code for extending ImageProcessor.
     /// </summary>
-    public class ImageProcessorBootstrapper
+    public sealed class ImageProcessorBootstrapper
     {
         /// <summary>
         /// A new instance Initializes a new instance of the <see cref="ImageProcessorBootstrapper"/> class.
@@ -59,7 +59,7 @@ namespace ImageProcessor.Configuration
         /// <summary>
         /// Gets the native binary factory for registering embedded (unmanaged) binaries.
         /// </summary>
-        public NativeBinaryFactory NativeBinaryFactory { get; private set; }
+        public NativeBinaryFactory NativeBinaryFactory { get; }
 
         /// <summary>
         /// Adds the given image formats to the supported format list. Useful for when 
@@ -68,27 +68,21 @@ namespace ImageProcessor.Configuration
         /// <param name="format">
         /// The <see cref="ISupportedImageFormat"/> instance to add.
         /// </param>
-        public void AddImageFormats(params ISupportedImageFormat[] format)
-        {
-            ((List<ISupportedImageFormat>)this.SupportedImageFormats).AddRange(format);
-        }
+        public void AddImageFormats(params ISupportedImageFormat[] format) => ((List<ISupportedImageFormat>)this.SupportedImageFormats).AddRange(format);
 
         /// <summary>
         /// Allows the setting of the default logger. Useful for when 
         /// the type finder fails to dynamically add the custom logger implementation.
         /// </summary>
         /// <param name="logger"></param>
-        public void SetLogger(ILogger logger)
-        {
-            this.Logger = logger;
-        }
+        public void SetLogger(ILogger logger) => this.Logger = logger;
 
         /// <summary>
         /// Creates a list, using reflection, of supported image formats that ImageProcessor can run.
         /// </summary>
         private void LoadSupportedImageFormats()
         {
-            List<ISupportedImageFormat> formats = new List<ISupportedImageFormat>
+            var formats = new List<ISupportedImageFormat>
             {
                 new BitmapFormat(),
                 new GifFormat(),
@@ -100,7 +94,7 @@ namespace ImageProcessor.Configuration
             Type type = typeof(ISupportedImageFormat);
             if (this.SupportedImageFormats == null)
             {
-                List<Type> availableTypes =
+                var availableTypes =
                     TypeFinder.GetAssembliesWithKnownExclusions()
                         .SelectMany(a => a.GetLoadableTypes())
                         .Where(t => type.IsAssignableFrom(t) && t.IsClass && !t.IsAbstract)
@@ -120,7 +114,7 @@ namespace ImageProcessor.Configuration
             Type type = typeof(ILogger);
             if (this.Logger == null)
             {
-                List<Type> availableTypes =
+                var availableTypes =
                     TypeFinder.GetAssembliesWithKnownExclusions()
                         .SelectMany(a => a.GetLoadableTypes())
                         .Where(t => type.IsAssignableFrom(t) && t.IsClass && !t.IsAbstract)

--- a/src/ImageProcessor/Configuration/NativeBinaryFactory.cs
+++ b/src/ImageProcessor/Configuration/NativeBinaryFactory.cs
@@ -48,10 +48,7 @@ namespace ImageProcessor.Configuration
         /// <summary>
         /// Initializes a new instance of the <see cref="NativeBinaryFactory"/> class.
         /// </summary>
-        public NativeBinaryFactory()
-        {
-            nativeBinaries = new ConcurrentDictionary<string, IntPtr>();
-        }
+        public NativeBinaryFactory() => nativeBinaries = new ConcurrentDictionary<string, IntPtr>();
 
         /// <summary>
         /// Finalizes an instance of the <see cref="T:ImageProcessor.Configuration.NativeBinaryFactory">ImageFactory</see> class. 
@@ -96,12 +93,12 @@ namespace ImageProcessor.Configuration
                 {
                     IntPtr pointer;
                     string folder = this.Is64BitEnvironment ? "x64" : "x86";
-                    Assembly assembly = Assembly.GetExecutingAssembly();
+                    var assembly = Assembly.GetExecutingAssembly();
                     string targetBasePath = new Uri(assembly.Location).LocalPath;
-                    string targetPath = Path.GetFullPath(Path.Combine(targetBasePath, "..\\" + folder + "\\" + name));
+                    string targetPath = Path.GetFullPath(Path.Combine(targetBasePath, "..\\" + folder + "\\" + b));
 
                     // Copy the file across if necessary.
-                    FileInfo fileInfo = new FileInfo(targetPath);
+                    var fileInfo = new FileInfo(targetPath);
                     bool rewrite = true;
                     if (fileInfo.Exists)
                     {
@@ -116,7 +113,7 @@ namespace ImageProcessor.Configuration
                     if (rewrite)
                     {
                         // ReSharper disable once AssignNullToNotNullAttribute
-                        DirectoryInfo directoryInfo = new DirectoryInfo(Path.GetDirectoryName(targetPath));
+                        var directoryInfo = new DirectoryInfo(Path.GetDirectoryName(targetPath));
                         if (!directoryInfo.Exists)
                         {
                             directoryInfo.Create();
@@ -137,7 +134,7 @@ namespace ImageProcessor.Configuration
 
                     if (pointer == IntPtr.Zero)
                     {
-                        throw new ApplicationException("Cannot load " + name);
+                        throw new ApplicationException("Cannot load " + b);
                     }
 
                     return pointer;

--- a/src/ImageProcessor/Configuration/NativeMethods.cs
+++ b/src/ImageProcessor/Configuration/NativeMethods.cs
@@ -16,7 +16,7 @@ namespace ImageProcessor.Configuration
     /// <summary>
     /// Provides access to unmanaged native methods.
     /// </summary>
-    internal class NativeMethods
+    internal static class NativeMethods
     {
         /// <summary>
         /// Loads the specified module into the address space of the calling process. 
@@ -56,7 +56,9 @@ namespace ImageProcessor.Configuration
         /// If the function succeeds, the return value is a handle to the module; otherwise null.
         /// </returns>
         [DllImport("libdl")]
+#pragma warning disable IDE1006 // Naming Styles
         public static extern IntPtr dlopen(string libname, int flags);
+#pragma warning restore IDE1006 // Naming Styles
 
         /// <summary>
         /// Frees the loaded dynamic-link library (DLL) module and, if necessary, decrements its reference count. 
@@ -67,6 +69,8 @@ namespace ImageProcessor.Configuration
         /// The LoadLibrary, LoadLibraryEx, GetModuleHandle, or GetModuleHandleEx function returns this handle.</param>
         /// <returns>If the function succeeds, the return value is nonzero; otherwise zero.</returns>
         [DllImport("libdl")]
+#pragma warning disable IDE1006 // Naming Styles
         public static extern int dlclose(IntPtr hModule);
+#pragma warning restore IDE1006 // Naming Styles
     }
 }

--- a/src/ImageProcessor/ImageFactory.cs
+++ b/src/ImageProcessor/ImageFactory.cs
@@ -89,7 +89,7 @@ namespace ImageProcessor
         /// Whether to fix the gamma component of the image.
         /// </param>
         public ImageFactory(bool preserveExifData, bool fixGamma)
-            : this(preserveExifData == false ? MetaDataMode.None : MetaDataMode.All, fixGamma)
+            : this(!preserveExifData ? MetaDataMode.None : MetaDataMode.All, fixGamma)
         {
         }
 
@@ -218,7 +218,7 @@ namespace ImageProcessor
         /// </returns>
         public ImageFactory Load(Stream stream)
         {
-            MemoryStream memoryStream = new MemoryStream();
+            var memoryStream = new MemoryStream();
 
             // Copy the stream. Disposal of the input stream is the responsibility
             // of the user.
@@ -286,13 +286,13 @@ namespace ImageProcessor
         /// </returns>
         public ImageFactory Load(string imagePath)
         {
-            FileInfo fileInfo = new FileInfo(imagePath);
+            var fileInfo = new FileInfo(imagePath);
             if (fileInfo.Exists)
             {
                 this.ImagePath = imagePath;
 
                 // Open a file stream to prevent the need for lock.
-                using (FileStream fileStream = new FileStream(imagePath, FileMode.Open, FileAccess.Read))
+                using (var fileStream = new FileStream(imagePath, FileMode.Open, FileAccess.Read))
                 {
                     ISupportedImageFormat format = FormatUtilities.GetFormat(fileStream);
 
@@ -301,7 +301,7 @@ namespace ImageProcessor
                         throw new ImageFormatException("Input stream is not a supported format.");
                     }
 
-                    MemoryStream memoryStream = new MemoryStream();
+                    var memoryStream = new MemoryStream();
 
                     // Copy the stream.
                     fileStream.CopyTo(memoryStream);
@@ -366,7 +366,7 @@ namespace ImageProcessor
         /// </returns>
         public ImageFactory Load(byte[] bytes)
         {
-            MemoryStream memoryStream = new MemoryStream(bytes);
+            var memoryStream = new MemoryStream(bytes);
 
             ISupportedImageFormat format = FormatUtilities.GetFormat(memoryStream);
 
@@ -428,7 +428,7 @@ namespace ImageProcessor
             // Try saving with the raw format. This might not be possible if the image was created
             // in-memory so we fall back to BMP to keep in line with the default in System.Drawing
             // if no format found.
-            MemoryStream memoryStream = new MemoryStream();
+            var memoryStream = new MemoryStream();
             ISupportedImageFormat format = new BitmapFormat();
             try
             {
@@ -441,8 +441,7 @@ namespace ImageProcessor
                 image.Save(memoryStream, ImageFormat.Bmp);
             }
 
-            IAnimatedImageFormat imageFormat = format as IAnimatedImageFormat;
-            if (imageFormat != null)
+            if (format is IAnimatedImageFormat imageFormat)
             {
                 imageFormat.AnimationProcessMode = this.AnimationProcessMode;
             }
@@ -531,7 +530,7 @@ namespace ImageProcessor
                     return this;
                 }
 
-                Alpha alpha = new Alpha { DynamicParameter = percentage };
+                var alpha = new Alpha { DynamicParameter = percentage };
                 this.backupFormat.ApplyProcessor(alpha.ProcessImage, this);
             }
 
@@ -549,7 +548,7 @@ namespace ImageProcessor
         {
             if (this.ShouldProcess)
             {
-                AutoRotate autoRotate = new AutoRotate();
+                var autoRotate = new AutoRotate();
                 this.backupFormat.ApplyProcessor(autoRotate.ProcessImage, this);
             }
 
@@ -597,7 +596,7 @@ namespace ImageProcessor
                     return this;
                 }
 
-                Brightness brightness = new Brightness { DynamicParameter = percentage };
+                var brightness = new Brightness { DynamicParameter = percentage };
                 this.backupFormat.ApplyProcessor(brightness.ProcessImage, this);
             }
 
@@ -617,7 +616,7 @@ namespace ImageProcessor
         {
             if (this.ShouldProcess)
             {
-                BackgroundColor backgroundColor = new BackgroundColor { DynamicParameter = color };
+                var backgroundColor = new BackgroundColor { DynamicParameter = color };
                 this.backupFormat.ApplyProcessor(backgroundColor.ProcessImage, this);
             }
 
@@ -637,7 +636,7 @@ namespace ImageProcessor
         {
             if (this.ShouldProcess)
             {
-                ResizeLayer layer = new ResizeLayer(size, ResizeMode.Max);
+                var layer = new ResizeLayer(size, ResizeMode.Max);
 
                 return this.Resize(layer);
             }
@@ -665,7 +664,7 @@ namespace ImageProcessor
                     return this;
                 }
 
-                Contrast contrast = new Contrast { DynamicParameter = percentage };
+                var contrast = new Contrast { DynamicParameter = percentage };
                 this.backupFormat.ApplyProcessor(contrast.ProcessImage, this);
             }
 
@@ -685,7 +684,7 @@ namespace ImageProcessor
         {
             if (this.ShouldProcess)
             {
-                CropLayer cropLayer = new CropLayer(rectangle.Left, rectangle.Top, rectangle.Width, rectangle.Height, CropMode.Pixels);
+                var cropLayer = new CropLayer(rectangle.Left, rectangle.Top, rectangle.Width, rectangle.Height, CropMode.Pixels);
                 return this.Crop(cropLayer);
             }
 
@@ -705,7 +704,7 @@ namespace ImageProcessor
         {
             if (this.ShouldProcess)
             {
-                Crop crop = new Crop { DynamicParameter = cropLayer };
+                var crop = new Crop { DynamicParameter = cropLayer };
                 this.backupFormat.ApplyProcessor(crop.ProcessImage, this);
             }
 
@@ -728,7 +727,7 @@ namespace ImageProcessor
         {
             if (this.ShouldProcess)
             {
-                DetectEdges detectEdges = new DetectEdges { DynamicParameter = new Tuple<IEdgeFilter, bool>(filter, greyscale) };
+                var detectEdges = new DetectEdges { DynamicParameter = new Tuple<IEdgeFilter, bool>(filter, greyscale) };
                 this.backupFormat.ApplyProcessor(detectEdges.ProcessImage, this);
             }
 
@@ -760,10 +759,10 @@ namespace ImageProcessor
                     return this;
                 }
 
-                Tuple<int, int, PropertyTagResolutionUnit> resolution =
+                var resolution =
                     new Tuple<int, int, PropertyTagResolutionUnit>(horizontal, vertical, unit);
 
-                Resolution dpi = new Resolution { DynamicParameter = resolution };
+                var dpi = new Resolution { DynamicParameter = resolution };
                 this.backupFormat.ApplyProcessor(dpi.ProcessImage, this);
             }
 
@@ -793,7 +792,7 @@ namespace ImageProcessor
         {
             if (this.ShouldProcess)
             {
-                EntropyCrop autoCrop = new EntropyCrop { DynamicParameter = threshold };
+                var autoCrop = new EntropyCrop { DynamicParameter = threshold };
                 this.backupFormat.ApplyProcessor(autoCrop.ProcessImage, this);
             }
 
@@ -814,7 +813,7 @@ namespace ImageProcessor
         {
             if (this.ShouldProcess)
             {
-                Filter filter = new Filter { DynamicParameter = matrixFilter };
+                var filter = new Filter { DynamicParameter = matrixFilter };
                 this.backupFormat.ApplyProcessor(filter.ProcessImage, this);
             }
 
@@ -849,7 +848,7 @@ namespace ImageProcessor
                         : RotateFlipType.RotateNoneFlipX;
                 }
 
-                Flip flip = new Flip { DynamicParameter = rotateFlipType };
+                var flip = new Flip { DynamicParameter = rotateFlipType };
                 this.backupFormat.ApplyProcessor(flip.ProcessImage, this);
             }
 
@@ -896,7 +895,7 @@ namespace ImageProcessor
                 }
 
                 this.CurrentGamma = value;
-                Gamma gamma = new Gamma { DynamicParameter = value };
+                var gamma = new Gamma { DynamicParameter = value };
                 this.backupFormat.ApplyProcessor(gamma.ProcessImage, this);
             }
 
@@ -922,7 +921,7 @@ namespace ImageProcessor
         {
             if (this.ShouldProcess && size > 0)
             {
-                GaussianLayer layer = new GaussianLayer(size);
+                var layer = new GaussianLayer(size);
                 return this.GaussianBlur(layer);
             }
 
@@ -943,7 +942,7 @@ namespace ImageProcessor
         {
             if (this.ShouldProcess)
             {
-                GaussianBlur gaussianBlur = new GaussianBlur { DynamicParameter = gaussianLayer };
+                var gaussianBlur = new GaussianBlur { DynamicParameter = gaussianLayer };
                 this.backupFormat.ApplyProcessor(gaussianBlur.ProcessImage, this);
             }
 
@@ -969,7 +968,7 @@ namespace ImageProcessor
         {
             if (this.ShouldProcess && size > 0)
             {
-                GaussianLayer layer = new GaussianLayer(size);
+                var layer = new GaussianLayer(size);
                 return this.GaussianSharpen(layer);
             }
 
@@ -990,7 +989,7 @@ namespace ImageProcessor
         {
             if (this.ShouldProcess)
             {
-                GaussianSharpen gaussianSharpen = new GaussianSharpen { DynamicParameter = gaussianLayer };
+                var gaussianSharpen = new GaussianSharpen { DynamicParameter = gaussianLayer };
                 this.backupFormat.ApplyProcessor(gaussianSharpen.ProcessImage, this);
             }
 
@@ -1020,7 +1019,7 @@ namespace ImageProcessor
 
             if (this.ShouldProcess)
             {
-                Hue hue = new Hue { DynamicParameter = new Tuple<int, bool>(degrees, rotate) };
+                var hue = new Hue { DynamicParameter = new Tuple<int, bool>(degrees, rotate) };
                 this.backupFormat.ApplyProcessor(hue.ProcessImage, this);
             }
 
@@ -1040,7 +1039,7 @@ namespace ImageProcessor
         {
             if (this.ShouldProcess)
             {
-                Halftone halftone = new Halftone { DynamicParameter = comicMode };
+                var halftone = new Halftone { DynamicParameter = comicMode };
                 this.backupFormat.ApplyProcessor(halftone.ProcessImage, this);
             }
 
@@ -1065,7 +1064,7 @@ namespace ImageProcessor
         {
             if (this.ShouldProcess)
             {
-                Mask mask = new Mask { DynamicParameter = imageLayer };
+                var mask = new Mask { DynamicParameter = imageLayer };
                 this.backupFormat.ApplyProcessor(mask.ProcessImage, this);
             }
 
@@ -1086,7 +1085,7 @@ namespace ImageProcessor
         {
             if (this.ShouldProcess)
             {
-                Overlay watermark = new Overlay { DynamicParameter = imageLayer };
+                var watermark = new Overlay { DynamicParameter = imageLayer };
                 this.backupFormat.ApplyProcessor(watermark.ProcessImage, this);
             }
 
@@ -1108,7 +1107,7 @@ namespace ImageProcessor
         {
             if (this.ShouldProcess && pixelSize > 0)
             {
-                Pixelate pixelate = new Pixelate { DynamicParameter = new Tuple<int, Rectangle?>(pixelSize, rectangle) };
+                var pixelate = new Pixelate { DynamicParameter = new Tuple<int, Rectangle?>(pixelSize, rectangle) };
                 this.backupFormat.ApplyProcessor(pixelate.ProcessImage, this);
             }
 
@@ -1160,7 +1159,7 @@ namespace ImageProcessor
 
             if (this.ShouldProcess && target != Color.Empty && replacement != Color.Empty)
             {
-                ReplaceColor replaceColor = new ReplaceColor
+                var replaceColor = new ReplaceColor
                 {
                     DynamicParameter = new Tuple<Color, Color, int>(target, replacement, fuzziness)
                 };
@@ -1186,7 +1185,7 @@ namespace ImageProcessor
                 int width = size.Width;
                 int height = size.Height;
 
-                ResizeLayer resizeLayer = new ResizeLayer(new Size(width, height));
+                var resizeLayer = new ResizeLayer(new Size(width, height));
                 return this.Resize(resizeLayer);
             }
 
@@ -1206,13 +1205,13 @@ namespace ImageProcessor
         {
             if (this.ShouldProcess)
             {
-                Dictionary<string, string> resizeSettings = new Dictionary<string, string>
+                var resizeSettings = new Dictionary<string, string>
                 {
                     { "MaxWidth", resizeLayer.Size.Width.ToString("G") },
                     { "MaxHeight", resizeLayer.Size.Height.ToString("G") }
                 };
 
-                Resize resize = new Resize { DynamicParameter = resizeLayer, Settings = resizeSettings };
+                var resize = new Resize { DynamicParameter = resizeLayer, Settings = resizeSettings };
                 this.backupFormat.ApplyProcessor(resize.ProcessImage, this);
             }
 
@@ -1232,7 +1231,7 @@ namespace ImageProcessor
         {
             if (this.ShouldProcess)
             {
-                Rotate rotate = new Rotate { DynamicParameter = degrees };
+                var rotate = new Rotate { DynamicParameter = degrees };
                 this.backupFormat.ApplyProcessor(rotate.ProcessImage, this);
             }
 
@@ -1261,7 +1260,7 @@ namespace ImageProcessor
         {
             if (this.ShouldProcess)
             {
-                RotateBounded rotate = new RotateBounded { DynamicParameter = new Tuple<float, bool>(degrees, keepSize) };
+                var rotate = new RotateBounded { DynamicParameter = new Tuple<float, bool>(degrees, keepSize) };
                 this.backupFormat.ApplyProcessor(rotate.ProcessImage, this);
             }
 
@@ -1286,9 +1285,9 @@ namespace ImageProcessor
                     radius = 0;
                 }
 
-                RoundedCornerLayer roundedCornerLayer = new RoundedCornerLayer(radius);
+                var roundedCornerLayer = new RoundedCornerLayer(radius);
 
-                RoundedCorners roundedCorners = new RoundedCorners { DynamicParameter = roundedCornerLayer };
+                var roundedCorners = new RoundedCorners { DynamicParameter = roundedCornerLayer };
                 this.backupFormat.ApplyProcessor(roundedCorners.ProcessImage, this);
             }
 
@@ -1313,7 +1312,7 @@ namespace ImageProcessor
                     roundedCornerLayer.Radius = 0;
                 }
 
-                RoundedCorners roundedCorners = new RoundedCorners { DynamicParameter = roundedCornerLayer };
+                var roundedCorners = new RoundedCorners { DynamicParameter = roundedCornerLayer };
                 this.backupFormat.ApplyProcessor(roundedCorners.ProcessImage, this);
             }
 
@@ -1340,7 +1339,7 @@ namespace ImageProcessor
                     return this;
                 }
 
-                Saturation saturate = new Saturation { DynamicParameter = percentage };
+                var saturate = new Saturation { DynamicParameter = percentage };
                 this.backupFormat.ApplyProcessor(saturate.ProcessImage, this);
             }
 
@@ -1360,7 +1359,7 @@ namespace ImageProcessor
         {
             if (this.ShouldProcess)
             {
-                Tint tint = new Tint { DynamicParameter = color };
+                var tint = new Tint { DynamicParameter = color };
                 this.backupFormat.ApplyProcessor(tint.ProcessImage, this);
             }
 
@@ -1380,7 +1379,7 @@ namespace ImageProcessor
         {
             if (this.ShouldProcess)
             {
-                Vignette vignette = new Vignette
+                var vignette = new Vignette
                 {
                     DynamicParameter = color.HasValue && !color.Equals(Color.Transparent)
                                         ? color.Value
@@ -1407,7 +1406,7 @@ namespace ImageProcessor
         {
             if (this.ShouldProcess)
             {
-                Watermark watermark = new Watermark { DynamicParameter = textLayer };
+                var watermark = new Watermark { DynamicParameter = textLayer };
                 this.backupFormat.ApplyProcessor(watermark.ProcessImage, this);
             }
 
@@ -1428,7 +1427,7 @@ namespace ImageProcessor
             if (this.ShouldProcess)
             {
                 // ReSharper disable once AssignNullToNotNullAttribute
-                DirectoryInfo directoryInfo = new DirectoryInfo(Path.GetDirectoryName(filePath));
+                var directoryInfo = new DirectoryInfo(Path.GetDirectoryName(filePath));
                 if (!directoryInfo.Exists)
                 {
                     directoryInfo.Create();

--- a/src/ImageProcessor/ImageProcessor.csproj
+++ b/src/ImageProcessor/ImageProcessor.csproj
@@ -12,6 +12,7 @@
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/ImageProcessor/Imaging/Colors/CmykColor.cs
+++ b/src/ImageProcessor/Imaging/Colors/CmykColor.cs
@@ -19,32 +19,12 @@ namespace ImageProcessor.Imaging.Colors
     /// <summary>
     /// Represents an CMYK (cyan, magenta, yellow, keyline) color.
     /// </summary>
-    public struct CmykColor : IEquatable<CmykColor>
+    public readonly struct CmykColor : IEquatable<CmykColor>
     {
         /// <summary>
         /// Represents a <see cref="CmykColor"/> that is null.
         /// </summary>
         public static readonly CmykColor Empty = new CmykColor();
-
-        /// <summary>
-        /// The cyan color component.
-        /// </summary>
-        private readonly float c;
-
-        /// <summary>
-        /// The magenta color component.
-        /// </summary>
-        private readonly float m;
-
-        /// <summary>
-        /// The yellow color component.
-        /// </summary>
-        private readonly float y;
-
-        /// <summary>
-        /// The keyline black color component.
-        /// </summary>
-        private readonly float k;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CmykColor"/> struct.
@@ -63,10 +43,10 @@ namespace ImageProcessor.Imaging.Colors
         /// </param>
         private CmykColor(float cyan, float magenta, float yellow, float keyline)
         {
-            this.c = Clamp(cyan);
-            this.m = Clamp(magenta);
-            this.y = Clamp(yellow);
-            this.k = Clamp(keyline);
+            this.C = Clamp(cyan);
+            this.M = Clamp(magenta);
+            this.Y = Clamp(yellow);
+            this.K = Clamp(keyline);
         }
 
         /// <summary>
@@ -78,59 +58,48 @@ namespace ImageProcessor.Imaging.Colors
         private CmykColor(Color color)
         {
             CmykColor cmykColor = color;
-            this.c = cmykColor.c;
-            this.m = cmykColor.m;
-            this.y = cmykColor.y;
-            this.k = cmykColor.k;
+            this.C = cmykColor.C;
+            this.M = cmykColor.M;
+            this.Y = cmykColor.Y;
+            this.K = cmykColor.K;
         }
 
         /// <summary>
         /// Gets the cyan component.
         /// <remarks>A value ranging between 0 and 100.</remarks>
         /// </summary>
-        public float C => this.c;
+        public float C { get; }
 
         /// <summary>
         /// Gets the magenta component.
         /// <remarks>A value ranging between 0 and 100.</remarks>
         /// </summary>
-        public float M => this.m;
+        public float M { get; }
 
         /// <summary>
         /// Gets the yellow component.
         /// <remarks>A value ranging between 0 and 100.</remarks>
         /// </summary>
-        public float Y => this.y;
+        public float Y { get; }
 
         /// <summary>
         /// Gets the keyline black component.
         /// <remarks>A value ranging between 0 and 100.</remarks>
         /// </summary>
-        public float K => this.k;
+        public float K { get; }
 
         /// <summary>
         /// Creates a <see cref="CmykColor"/> structure from the four 32-bit CMYK 
         /// components (cyan, magenta, yellow, and keyline) values.
         /// </summary>
-        /// <param name="cyan">
-        /// The cyan component.
-        /// </param>
-        /// <param name="magenta">
-        /// The magenta component.
-        /// </param>
-        /// <param name="yellow">
-        /// The yellow component.
-        /// </param>
-        /// <param name="keyline">
-        /// The keyline black component.
-        /// </param>
+        /// <param name="cyan">The cyan component.</param>
+        /// <param name="magenta">The magenta component.</param>
+        /// <param name="yellow">The yellow component.</param>
+        /// <param name="keyline">The keyline black component.</param>
         /// <returns>
         /// The <see cref="CmykColor"/>.
         /// </returns>
-        public static CmykColor FromCmykColor(float cyan, float magenta, float yellow, float keyline)
-        {
-            return new CmykColor(cyan, magenta, yellow, keyline);
-        }
+        public static CmykColor FromCmykColor(float cyan, float magenta, float yellow, float keyline) => new CmykColor(cyan, magenta, yellow, keyline);
 
         /// <summary>
         /// Creates a <see cref="CmykColor"/> structure from the specified <see cref="System.Drawing.Color"/> structure
@@ -141,10 +110,7 @@ namespace ImageProcessor.Imaging.Colors
         /// <returns>
         /// The <see cref="CmykColor"/>.
         /// </returns>
-        public static CmykColor FromColor(Color color)
-        {
-            return new CmykColor(color);
-        }
+        public static CmykColor FromColor(Color color) => new CmykColor(color);
 
         /// <summary>
         /// Allows the implicit conversion of an instance of <see cref="System.Drawing.Color"/> to a 
@@ -186,10 +152,7 @@ namespace ImageProcessor.Imaging.Colors
         /// <returns>
         /// An instance of <see cref="CmykColor"/>.
         /// </returns>
-        public static implicit operator CmykColor(RgbaColor rgbaColor)
-        {
-            return FromColor(rgbaColor);
-        }
+        public static implicit operator CmykColor(RgbaColor rgbaColor) => FromColor(rgbaColor);
 
         /// <summary>
         /// Allows the implicit conversion of an instance of <see cref="YCbCrColor"/> to a 
@@ -219,9 +182,9 @@ namespace ImageProcessor.Imaging.Colors
         /// </returns>
         public static implicit operator Color(CmykColor cmykColor)
         {
-            int red = Convert.ToInt32((1 - (cmykColor.c / 100)) * (1 - (cmykColor.k / 100)) * 255.0);
-            int green = Convert.ToInt32((1 - (cmykColor.m / 100)) * (1 - (cmykColor.k / 100)) * 255.0);
-            int blue = Convert.ToInt32((1 - (cmykColor.y / 100)) * (1 - (cmykColor.k / 100)) * 255.0);
+            int red = Convert.ToInt32((1 - (cmykColor.C / 100)) * (1 - (cmykColor.K / 100)) * 255.0);
+            int green = Convert.ToInt32((1 - (cmykColor.M / 100)) * (1 - (cmykColor.K / 100)) * 255.0);
+            int blue = Convert.ToInt32((1 - (cmykColor.Y / 100)) * (1 - (cmykColor.K / 100)) * 255.0);
             return Color.FromArgb(red.ToByte(), green.ToByte(), blue.ToByte());
         }
 
@@ -237,9 +200,9 @@ namespace ImageProcessor.Imaging.Colors
         /// </returns>
         public static implicit operator RgbaColor(CmykColor cmykColor)
         {
-            int red = Convert.ToInt32((1 - (cmykColor.c / 100)) * (1 - (cmykColor.k / 100)) * 255.0);
-            int green = Convert.ToInt32((1 - (cmykColor.m / 100)) * (1 - (cmykColor.k / 100)) * 255.0);
-            int blue = Convert.ToInt32((1 - (cmykColor.y / 100)) * (1 - (cmykColor.k / 100)) * 255.0);
+            int red = Convert.ToInt32((1 - (cmykColor.C / 100)) * (1 - (cmykColor.K / 100)) * 255.0);
+            int green = Convert.ToInt32((1 - (cmykColor.M / 100)) * (1 - (cmykColor.K / 100)) * 255.0);
+            int blue = Convert.ToInt32((1 - (cmykColor.Y / 100)) * (1 - (cmykColor.K / 100)) * 255.0);
             return RgbaColor.FromRgba(red.ToByte(), green.ToByte(), blue.ToByte());
         }
 
@@ -253,10 +216,7 @@ namespace ImageProcessor.Imaging.Colors
         /// <returns>
         /// An instance of <see cref="YCbCrColor"/>.
         /// </returns>
-        public static implicit operator YCbCrColor(CmykColor cmykColor)
-        {
-            return YCbCrColor.FromColor(cmykColor);
-        }
+        public static implicit operator YCbCrColor(CmykColor cmykColor) => YCbCrColor.FromColor(cmykColor);
 
         /// <summary>
         /// Allows the implicit conversion of an instance of <see cref="CmykColor"/> to a 
@@ -268,10 +228,7 @@ namespace ImageProcessor.Imaging.Colors
         /// <returns>
         /// An instance of <see cref="HslaColor"/>.
         /// </returns>
-        public static implicit operator HslaColor(CmykColor cmykColor)
-        {
-            return HslaColor.FromColor(cmykColor);
-        }
+        public static implicit operator HslaColor(CmykColor cmykColor) => HslaColor.FromColor(cmykColor);
 
         /// <summary>
         /// Returns a <see cref="System.String" /> that represents this instance.
@@ -296,15 +253,7 @@ namespace ImageProcessor.Imaging.Colors
         /// true if <paramref name="obj"/> and this instance are the same type and represent the same value; otherwise, false.
         /// </returns>
         /// <param name="obj">Another object to compare to. </param>
-        public override bool Equals(object obj)
-        {
-            if (obj is CmykColor)
-            {
-                return this.Equals((CmykColor)obj);
-            }
-
-            return false;
-        }
+        public override bool Equals(object obj) => obj is CmykColor cmykColor && this.Equals(cmykColor);
 
         /// <summary>
         /// Indicates whether the current object is equal to another object of the same type.
@@ -339,10 +288,7 @@ namespace ImageProcessor.Imaging.Colors
         /// <returns>
         /// The sanitized <see cref="float"/>.
         /// </returns>
-        private static float Clamp(float value)
-        {
-            return ImageMaths.Clamp(value, 0, 100);
-        }
+        private static float Clamp(float value) => ImageMaths.Clamp(value, 0, 100);
 
         /// <summary>
         /// Returns a value indicating whether the current instance is empty.
@@ -353,8 +299,8 @@ namespace ImageProcessor.Imaging.Colors
         private bool IsEmpty()
         {
             const float Epsilon = .0001f;
-            return Math.Abs(this.c - 0) <= Epsilon && Math.Abs(this.m - 0) <= Epsilon &&
-                   Math.Abs(this.y - 0) <= Epsilon && Math.Abs(this.k - 0) <= Epsilon;
+            return Math.Abs(this.C - 0) <= Epsilon && Math.Abs(this.M - 0) <= Epsilon
+                   && Math.Abs(this.Y - 0) <= Epsilon && Math.Abs(this.K - 0) <= Epsilon;
         }
     }
 }

--- a/src/ImageProcessor/Imaging/Colors/Color32.cs
+++ b/src/ImageProcessor/Imaging/Colors/Color32.cs
@@ -78,18 +78,12 @@ namespace ImageProcessor.Imaging.Colors
         /// The combined color components.
         /// </param>
         public Color32(int argb)
-            : this()
-        {
-            this.Argb = argb;
-        }
+            : this() => this.Argb = argb;
 
         /// <summary>
         /// Gets the color for this Color32 object
         /// </summary>
-        public Color Color
-        {
-            get { return Color.FromArgb(this.A, this.R, this.G, this.B); }
-        }
+        public Color Color => Color.FromArgb(this.A, this.R, this.G, this.B);
 
         /// <summary>
         /// Indicates whether this instance and a specified object are equal.
@@ -98,25 +92,14 @@ namespace ImageProcessor.Imaging.Colors
         /// true if <paramref name="obj"/> and this instance are the same type and represent the same value; otherwise, false.
         /// </returns>
         /// <param name="obj">Another object to compare to. </param>
-        public override bool Equals(object obj)
-        {
-            if (obj is Color32)
-            {
-                return this.Equals((Color32)obj);
-            }
-
-            return false;
-        }
+        public override bool Equals(object obj) => obj is Color32 color32 && this.Equals(color32);
 
         /// <summary>
         /// Indicates whether the current object is equal to another object of the same type.
         /// </summary>
         /// <param name="other">An object to compare with this object.</param>
         /// <returns>true if the current object is equal to the <paramref name="other" /> parameter; otherwise, false.</returns>
-        public bool Equals(Color32 other)
-        {
-            return this.Argb.Equals(other.Argb);
-        }
+        public bool Equals(Color32 other) => this.Argb.Equals(other.Argb);
 
         /// <summary>
         /// Returns the hash code for this instance.
@@ -124,10 +107,7 @@ namespace ImageProcessor.Imaging.Colors
         /// <returns>
         /// A 32-bit signed integer that is the hash code for this instance.
         /// </returns>
-        public override int GetHashCode()
-        {
-            return this.GetHashCode(this);
-        }
+        public override int GetHashCode() => this.GetHashCode(this);
 
         /// <summary>
         /// Returns the hash code for the given instance.
@@ -145,8 +125,7 @@ namespace ImageProcessor.Imaging.Colors
                 int hashCode = obj.B.GetHashCode();
                 hashCode = (hashCode * 397) ^ obj.G.GetHashCode();
                 hashCode = (hashCode * 397) ^ obj.R.GetHashCode();
-                hashCode = (hashCode * 397) ^ obj.A.GetHashCode();
-                return hashCode;
+                return (hashCode * 397) ^ obj.A.GetHashCode();
             }
         }
     }

--- a/src/ImageProcessor/Imaging/Colors/ColorExtensions.cs
+++ b/src/ImageProcessor/Imaging/Colors/ColorExtensions.cs
@@ -23,12 +23,8 @@ namespace ImageProcessor.Imaging.Colors
         /// <summary>
         /// Adds colors together using the RGBA color format.
         /// </summary>
-        /// <param name="color">
-        /// The color to add to.
-        /// </param>
-        /// <param name="colors">
-        /// The colors to add to the initial one.
-        /// </param>
+        /// <param name="color">The color to add to.</param>
+        /// <param name="colors">The colors to add to the initial one.</param>
         /// <returns>
         /// The combined <see cref="Color"/>.
         /// </returns>
@@ -44,7 +40,7 @@ namespace ImageProcessor.Imaging.Colors
             {
                 if (addColor.A > 0)
                 {
-                    counter += 1;
+                    counter++;
                     red += addColor.R;
                     green += addColor.G;
                     blue += addColor.B;

--- a/src/ImageProcessor/Imaging/Colors/HSLAColor.cs
+++ b/src/ImageProcessor/Imaging/Colors/HSLAColor.cs
@@ -16,35 +16,12 @@ namespace ImageProcessor.Imaging.Colors
     /// Represents an HSLA (hue, saturation, luminosity, alpha) color.
     /// Adapted from <see href="http://richnewman.wordpress.com/about/code-listings-and-diagrams/hslcolor-class/"/>
     /// </summary>
-    public struct HslaColor : IEquatable<HslaColor>
+    public readonly struct HslaColor : IEquatable<HslaColor>
     {
         /// <summary>
         /// Represents a <see cref="HslaColor"/> that is null.
         /// </summary>
         public static readonly HslaColor Empty = new HslaColor();
-
-        // Private data members below are on scale 0-1
-        // They are scaled for use externally based on scale
-
-        /// <summary>
-        /// The hue component.
-        /// </summary>
-        private readonly float h;
-
-        /// <summary>
-        /// The luminosity component.
-        /// </summary>
-        private readonly float l;
-
-        /// <summary>
-        /// The saturation component.
-        /// </summary>
-        private readonly float s;
-
-        /// <summary>
-        /// The alpha component.
-        /// </summary>
-        private readonly float a;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="HslaColor"/> struct.
@@ -55,10 +32,10 @@ namespace ImageProcessor.Imaging.Colors
         /// <param name="alpha">The alpha component.</param>
         private HslaColor(float hue, float saturation, float luminosity, float alpha)
         {
-            this.h = Clamp(hue);
-            this.s = Clamp(saturation);
-            this.l = Clamp(luminosity);
-            this.a = Clamp(alpha);
+            this.H = Clamp(hue);
+            this.S = Clamp(saturation);
+            this.L = Clamp(luminosity);
+            this.A = Clamp(alpha);
         }
 
         /// <summary>
@@ -70,35 +47,35 @@ namespace ImageProcessor.Imaging.Colors
         private HslaColor(Color color)
         {
             HslaColor hslColor = color;
-            this.h = hslColor.h;
-            this.s = hslColor.s;
-            this.l = hslColor.l;
-            this.a = hslColor.a;
+            this.H = hslColor.H;
+            this.S = hslColor.S;
+            this.L = hslColor.L;
+            this.A = hslColor.A;
         }
 
         /// <summary>
         /// Gets the hue component.
         /// <remarks>A value ranging between 0 and 1.</remarks>
         /// </summary>
-        public float H => this.h;
+        public float H { get; }
 
         /// <summary>
         /// Gets the luminosity component.
         /// <remarks>A value ranging between 0 and 1.</remarks>
         /// </summary>
-        public float L => this.l;
+        public float L { get; }
 
         /// <summary>
         /// Gets the saturation component.
         /// <remarks>A value ranging between 0 and 1.</remarks>
         /// </summary>
-        public float S => this.s;
+        public float S { get; }
 
         /// <summary>
         /// Gets the alpha component.
         /// <remarks>A value ranging between 0 and 1.</remarks>
         /// </summary>
-        public float A => this.a;
+        public float A { get; }
 
         /// <summary>
         /// Creates a <see cref="HslaColor"/> structure from the three 32-bit HSLA 
@@ -110,10 +87,7 @@ namespace ImageProcessor.Imaging.Colors
         /// <returns>
         /// The <see cref="HslaColor"/>.
         /// </returns>
-        public static HslaColor FromHslaColor(float hue, float saturation, float luminosity)
-        {
-            return new HslaColor(hue, saturation, luminosity, 1.0f);
-        }
+        public static HslaColor FromHslaColor(float hue, float saturation, float luminosity) => new HslaColor(hue, saturation, luminosity, 1.0f);
 
         /// <summary>
         /// Creates a <see cref="HslaColor"/> structure from the four 32-bit HSLA 
@@ -126,10 +100,7 @@ namespace ImageProcessor.Imaging.Colors
         /// <returns>
         /// The <see cref="HslaColor"/>.
         /// </returns>
-        public static HslaColor FromHslaColor(float hue, float saturation, float luminosity, float alpha)
-        {
-            return new HslaColor(hue, saturation, luminosity, alpha);
-        }
+        public static HslaColor FromHslaColor(float hue, float saturation, float luminosity, float alpha) => new HslaColor(hue, saturation, luminosity, alpha);
 
         /// <summary>
         /// Creates a <see cref="HslaColor"/> structure from the specified <see cref="System.Drawing.Color"/> structure
@@ -140,10 +111,7 @@ namespace ImageProcessor.Imaging.Colors
         /// <returns>
         /// The <see cref="HslaColor"/>.
         /// </returns>
-        public static HslaColor FromColor(Color color)
-        {
-            return new HslaColor(color);
-        }
+        public static HslaColor FromColor(Color color) => new HslaColor(color);
 
         /// <summary>
         /// Allows the implicit conversion of an instance of <see cref="System.Drawing.Color"/> to a 
@@ -157,13 +125,11 @@ namespace ImageProcessor.Imaging.Colors
         /// </returns>
         public static implicit operator HslaColor(Color color)
         {
-            HslaColor hslColor = new HslaColor(
+            return new HslaColor(
                   color.GetHue() / 360.0f,
                   color.GetSaturation(),
                   color.GetBrightness(),
                   color.A / 255f);
-
-            return hslColor;
         }
 
         /// <summary>
@@ -176,10 +142,7 @@ namespace ImageProcessor.Imaging.Colors
         /// <returns>
         /// An instance of <see cref="HslaColor"/>.
         /// </returns>
-        public static implicit operator HslaColor(RgbaColor rgbaColor)
-        {
-            return FromColor(rgbaColor);
-        }
+        public static implicit operator HslaColor(RgbaColor rgbaColor) => FromColor(rgbaColor);
 
         /// <summary>
         /// Allows the implicit conversion of an instance of <see cref="YCbCrColor"/> to a 
@@ -194,18 +157,16 @@ namespace ImageProcessor.Imaging.Colors
         public static implicit operator HslaColor(YCbCrColor ycbcrColor)
         {
             Color color = ycbcrColor;
-            HslaColor hslColor = new HslaColor(
+            return new HslaColor(
                 color.GetHue() / 360.0f,
                 color.GetSaturation(),
                 color.GetBrightness(),
                 color.A / 255f);
-
-            return hslColor;
         }
 
         /// <summary>
         /// Allows the implicit conversion of an instance of <see cref="HslaColor"/> to a 
-        /// <see cref="System.Drawing.Color"/>.
+        /// <see cref="Color"/>.
         /// </summary>
         /// <param name="hslaColor">
         /// The instance of <see cref="HslaColor"/> to convert.
@@ -216,25 +177,25 @@ namespace ImageProcessor.Imaging.Colors
         public static implicit operator Color(HslaColor hslaColor)
         {
             float r = 0, g = 0, b = 0;
-            if (Math.Abs(hslaColor.l - 0) > .0001)
+            if (Math.Abs(hslaColor.L - 0) > .0001)
             {
-                if (Math.Abs(hslaColor.s - 0) <= .0001)
+                if (Math.Abs(hslaColor.S - 0) <= .0001)
                 {
-                    r = g = b = hslaColor.l;
+                    r = g = b = hslaColor.L;
                 }
                 else
                 {
                     float temp2 = GetTemp2(hslaColor);
-                    float temp1 = (2.0f * hslaColor.l) - temp2;
+                    float temp1 = (2.0f * hslaColor.L) - temp2;
 
-                    r = GetColorComponent(temp1, temp2, hslaColor.h + (1.0f / 3.0f));
-                    g = GetColorComponent(temp1, temp2, hslaColor.h);
-                    b = GetColorComponent(temp1, temp2, hslaColor.h - (1.0f / 3.0f));
+                    r = GetColorComponent(temp1, temp2, hslaColor.H + (1.0f / 3.0f));
+                    g = GetColorComponent(temp1, temp2, hslaColor.H);
+                    b = GetColorComponent(temp1, temp2, hslaColor.H - (1.0f / 3.0f));
                 }
             }
 
             return Color.FromArgb(
-                Convert.ToInt32(255 * hslaColor.a),
+                Convert.ToInt32(255 * hslaColor.A),
                 Convert.ToInt32(255 * r),
                 Convert.ToInt32(255 * g),
                 Convert.ToInt32(255 * b));
@@ -250,10 +211,7 @@ namespace ImageProcessor.Imaging.Colors
         /// <returns>
         /// An instance of <see cref="YCbCrColor"/>.
         /// </returns>
-        public static implicit operator YCbCrColor(HslaColor hslaColor)
-        {
-            return YCbCrColor.FromColor(hslaColor);
-        }
+        public static implicit operator YCbCrColor(HslaColor hslaColor) => YCbCrColor.FromColor(hslaColor);
 
         /// <summary>
         /// Allows the implicit conversion of an instance of <see cref="HslaColor"/> to a 
@@ -265,10 +223,7 @@ namespace ImageProcessor.Imaging.Colors
         /// <returns>
         /// An instance of <see cref="CmykColor"/>.
         /// </returns>
-        public static implicit operator CmykColor(HslaColor hslaColor)
-        {
-            return CmykColor.FromColor(hslaColor);
-        }
+        public static implicit operator CmykColor(HslaColor hslaColor) => CmykColor.FromColor(hslaColor);
 
         /// <summary>
         /// Returns a <see cref="System.String" /> that represents this instance.
@@ -293,15 +248,7 @@ namespace ImageProcessor.Imaging.Colors
         /// true if <paramref name="obj"/> and this instance are the same type and represent the same value; otherwise, false.
         /// </returns>
         /// <param name="obj">Another object to compare to. </param>
-        public override bool Equals(object obj)
-        {
-            if (obj is HslaColor)
-            {
-                return this.Equals((HslaColor)obj);
-            }
-
-            return false;
-        }
+        public override bool Equals(object obj) => obj is HslaColor hslaColor && this.Equals(hslaColor);
 
         /// <summary>
         /// Indicates whether the current object is equal to another object of the same type.
@@ -372,19 +319,16 @@ namespace ImageProcessor.Imaging.Colors
         /// <returns>
         /// The <see cref="float"/>.
         /// </returns>
-        private static float GetTemp2(HslaColor hslColor)
+        private static float GetTemp2(in HslaColor hslColor)
         {
-            float temp2;
-            if (hslColor.l <= 0.5)
+            if (hslColor.L <= 0.5)
             {
-                temp2 = hslColor.l * (1.0f + hslColor.s);
+                return hslColor.L * (1.0f + hslColor.S);
             }
             else
             {
-                temp2 = hslColor.l + hslColor.s - (hslColor.l * hslColor.s);
+                return hslColor.L + hslColor.S - (hslColor.L * hslColor.S);
             }
-
-            return temp2;
         }
 
         /// <summary>
@@ -400,11 +344,11 @@ namespace ImageProcessor.Imaging.Colors
         {
             if (temp3 < 0.0)
             {
-                temp3 += 1.0f;
+                temp3++;
             }
             else if (temp3 > 1.0)
             {
-                temp3 -= 1.0f;
+                temp3--;
             }
 
             return temp3;
@@ -419,10 +363,7 @@ namespace ImageProcessor.Imaging.Colors
         /// <returns>
         /// The sanitized <see cref="float"/>.
         /// </returns>
-        private static float Clamp(float value)
-        {
-            return ImageMaths.Clamp(value, 0, 1);
-        }
+        private static float Clamp(float value) => ImageMaths.Clamp(value, 0, 1);
 
         /// <summary>
         /// Returns a value indicating whether the current instance is empty.
@@ -433,8 +374,8 @@ namespace ImageProcessor.Imaging.Colors
         private bool IsEmpty()
         {
             const float Epsilon = .0001f;
-            return Math.Abs(this.h - 0) <= Epsilon && Math.Abs(this.s - 0) <= Epsilon &&
-                   Math.Abs(this.l - 0) <= Epsilon && Math.Abs(this.a - 0) <= Epsilon;
+            return Math.Abs(this.H - 0) <= Epsilon && Math.Abs(this.S - 0) <= Epsilon
+                   && Math.Abs(this.L - 0) <= Epsilon && Math.Abs(this.A - 0) <= Epsilon;
         }
     }
 }

--- a/src/ImageProcessor/Imaging/Colors/RGBAColor.cs
+++ b/src/ImageProcessor/Imaging/Colors/RGBAColor.cs
@@ -13,32 +13,12 @@ namespace ImageProcessor.Imaging.Colors
     /// <summary>
     /// Represents an RGBA (red, green, blue, alpha) color.
     /// </summary>
-    public struct RgbaColor : IEquatable<RgbaColor>
+    public readonly struct RgbaColor : IEquatable<RgbaColor>
     {
         /// <summary>
         /// Represents a <see cref="RgbaColor"/> that is null.
         /// </summary>
         public static readonly RgbaColor Empty = new RgbaColor();
-
-        /// <summary>
-        /// The red component.
-        /// </summary>
-        private readonly byte r;
-
-        /// <summary>
-        /// The green component.
-        /// </summary>
-        private readonly byte g;
-
-        /// <summary>
-        /// The blue component.
-        /// </summary>
-        private readonly byte b;
-
-        /// <summary>
-        /// The alpha component.
-        /// </summary>
-        private readonly byte a;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RgbaColor"/> struct. 
@@ -57,10 +37,10 @@ namespace ImageProcessor.Imaging.Colors
         /// </param>
         private RgbaColor(byte red, byte green, byte blue, byte alpha)
         {
-            this.r = red;
-            this.g = green;
-            this.b = blue;
-            this.a = alpha;
+            this.R = red;
+            this.G = green;
+            this.B = blue;
+            this.A = alpha;
         }
 
         /// <summary>
@@ -71,31 +51,31 @@ namespace ImageProcessor.Imaging.Colors
         /// </param>
         private RgbaColor(Color color)
         {
-            this.r = color.R;
-            this.g = color.G;
-            this.b = color.B;
-            this.a = color.A;
+            this.R = color.R;
+            this.G = color.G;
+            this.B = color.B;
+            this.A = color.A;
         }
 
         /// <summary>
         /// Gets the red component.
         /// </summary>
-        public byte R => this.r;
+        public byte R { get; }
 
         /// <summary>
         /// Gets the green component.
         /// </summary>
-        public byte G => this.g;
+        public byte G { get; }
 
         /// <summary>
         /// Gets the blue component.
         /// </summary>
-        public byte B => this.b;
+        public byte B { get; }
 
         /// <summary>
         /// Gets the alpha component.
         /// </summary>
-        public byte A => this.a;
+        public byte A { get; }
 
         /// <summary>
         /// Creates a <see cref="RgbaColor"/> structure from the three 8-bit RGBA 
@@ -107,10 +87,7 @@ namespace ImageProcessor.Imaging.Colors
         /// <returns>
         /// The <see cref="RgbaColor"/>.
         /// </returns>
-        public static RgbaColor FromRgba(byte red, byte green, byte blue)
-        {
-            return new RgbaColor(red, green, blue, 255);
-        }
+        public static RgbaColor FromRgba(byte red, byte green, byte blue) => new RgbaColor(red, green, blue, 255);
 
         /// <summary>
         /// Creates a <see cref="RgbaColor"/> structure from the four 8-bit RGBA 
@@ -123,10 +100,7 @@ namespace ImageProcessor.Imaging.Colors
         /// <returns>
         /// The <see cref="RgbaColor"/>.
         /// </returns>
-        public static RgbaColor FromRgba(byte red, byte green, byte blue, byte alpha)
-        {
-            return new RgbaColor(red, green, blue, alpha);
-        }
+        public static RgbaColor FromRgba(byte red, byte green, byte blue, byte alpha) => new RgbaColor(red, green, blue, alpha);
 
         /// <summary>
         /// Creates a <see cref="RgbaColor"/> structure from the specified <see cref="System.Drawing.Color"/> structure
@@ -137,10 +111,7 @@ namespace ImageProcessor.Imaging.Colors
         /// <returns>
         /// The <see cref="RgbaColor"/>.
         /// </returns>
-        public static RgbaColor FromColor(Color color)
-        {
-            return new RgbaColor(color);
-        }
+        public static RgbaColor FromColor(Color color) => new RgbaColor(color);
 
         /// <summary>
         /// Allows the implicit conversion of an instance of <see cref="System.Drawing.Color"/> to a 
@@ -152,10 +123,7 @@ namespace ImageProcessor.Imaging.Colors
         /// <returns>
         /// An instance of <see cref="RgbaColor"/>.
         /// </returns>
-        public static implicit operator RgbaColor(Color color)
-        {
-            return FromColor(color);
-        }
+        public static implicit operator RgbaColor(Color color) => FromColor(color);
 
         /// <summary>
         /// Allows the implicit conversion of an instance of <see cref="HslaColor"/> to a 
@@ -167,10 +135,7 @@ namespace ImageProcessor.Imaging.Colors
         /// <returns>
         /// An instance of <see cref="RgbaColor"/>.
         /// </returns>
-        public static implicit operator RgbaColor(HslaColor hslaColor)
-        {
-            return FromColor(hslaColor);
-        }
+        public static implicit operator RgbaColor(HslaColor hslaColor) => FromColor(hslaColor);
 
         /// <summary>
         /// Allows the implicit conversion of an instance of <see cref="YCbCrColor"/> to a 
@@ -182,10 +147,7 @@ namespace ImageProcessor.Imaging.Colors
         /// <returns>
         /// An instance of <see cref="RgbaColor"/>.
         /// </returns>
-        public static implicit operator RgbaColor(YCbCrColor ycbcrColor)
-        {
-            return FromColor(ycbcrColor);
-        }
+        public static implicit operator RgbaColor(YCbCrColor ycbcrColor) => FromColor(ycbcrColor);
 
         /// <summary>
         /// Allows the implicit conversion of an instance of <see cref="RgbaColor"/> to a 
@@ -197,10 +159,7 @@ namespace ImageProcessor.Imaging.Colors
         /// <returns>
         /// An instance of <see cref="System.Drawing.Color"/>.
         /// </returns>
-        public static implicit operator Color(RgbaColor rgbaColor)
-        {
-            return Color.FromArgb(rgbaColor.A, rgbaColor.R, rgbaColor.G, rgbaColor.B);
-        }
+        public static implicit operator Color(RgbaColor rgbaColor) => Color.FromArgb(rgbaColor.A, rgbaColor.R, rgbaColor.G, rgbaColor.B);
 
         /// <summary>
         /// Allows the implicit conversion of an instance of <see cref="RgbaColor"/> to a 
@@ -212,10 +171,7 @@ namespace ImageProcessor.Imaging.Colors
         /// <returns>
         /// An instance of <see cref="YCbCrColor"/>.
         /// </returns>
-        public static implicit operator YCbCrColor(RgbaColor rgbaColor)
-        {
-            return YCbCrColor.FromColor(rgbaColor);
-        }
+        public static implicit operator YCbCrColor(RgbaColor rgbaColor) => YCbCrColor.FromColor(rgbaColor);
 
         /// <summary>
         /// Returns a <see cref="System.String" /> that represents this instance.
@@ -240,15 +196,7 @@ namespace ImageProcessor.Imaging.Colors
         /// true if <paramref name="obj"/> and this instance are the same type and represent the same value; otherwise, false.
         /// </returns>
         /// <param name="obj">Another object to compare to. </param>
-        public override bool Equals(object obj)
-        {
-            if (obj is RgbaColor)
-            {
-                return this.Equals((RgbaColor)obj);
-            }
-
-            return false;
-        }
+        public override bool Equals(object obj) => obj is RgbaColor rgbaColor && this.Equals(rgbaColor);
 
         /// <summary>
         /// Indicates whether the current object is equal to another object of the same type.

--- a/src/ImageProcessor/Imaging/Colors/YCbCrColor.cs
+++ b/src/ImageProcessor/Imaging/Colors/YCbCrColor.cs
@@ -20,27 +20,12 @@ namespace ImageProcessor.Imaging.Colors
     /// Represents an YCbCr (luminance, chroma, chroma) color conforming to the ITU-R BT.601 standard used in digital imaging systems.
     /// <see href="http://en.wikipedia.org/wiki/YCbCr"/>
     /// </summary>
-    public struct YCbCrColor : IEquatable<YCbCrColor>
+    public readonly struct YCbCrColor : IEquatable<YCbCrColor>
     {
         /// <summary>
         /// Represents a <see cref="YCbCrColor"/> that is null.
         /// </summary>
         public static readonly YCbCrColor Empty = new YCbCrColor();
-
-        /// <summary>
-        /// The y luminance component.
-        /// </summary>
-        private readonly float y;
-
-        /// <summary>
-        /// The u chroma component.
-        /// </summary>
-        private readonly float cb;
-
-        /// <summary>
-        /// The v chroma component.
-        /// </summary>
-        private readonly float cr;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="YCbCrColor"/> struct.
@@ -50,28 +35,28 @@ namespace ImageProcessor.Imaging.Colors
         /// <param name="cr">The v chroma component.</param> 
         private YCbCrColor(float y, float cb, float cr)
         {
-            this.y = ImageMaths.Clamp(y, 0, 255);
-            this.cb = ImageMaths.Clamp(cb, 0, 255);
-            this.cr = ImageMaths.Clamp(cr, 0, 255);
+            this.Y = ImageMaths.Clamp(y, 0, 255);
+            this.Cb = ImageMaths.Clamp(cb, 0, 255);
+            this.Cr = ImageMaths.Clamp(cr, 0, 255);
         }
 
         /// <summary>
         /// Gets the Y luminance component.
         /// <remarks>A value ranging between 0 and 255.</remarks>
         /// </summary>
-        public float Y => this.y;
+        public float Y { get; }
 
         /// <summary>
         /// Gets the U chroma component.
         /// <remarks>A value ranging between 0 and 255.</remarks>
         /// </summary>
-        public float Cb => this.cb;
+        public float Cb { get; }
 
         /// <summary>
         /// Gets the V chroma component.
         /// <remarks>A value ranging between 0 and 255.</remarks>
         /// </summary>
-        public float Cr => this.cr;
+        public float Cr { get; }
 
         /// <summary>
         /// Creates a <see cref="YCbCrColor"/> structure from the three 32-bit YCbCr 
@@ -83,10 +68,7 @@ namespace ImageProcessor.Imaging.Colors
         /// <returns>
         /// The <see cref="YCbCrColor"/>.
         /// </returns>
-        public static YCbCrColor FromYCbCr(float y, float cb, float cr)
-        {
-            return new YCbCrColor(y, cb, cr);
-        }
+        public static YCbCrColor FromYCbCr(float y, float cb, float cr) => new YCbCrColor(y, cb, cr);
 
         /// <summary>
         /// Creates a <see cref="YCbCrColor"/> structure from the specified <see cref="System.Drawing.Color"/> structure
@@ -120,10 +102,7 @@ namespace ImageProcessor.Imaging.Colors
         /// <returns>
         /// An instance of <see cref="YCbCrColor"/>.
         /// </returns>
-        public static implicit operator YCbCrColor(Color color)
-        {
-            return FromColor(color);
-        }
+        public static implicit operator YCbCrColor(Color color) => FromColor(color);
 
         /// <summary>
         /// Allows the implicit conversion of an instance of <see cref="RgbaColor"/> to a 
@@ -135,10 +114,7 @@ namespace ImageProcessor.Imaging.Colors
         /// <returns>
         /// An instance of <see cref="YCbCrColor"/>.
         /// </returns>
-        public static implicit operator YCbCrColor(RgbaColor rgbaColor)
-        {
-            return FromColor(rgbaColor);
-        }
+        public static implicit operator YCbCrColor(RgbaColor rgbaColor) => FromColor(rgbaColor);
 
         /// <summary>
         /// Allows the implicit conversion of an instance of <see cref="HslaColor"/> to a 
@@ -150,10 +126,7 @@ namespace ImageProcessor.Imaging.Colors
         /// <returns>
         /// An instance of <see cref="YCbCrColor"/>.
         /// </returns>
-        public static implicit operator YCbCrColor(HslaColor hslaColor)
-        {
-            return FromColor(hslaColor);
-        }
+        public static implicit operator YCbCrColor(HslaColor hslaColor) => FromColor(hslaColor);
 
         /// <summary>
         /// Allows the implicit conversion of an instance of <see cref="YCbCrColor"/> to a 
@@ -201,15 +174,7 @@ namespace ImageProcessor.Imaging.Colors
         /// true if <paramref name="obj"/> and this instance are the same type and represent the same value; otherwise, false.
         /// </returns>
         /// <param name="obj">Another object to compare to. </param>
-        public override bool Equals(object obj)
-        {
-            if (obj is YCbCrColor)
-            {
-                return this.Equals((YCbCrColor)obj);
-            }
-
-            return false;
-        }
+        public override bool Equals(object obj) => obj is YCbCrColor yCbCrColor && this.Equals(yCbCrColor);
 
         /// <summary>
         /// Indicates whether the current object is equal to another object of the same type.
@@ -244,8 +209,8 @@ namespace ImageProcessor.Imaging.Colors
         private bool IsEmpty()
         {
             const float Epsilon = .0001f;
-            return Math.Abs(this.y - 0) <= Epsilon && Math.Abs(this.cb - 0) <= Epsilon &&
-                   Math.Abs(this.cr - 0) <= Epsilon;
+            return Math.Abs(this.Y - 0) <= Epsilon && Math.Abs(this.Cb - 0) <= Epsilon
+                   && Math.Abs(this.Cr - 0) <= Epsilon;
         }
     }
 }

--- a/src/ImageProcessor/Imaging/ComputerArchitectureInfo.cs
+++ b/src/ImageProcessor/Imaging/ComputerArchitectureInfo.cs
@@ -21,9 +21,6 @@ namespace ImageProcessor.Imaging
         /// Returns a value indicating whether the current computer architecture is little endian. 
         /// </summary>
         /// <returns>The <see cref="bool"/></returns>
-        public bool IsLittleEndian()
-        {
-            return BitConverter.IsLittleEndian;
-        }
+        public bool IsLittleEndian() => BitConverter.IsLittleEndian;
     }
 }

--- a/src/ImageProcessor/Imaging/Convolution.cs
+++ b/src/ImageProcessor/Imaging/Convolution.cs
@@ -41,10 +41,7 @@ namespace ImageProcessor.Imaging
         /// <param name="standardDeviation">
         /// The standard deviation.
         /// </param>
-        public Convolution(double standardDeviation)
-        {
-            this.standardDeviation = standardDeviation;
-        }
+        public Convolution(double standardDeviation) => this.standardDeviation = standardDeviation;
 
         /// <summary>
         /// Gets or sets the threshold to add to the weighted sum.
@@ -104,7 +101,7 @@ namespace ImageProcessor.Imaging
             // Normalise kernel so that the sum of all weights equals 1
             for (int i = 0; i < kernelSize; i++)
             {
-                kernel[i, 0] = kernel[i, 0] / sum;
+                kernel[i, 0] /= sum;
             }
 
             return kernel;
@@ -250,12 +247,12 @@ namespace ImageProcessor.Imaging
         {
             int width = source.Width;
             int height = source.Height;
-            Bitmap destination = new Bitmap(width, height, PixelFormat.Format32bppPArgb);
+            var destination = new Bitmap(width, height, PixelFormat.Format32bppPArgb);
             destination.SetResolution(source.HorizontalResolution, source.VerticalResolution);
 
-            using (FastBitmap sourceBitmap = new FastBitmap(source))
+            using (var sourceBitmap = new FastBitmap(source))
             {
-                using (FastBitmap destinationBitmap = new FastBitmap(destination))
+                using (var destinationBitmap = new FastBitmap(destination))
                 {
                     int kernelLength = kernel.GetLength(0);
                     int radius = kernelLength >> 1;
@@ -365,7 +362,7 @@ namespace ImageProcessor.Imaging
                                 blue += threshold;
                                 alpha += threshold;
 
-                                Color destinationColor = Color.FromArgb(alpha.ToByte(), red.ToByte(), green.ToByte(), blue.ToByte());
+                                var destinationColor = Color.FromArgb(alpha.ToByte(), red.ToByte(), green.ToByte(), blue.ToByte());
 
                                 if (fixGamma)
                                 {
@@ -400,7 +397,7 @@ namespace ImageProcessor.Imaging
             int kernelSize = kernelLength * kernelLength;
             int threshold = this.Threshold;
 
-            Color[,] destination = new Color[width, height];
+            var destination = new Color[width, height];
 
             // For each line
             Parallel.For(
@@ -505,7 +502,7 @@ namespace ImageProcessor.Imaging
                         blue += threshold;
                         alpha += threshold;
 
-                        Color destinationColor = Color.FromArgb(alpha.ToByte(), red.ToByte(), green.ToByte(), blue.ToByte());
+                        var destinationColor = Color.FromArgb(alpha.ToByte(), red.ToByte(), green.ToByte(), blue.ToByte());
 
                         if (fixGamma)
                         {
@@ -547,7 +544,7 @@ namespace ImageProcessor.Imaging
         private double Gaussian2D(double x, double y)
         {
             const double Numerator = 1.0;
-            double denominator = (2 * Math.PI) * Math.Pow(this.standardDeviation, 2);
+            double denominator = 2 * Math.PI * Math.Pow(this.standardDeviation, 2);
 
             double exponentNumerator = (-x * x) + (-y * y);
             double exponentDenominator = 2 * Math.Pow(this.standardDeviation, 2);

--- a/src/ImageProcessor/Imaging/CropLayer.cs
+++ b/src/ImageProcessor/Imaging/CropLayer.cs
@@ -81,9 +81,7 @@ namespace ImageProcessor.Imaging
         /// </returns>
         public override bool Equals(object obj)
         {
-            CropLayer cropLayer = obj as CropLayer;
-
-            if (cropLayer == null)
+            if (!(obj is CropLayer cropLayer))
             {
                 return false;
             }
@@ -110,8 +108,7 @@ namespace ImageProcessor.Imaging
                 hashCode = (hashCode * 397) ^ this.Top.GetHashCode();
                 hashCode = (hashCode * 397) ^ this.Right.GetHashCode();
                 hashCode = (hashCode * 397) ^ this.Bottom.GetHashCode();
-                hashCode = (hashCode * 397) ^ (int)this.CropMode;
-                return hashCode;
+                return (hashCode * 397) ^ (int)this.CropMode;
             }
         }
     }

--- a/src/ImageProcessor/Imaging/FastBitmap.cs
+++ b/src/ImageProcessor/Imaging/FastBitmap.cs
@@ -52,16 +52,6 @@ namespace ImageProcessor.Imaging
         private readonly Bitmap bitmap;
 
         /// <summary>
-        /// The width of the bitmap.
-        /// </summary>
-        private readonly int width;
-
-        /// <summary>
-        /// The height of the bitmap.
-        /// </summary>
-        private readonly int height;
-
-        /// <summary>
         /// The color channel - blue, green, red, alpha.
         /// </summary>
         private readonly int channel;
@@ -200,17 +190,17 @@ namespace ImageProcessor.Imaging
             int pixelFormat = (int)bitmap.PixelFormat;
 
             // Check image format
-            if (!(pixelFormat == Format8bppIndexed ||
-                  pixelFormat == Format24bppRgb ||
-                  pixelFormat == Format32bppArgb ||
-                  pixelFormat == Format32bppPArgb))
+            if (!(pixelFormat == Format8bppIndexed
+                  || pixelFormat == Format24bppRgb
+                  || pixelFormat == Format32bppArgb
+                  || pixelFormat == Format32bppPArgb))
             {
                 throw new ArgumentException("Only 8bpp, 24bpp and 32bpp images are supported.");
             }
 
             this.bitmap = (Bitmap)bitmap;
-            this.width = this.bitmap.Width;
-            this.height = this.bitmap.Height;
+            this.Width = this.bitmap.Width;
+            this.Height = this.bitmap.Height;
 
             this.channel = pixelFormat == Format8bppIndexed ? 0 : 2;
             this.computeIntegrals = computeIntegrals;
@@ -222,12 +212,12 @@ namespace ImageProcessor.Imaging
         /// <summary>
         /// Gets the width, in pixels of the <see cref="System.Drawing.Bitmap"/>.
         /// </summary>
-        public int Width => this.width;
+        public int Width { get; }
 
         /// <summary>
         /// Gets the height, in pixels of the <see cref="System.Drawing.Bitmap"/>.
         /// </summary>
-        public int Height => this.height;
+        public int Height { get; }
 
         /// <summary>
         /// Gets the Integral Image for values' sum.
@@ -268,10 +258,7 @@ namespace ImageProcessor.Imaging
         /// <returns>
         /// An instance of <see cref="System.Drawing.Image"/>.
         /// </returns>
-        public static implicit operator Image(FastBitmap fastBitmap)
-        {
-            return fastBitmap.bitmap;
-        }
+        public static implicit operator Image(FastBitmap fastBitmap) => fastBitmap.bitmap;
 
         /// <summary>
         /// Allows the implicit conversion of an instance of <see cref="FastBitmap"/> to a 
@@ -283,10 +270,7 @@ namespace ImageProcessor.Imaging
         /// <returns>
         /// An instance of <see cref="System.Drawing.Bitmap"/>.
         /// </returns>
-        public static implicit operator Bitmap(FastBitmap fastBitmap)
-        {
-            return fastBitmap.bitmap;
-        }
+        public static implicit operator Bitmap(FastBitmap fastBitmap) => fastBitmap.bitmap;
 
         /// <summary>
         /// Gets the color at the specified pixel of the <see cref="System.Drawing.Bitmap"/>.
@@ -297,14 +281,14 @@ namespace ImageProcessor.Imaging
         public Color GetPixel(int x, int y)
         {
 #if DEBUG
-            if ((x < 0) || (x >= this.width))
+            if ((x < 0) || (x >= this.Width))
             {
-                throw new ArgumentOutOfRangeException("x", "Value cannot be less than zero or greater than the bitmap width.");
+                throw new ArgumentOutOfRangeException(nameof(x), "Value cannot be less than zero or greater than the bitmap width.");
             }
 
-            if ((y < 0) || (y >= this.height))
+            if ((y < 0) || (y >= this.Height))
             {
-                throw new ArgumentOutOfRangeException("y", "Value cannot be less than zero or greater than the bitmap height.");
+                throw new ArgumentOutOfRangeException(nameof(y), "Value cannot be less than zero or greater than the bitmap height.");
             }
 #endif
             Color32* data = this[x, y];
@@ -323,14 +307,14 @@ namespace ImageProcessor.Imaging
         public void SetPixel(int x, int y, Color color)
         {
 #if DEBUG
-            if ((x < 0) || (x >= this.width))
+            if ((x < 0) || (x >= this.Width))
             {
-                throw new ArgumentOutOfRangeException("x", "Value cannot be less than zero or greater than the bitmap width.");
+                throw new ArgumentOutOfRangeException(nameof(x), "Value cannot be less than zero or greater than the bitmap width.");
             }
 
-            if ((y < 0) || (y >= this.height))
+            if ((y < 0) || (y >= this.Height))
             {
-                throw new ArgumentOutOfRangeException("y", "Value cannot be less than zero or greater than the bitmap height.");
+                throw new ArgumentOutOfRangeException(nameof(y), "Value cannot be less than zero or greater than the bitmap height.");
             }
 #endif
             Color32* data = this[x, y];
@@ -424,9 +408,7 @@ namespace ImageProcessor.Imaging
         /// <param name="obj">The object to compare with the current object. </param>
         public override bool Equals(object obj)
         {
-            FastBitmap fastBitmap = obj as FastBitmap;
-
-            if (fastBitmap == null)
+            if (!(obj is FastBitmap fastBitmap))
             {
                 return false;
             }
@@ -440,10 +422,7 @@ namespace ImageProcessor.Imaging
         /// <returns>
         /// A hash code for the current <see cref="T:System.Object"/>.
         /// </returns>
-        public override int GetHashCode()
-        {
-            return this.bitmap.GetHashCode();
-        }
+        public override int GetHashCode() => this.bitmap.GetHashCode();
 
         /// <summary>
         /// Disposes the object and frees resources for the Garbage Collector.
@@ -491,7 +470,7 @@ namespace ImageProcessor.Imaging
         /// </summary>
         private void LockBitmap()
         {
-            Rectangle bounds = new Rectangle(Point.Empty, this.bitmap.Size);
+            var bounds = new Rectangle(Point.Empty, this.bitmap.Size);
 
             // Figure out the number of bytes in a row. This is rounded up to be a multiple
             // of 4 bytes, since a scan line in an image must always be a multiple of 4 bytes
@@ -512,11 +491,11 @@ namespace ImageProcessor.Imaging
             if (this.computeIntegrals)
             {
                 // Allocate values for integral image calculation.
-                this.normalWidth = this.width + 1;
-                int normalHeight = this.height + 1;
+                this.normalWidth = this.Width + 1;
+                int normalHeight = this.Height + 1;
 
-                this.tiltedWidth = this.width + 2;
-                int tiltedHeight = this.height + 2;
+                this.tiltedWidth = this.Width + 2;
+                int tiltedHeight = this.Height + 2;
 
                 this.normalSumImage = new long[normalHeight, this.normalWidth];
                 this.normalSumHandle = GCHandle.Alloc(this.normalSumImage, GCHandleType.Pinned);
@@ -551,13 +530,13 @@ namespace ImageProcessor.Imaging
             byte* src = srcStart;
 
             // For each line
-            for (int y = 1; y <= this.height; y++)
+            for (int y = 1; y <= this.Height; y++)
             {
                 int yy = this.normalWidth * y;
                 int y1 = this.normalWidth * (y - 1);
 
                 // For each pixel
-                for (int x = 1; x <= this.width; x++, src += this.pixelSize)
+                for (int x = 1; x <= this.Width; x++, src += this.pixelSize)
                 {
                     int pixel = *src;
                     int pixelSquared = pixel * pixel;
@@ -579,12 +558,12 @@ namespace ImageProcessor.Imaging
                 src = srcStart;
 
                 // Left-to-right, top-to-bottom pass
-                for (int y = 1; y <= this.height; y++, src += offset)
+                for (int y = 1; y <= this.Height; y++, src += offset)
                 {
                     int yy = this.tiltedWidth * y;
                     int y1 = this.tiltedWidth * (y - 1);
 
-                    for (int x = 2; x < this.width + 2; x++, src += this.pixelSize)
+                    for (int x = 2; x < this.Width + 2; x++, src += this.pixelSize)
                     {
                         int a = y1 + (x - 1);
                         int b = yy + (x - 1);
@@ -596,10 +575,10 @@ namespace ImageProcessor.Imaging
                 }
 
                 {
-                    int yy = this.tiltedWidth * this.height;
-                    int y1 = this.tiltedWidth * (this.height + 1);
+                    int yy = this.tiltedWidth * this.Height;
+                    int y1 = this.tiltedWidth * (this.Height + 1);
 
-                    for (int x = 2; x < this.width + 2; x++, src += this.pixelSize)
+                    for (int x = 2; x < this.Width + 2; x++, src += this.pixelSize)
                     {
                         int a = yy + (x - 1);
                         int c = yy + (x - 2);
@@ -611,12 +590,12 @@ namespace ImageProcessor.Imaging
                 }
 
                 // Right-to-left, bottom-to-top pass
-                for (int y = this.height; y >= 0; y--)
+                for (int y = this.Height; y >= 0; y--)
                 {
                     int yy = this.tiltedWidth * y;
                     int y1 = this.tiltedWidth * (y + 1);
 
-                    for (int x = this.width + 1; x >= 1; x--)
+                    for (int x = this.Width + 1; x >= 1; x--)
                     {
                         int r = yy + x;
                         int b = y1 + (x - 1);
@@ -625,11 +604,11 @@ namespace ImageProcessor.Imaging
                     }
                 }
 
-                for (int y = this.height + 1; y >= 0; y--)
+                for (int y = this.Height + 1; y >= 0; y--)
                 {
                     int yy = this.tiltedWidth * y;
 
-                    for (int x = this.width + 1; x >= 2; x--)
+                    for (int x = this.Width + 1; x >= 2; x--)
                     {
                         int r = yy + x;
                         int b = yy + (x - 2);

--- a/src/ImageProcessor/Imaging/Filters/Artistic/HalftoneFilter.cs
+++ b/src/ImageProcessor/Imaging/Filters/Artistic/HalftoneFilter.cs
@@ -26,32 +26,6 @@ namespace ImageProcessor.Imaging.Filters.Artistic
     public class HalftoneFilter
     {
         /// <summary>
-        /// The angle of the cyan component in degrees.
-        /// </summary>
-        private float cyanAngle = 15f;
-
-        /// <summary>
-        /// The angle of the magenta component in degrees.
-        /// </summary>
-        private float magentaAngle = 75f;
-
-        /// <summary>
-        /// The angle of the yellow component in degrees.
-        /// </summary>
-        // ReSharper disable once RedundantDefaultMemberInitializer
-        private float yellowAngle = 0f;
-
-        /// <summary>
-        /// The angle of the keyline component in degrees.
-        /// </summary>
-        private float keylineAngle = 45f;
-
-        /// <summary>
-        /// The distance between component points.
-        /// </summary>
-        private int distance = 4;
-
-        /// <summary>
         /// Initializes a new instance of the <see cref="HalftoneFilter"/> class.
         /// </summary>
         public HalftoneFilter()
@@ -64,90 +38,32 @@ namespace ImageProcessor.Imaging.Filters.Artistic
         /// <param name="distance">
         /// The distance.
         /// </param>
-        public HalftoneFilter(int distance)
-        {
-            this.distance = distance;
-        }
+        public HalftoneFilter(int distance) => this.Distance = distance;
 
         /// <summary>
         /// Gets or sets the angle of the cyan component in degrees.
         /// </summary>
-        public float CyanAngle
-        {
-            get
-            {
-                return this.cyanAngle;
-            }
-
-            set
-            {
-                this.cyanAngle = value;
-            }
-        }
+        public float CyanAngle { get; set; } = 15f;
 
         /// <summary>
         /// Gets or sets the angle of the magenta component in degrees.
         /// </summary>
-        public float MagentaAngle
-        {
-            get
-            {
-                return this.magentaAngle;
-            }
-
-            set
-            {
-                this.magentaAngle = value;
-            }
-        }
+        public float MagentaAngle { get; set; } = 75f;
 
         /// <summary>
         /// Gets or sets the angle of the yellow component in degrees.
         /// </summary>
-        public float YellowAngle
-        {
-            get
-            {
-                return this.yellowAngle;
-            }
-
-            set
-            {
-                this.yellowAngle = value;
-            }
-        }
+        public float YellowAngle { get; set; }
 
         /// <summary>
         /// Gets or sets the angle of the keyline black component in degrees.
         /// </summary>
-        public float KeylineAngle
-        {
-            get
-            {
-                return this.keylineAngle;
-            }
-
-            set
-            {
-                this.keylineAngle = value;
-            }
-        }
+        public float KeylineAngle { get; set; } = 45f;
 
         /// <summary>
         /// Gets or sets the distance between component points.
         /// </summary>
-        public int Distance
-        {
-            get
-            {
-                return this.distance;
-            }
-
-            set
-            {
-                this.distance = value;
-            }
-        }
+        public int Distance { get; set; } = 4;
 
         /// <summary>
         /// Applies the halftone filter. 
@@ -172,21 +88,21 @@ namespace ImageProcessor.Imaging.Filters.Artistic
             {
                 int sourceWidth = source.Width;
                 int sourceHeight = source.Height;
-                int width = source.Width + this.distance;
-                int height = source.Height + this.distance;
+                int width = source.Width + this.Distance;
+                int height = source.Height + this.Distance;
 
                 // Draw a slightly larger image, flipping the top/left pixels to prevent
                 // jagged edge of output.
                 padded = new Bitmap(width, height, PixelFormat.Format32bppPArgb);
                 padded.SetResolution(source.HorizontalResolution, source.VerticalResolution);
-                using (Graphics graphicsPadded = Graphics.FromImage(padded))
+                using (var graphicsPadded = Graphics.FromImage(padded))
                 {
                     graphicsPadded.Clear(Color.White);
-                    Rectangle destinationRectangle = new Rectangle(0, 0, sourceWidth + this.distance, source.Height + this.distance);
-                    using (TextureBrush tb = new TextureBrush(source))
+                    var destinationRectangle = new Rectangle(0, 0, sourceWidth + this.Distance, source.Height + this.Distance);
+                    using (var tb = new TextureBrush(source))
                     {
                         tb.WrapMode = WrapMode.TileFlipXY;
-                        tb.TranslateTransform(this.distance, this.distance);
+                        tb.TranslateTransform(this.Distance, this.Distance);
                         graphicsPadded.FillRectangle(tb, destinationRectangle);
                     }
                 }
@@ -200,12 +116,12 @@ namespace ImageProcessor.Imaging.Filters.Artistic
                 Point center = Point.Empty;
 
                 // Yellow oversaturates the output.
-                int offset = this.distance;
-                float yellowMultiplier = this.distance * 1.587f;
-                float magentaMultiplier = this.distance * 2.176f;
-                float multiplier = this.distance * 2.2f;
-                float max = this.distance * (float)Math.Sqrt(2);
-                float magentaMax = this.distance * (float)Math.Sqrt(1.4545);
+                int offset = this.Distance;
+                float yellowMultiplier = this.Distance * 1.587f;
+                float magentaMultiplier = this.Distance * 2.176f;
+                float multiplier = this.Distance * 2.2f;
+                float max = this.Distance * (float)Math.Sqrt(2);
+                float magentaMax = this.Distance * (float)Math.Sqrt(1.4545);
 
                 // Bump up the keyline max so that black looks black.
                 float keylineMax = max * (float)Math.Sqrt(2);
@@ -231,12 +147,12 @@ namespace ImageProcessor.Imaging.Filters.Artistic
                 newImage.SetResolution(source.HorizontalResolution, source.VerticalResolution);
 
                 // Check bounds against this.
-                Rectangle rectangle = new Rectangle(0, 0, width, height);
+                var rectangle = new Rectangle(0, 0, width, height);
 
-                using (Graphics graphicsCyan = Graphics.FromImage(cyan))
-                using (Graphics graphicsMagenta = Graphics.FromImage(magenta))
-                using (Graphics graphicsYellow = Graphics.FromImage(yellow))
-                using (Graphics graphicsKeyline = Graphics.FromImage(keyline))
+                using (var graphicsCyan = Graphics.FromImage(cyan))
+                using (var graphicsMagenta = Graphics.FromImage(magenta))
+                using (var graphicsYellow = Graphics.FromImage(yellow))
+                using (var graphicsKeyline = Graphics.FromImage(keyline))
                 {
                     // Set the quality properties.
                     graphicsCyan.PixelOffsetMode = PixelOffsetMode.Half;
@@ -262,7 +178,7 @@ namespace ImageProcessor.Imaging.Filters.Artistic
 
                     // This is too slow. The graphics object can't be called within a parallel 
                     // loop so we have to do it old school. :(
-                    using (FastBitmap sourceBitmap = new FastBitmap(padded))
+                    using (var sourceBitmap = new FastBitmap(padded))
                     {
                         for (int y = minY; y < maxY; y += offset)
                         {
@@ -273,7 +189,7 @@ namespace ImageProcessor.Imaging.Filters.Artistic
                                 float brushWidth;
 
                                 // Cyan
-                                Point rotatedPoint = ImageMaths.RotatePoint(new Point(x, y), this.cyanAngle, center);
+                                Point rotatedPoint = ImageMaths.RotatePoint(new Point(x, y), this.CyanAngle, center);
                                 int angledX = rotatedPoint.X;
                                 int angledY = rotatedPoint.Y;
                                 if (rectangle.Contains(new Point(angledX, angledY)))
@@ -285,7 +201,7 @@ namespace ImageProcessor.Imaging.Filters.Artistic
                                 }
 
                                 // Magenta
-                                rotatedPoint = ImageMaths.RotatePoint(new Point(x, y), this.magentaAngle, center);
+                                rotatedPoint = ImageMaths.RotatePoint(new Point(x, y), this.MagentaAngle, center);
                                 angledX = rotatedPoint.X;
                                 angledY = rotatedPoint.Y;
                                 if (rectangle.Contains(new Point(angledX, angledY)))
@@ -297,7 +213,7 @@ namespace ImageProcessor.Imaging.Filters.Artistic
                                 }
 
                                 // Yellow
-                                rotatedPoint = ImageMaths.RotatePoint(new Point(x, y), this.yellowAngle, center);
+                                rotatedPoint = ImageMaths.RotatePoint(new Point(x, y), this.YellowAngle, center);
                                 angledX = rotatedPoint.X;
                                 angledY = rotatedPoint.Y;
                                 if (rectangle.Contains(new Point(angledX, angledY)))
@@ -309,7 +225,7 @@ namespace ImageProcessor.Imaging.Filters.Artistic
                                 }
 
                                 // Keyline 
-                                rotatedPoint = ImageMaths.RotatePoint(new Point(x, y), this.keylineAngle, center);
+                                rotatedPoint = ImageMaths.RotatePoint(new Point(x, y), this.KeylineAngle, center);
                                 angledX = rotatedPoint.X;
                                 angledY = rotatedPoint.Y;
                                 if (rectangle.Contains(new Point(angledX, angledY)))
@@ -327,17 +243,17 @@ namespace ImageProcessor.Imaging.Filters.Artistic
                     }
 
                     // Set our white background.
-                    using (Graphics graphics = Graphics.FromImage(newImage))
+                    using (var graphics = Graphics.FromImage(newImage))
                     {
                         graphics.Clear(Color.White);
                     }
 
                     // Blend the colors now to mimic adaptive blending.
-                    using (FastBitmap cyanBitmap = new FastBitmap(cyan))
-                    using (FastBitmap magentaBitmap = new FastBitmap(magenta))
-                    using (FastBitmap yellowBitmap = new FastBitmap(yellow))
-                    using (FastBitmap keylineBitmap = new FastBitmap(keyline))
-                    using (FastBitmap destinationBitmap = new FastBitmap(newImage))
+                    using (var cyanBitmap = new FastBitmap(cyan))
+                    using (var magentaBitmap = new FastBitmap(magenta))
+                    using (var yellowBitmap = new FastBitmap(yellow))
+                    using (var keylineBitmap = new FastBitmap(keyline))
+                    using (var destinationBitmap = new FastBitmap(newImage))
                     {
                         Parallel.For(
                             offset,
@@ -377,35 +293,12 @@ namespace ImageProcessor.Imaging.Filters.Artistic
             }
             catch
             {
-                if (padded != null)
-                {
-                    padded.Dispose();
-                }
-
-                if (cyan != null)
-                {
-                    cyan.Dispose();
-                }
-
-                if (magenta != null)
-                {
-                    magenta.Dispose();
-                }
-
-                if (yellow != null)
-                {
-                    yellow.Dispose();
-                }
-
-                if (keyline != null)
-                {
-                    keyline.Dispose();
-                }
-
-                if (newImage != null)
-                {
-                    newImage.Dispose();
-                }
+                padded?.Dispose();
+                cyan?.Dispose();
+                magenta?.Dispose();
+                yellow?.Dispose();
+                keyline?.Dispose();
+                newImage?.Dispose();
             }
 
             return source;
@@ -427,9 +320,7 @@ namespace ImageProcessor.Imaging.Filters.Artistic
         {
             int maxWidth = 0;
             int maxHeight = 0;
-            List<float> angles = new List<float> { this.CyanAngle, this.MagentaAngle, this.YellowAngle, this.KeylineAngle };
-
-            foreach (float angle in angles)
+            foreach (float angle in new List<float> { this.CyanAngle, this.MagentaAngle, this.YellowAngle, this.KeylineAngle })
             {
                 Size rotatedSize = ImageMaths.GetBoundingRotatedRectangle(width, height, angle).Size;
                 maxWidth = Math.Max(maxWidth, rotatedSize.Width);

--- a/src/ImageProcessor/Imaging/Filters/Artistic/OilPaintingFilter.cs
+++ b/src/ImageProcessor/Imaging/Filters/Artistic/OilPaintingFilter.cs
@@ -52,10 +52,7 @@ namespace ImageProcessor.Imaging.Filters.Artistic
         /// </summary>
         public int Levels
         {
-            get
-            {
-                return this.levels;
-            }
+            get => this.levels;
 
             set
             {
@@ -71,10 +68,7 @@ namespace ImageProcessor.Imaging.Filters.Artistic
         /// </summary>
         public int BrushSize
         {
-            get
-            {
-                return this.brushSize;
-            }
+            get => this.brushSize;
 
             set
             {
@@ -102,11 +96,11 @@ namespace ImageProcessor.Imaging.Filters.Artistic
 
             int radius = this.brushSize >> 1;
 
-            Bitmap destination = new Bitmap(width, height, PixelFormat.Format32bppPArgb);
+            var destination = new Bitmap(width, height, PixelFormat.Format32bppPArgb);
             destination.SetResolution(source.HorizontalResolution, source.VerticalResolution);
-            using (FastBitmap sourceBitmap = new FastBitmap(source))
+            using (var sourceBitmap = new FastBitmap(source))
             {
-                using (FastBitmap destinationBitmap = new FastBitmap(destination))
+                using (var destinationBitmap = new FastBitmap(destination))
                 {
                     Parallel.For(
                         0,
@@ -163,7 +157,7 @@ namespace ImageProcessor.Imaging.Filters.Artistic
 
                                             int currentIntensity = (int)Math.Round(((sourceBlue + sourceGreen + sourceRed) / 3.0 * (this.levels - 1)) / 255.0);
 
-                                            intensityBin[currentIntensity] += 1;
+                                            intensityBin[currentIntensity]++;
                                             blueBin[currentIntensity] += sourceBlue;
                                             greenBin[currentIntensity] += sourceGreen;
                                             redBin[currentIntensity] += sourceRed;

--- a/src/ImageProcessor/Imaging/Filters/Binarization/BinaryThreshold.cs
+++ b/src/ImageProcessor/Imaging/Filters/Binarization/BinaryThreshold.cs
@@ -19,36 +19,17 @@ namespace ImageProcessor.Imaging.Filters.Binarization
     public class BinaryThreshold
     {
         /// <summary>
-        /// The threshold value.
-        /// </summary>
-        private byte threshold;
-
-        /// <summary>
         /// Initializes a new instance of the <see cref="BinaryThreshold"/> class.
         /// </summary>
         /// <param name="threshold">
         /// The threshold.
         /// </param>
-        public BinaryThreshold(byte threshold = 10)
-        {
-            this.threshold = threshold;
-        }
+        public BinaryThreshold(byte threshold = 10) => this.Threshold = threshold;
 
         /// <summary>
         /// Gets or sets the threshold.
         /// </summary>
-        public byte Threshold
-        {
-            get
-            {
-                return this.threshold;
-            }
-
-            set
-            {
-                this.threshold = value;
-            }
-        }
+        public byte Threshold { get; set; }
 
         /// <summary>
         /// Processes the given bitmap to apply the threshold.
@@ -64,18 +45,18 @@ namespace ImageProcessor.Imaging.Filters.Binarization
             int width = source.Width;
             int height = source.Height;
 
-            using (FastBitmap sourceBitmap = new FastBitmap(source))
+            using (var sourceBitmap = new FastBitmap(source))
             {
                 Parallel.For(
-                    0, 
-                    height, 
+                    0,
+                    height,
                     y =>
                     {
                         for (int x = 0; x < width; x++)
                         {
                             // ReSharper disable AccessToDisposedClosure
                             Color color = sourceBitmap.GetPixel(x, y);
-                            sourceBitmap.SetPixel(x, y, color.B >= this.threshold ? Color.White : Color.Black);
+                            sourceBitmap.SetPixel(x, y, color.B >= this.Threshold ? Color.White : Color.Black);
 
                             // ReSharper restore AccessToDisposedClosure
                         }

--- a/src/ImageProcessor/Imaging/Filters/EdgeDetection/ConvolutionFilter.cs
+++ b/src/ImageProcessor/Imaging/Filters/EdgeDetection/ConvolutionFilter.cs
@@ -63,21 +63,21 @@ namespace ImageProcessor.Imaging.Filters.EdgeDetection
             int bufferedWidth = width + 2;
             int bufferedHeight = height + 2;
 
-            Bitmap destination = new Bitmap(width, height, PixelFormat.Format32bppPArgb);
-            Bitmap input = new Bitmap(bufferedWidth, bufferedHeight, PixelFormat.Format32bppPArgb);
+            var destination = new Bitmap(width, height, PixelFormat.Format32bppPArgb);
+            var input = new Bitmap(bufferedWidth, bufferedHeight, PixelFormat.Format32bppPArgb);
             destination.SetResolution(source.HorizontalResolution, source.VerticalResolution);
             input.SetResolution(source.HorizontalResolution, source.VerticalResolution);
 
-            using (Graphics graphics = Graphics.FromImage(input))
+            using (var graphics = Graphics.FromImage(input))
             {
                 // Fixes an issue with transparency not converting properly.
                 graphics.Clear(Color.Transparent);
 
-                Rectangle destinationRectangle = new Rectangle(0, 0, bufferedWidth, bufferedHeight);
-                Rectangle rectangle = new Rectangle(0, 0, width, height);
+                var destinationRectangle = new Rectangle(0, 0, bufferedWidth, bufferedHeight);
+                var rectangle = new Rectangle(0, 0, width, height);
 
                 // If it's greyscale apply a colormatrix to the image.
-                using (ImageAttributes attributes = new ImageAttributes())
+                using (var attributes = new ImageAttributes())
                 {
                     if (this.greyscale)
                     {
@@ -87,7 +87,7 @@ namespace ImageProcessor.Imaging.Filters.EdgeDetection
                     // We use a trick here to detect right to the edges of the image.
                     // flip/tile the image with a pixel in excess in each direction to duplicate pixels.
                     // Later on we draw pixels without that excess.
-                    using (TextureBrush tb = new TextureBrush(source, rectangle, attributes))
+                    using (var tb = new TextureBrush(source, rectangle, attributes))
                     {
                         tb.WrapMode = WrapMode.TileFlipXY;
                         tb.TranslateTransform(1, 1);
@@ -104,9 +104,9 @@ namespace ImageProcessor.Imaging.Filters.EdgeDetection
                 int kernelLength = horizontalFilter.GetLength(0);
                 int radius = kernelLength >> 1;
 
-                using (FastBitmap sourceBitmap = new FastBitmap(input))
+                using (var sourceBitmap = new FastBitmap(input))
                 {
-                    using (FastBitmap destinationBitmap = new FastBitmap(destination))
+                    using (var destinationBitmap = new FastBitmap(destination))
                     {
                         // Loop through the pixels.
                         Parallel.For(
@@ -171,7 +171,7 @@ namespace ImageProcessor.Imaging.Filters.EdgeDetection
                                     byte green = gX.ToByte();
                                     byte blue = bX.ToByte();
 
-                                    Color newColor = Color.FromArgb(red, green, blue);
+                                    var newColor = Color.FromArgb(red, green, blue);
                                     if (y > 0 && x > 0 && y < maxHeight && x < maxWidth)
                                     {
                                         // ReSharper disable once AccessToDisposedClosure
@@ -205,21 +205,21 @@ namespace ImageProcessor.Imaging.Filters.EdgeDetection
             int bufferedWidth = width + 2;
             int bufferedHeight = height + 2;
 
-            Bitmap destination = new Bitmap(width, height, PixelFormat.Format32bppPArgb);
-            Bitmap input = new Bitmap(bufferedWidth, bufferedHeight, PixelFormat.Format32bppPArgb);
+            var destination = new Bitmap(width, height, PixelFormat.Format32bppPArgb);
+            var input = new Bitmap(bufferedWidth, bufferedHeight, PixelFormat.Format32bppPArgb);
             destination.SetResolution(source.HorizontalResolution, source.VerticalResolution);
             input.SetResolution(source.HorizontalResolution, source.VerticalResolution);
 
-            using (Graphics graphics = Graphics.FromImage(input))
+            using (var graphics = Graphics.FromImage(input))
             {
                 // Fixes an issue with transparency not converting properly.
                 graphics.Clear(Color.Transparent);
 
-                Rectangle destinationRectangle = new Rectangle(0, 0, bufferedWidth, bufferedHeight);
-                Rectangle rectangle = new Rectangle(0, 0, width, height);
+                var destinationRectangle = new Rectangle(0, 0, bufferedWidth, bufferedHeight);
+                var rectangle = new Rectangle(0, 0, width, height);
 
                 // If it's greyscale apply a colormatrix to the image.
-                using (ImageAttributes attributes = new ImageAttributes())
+                using (var attributes = new ImageAttributes())
                 {
                     if (this.greyscale)
                     {
@@ -229,7 +229,7 @@ namespace ImageProcessor.Imaging.Filters.EdgeDetection
                     // We use a trick here to detect right to the edges of the image.
                     // flip/tile the image with a pixel in excess in each direction to duplicate pixels.
                     // Later on we draw pixels without that excess.
-                    using (TextureBrush tb = new TextureBrush(source, rectangle, attributes))
+                    using (var tb = new TextureBrush(source, rectangle, attributes))
                     {
                         tb.WrapMode = WrapMode.TileFlipXY;
                         tb.TranslateTransform(1, 1);
@@ -247,9 +247,9 @@ namespace ImageProcessor.Imaging.Filters.EdgeDetection
                 int kernelLength = horizontalFilter.GetLength(0);
                 int radius = kernelLength >> 1;
 
-                using (FastBitmap sourceBitmap = new FastBitmap(input))
+                using (var sourceBitmap = new FastBitmap(input))
                 {
-                    using (FastBitmap destinationBitmap = new FastBitmap(destination))
+                    using (var destinationBitmap = new FastBitmap(destination))
                     {
                         // Loop through the pixels.
                         Parallel.For(
@@ -320,7 +320,7 @@ namespace ImageProcessor.Imaging.Filters.EdgeDetection
                                     byte green = Math.Sqrt((gX * gX) + (gY * gY)).ToByte();
                                     byte blue = Math.Sqrt((bX * bX) + (bY * bY)).ToByte();
 
-                                    Color newColor = Color.FromArgb(red, green, blue);
+                                    var newColor = Color.FromArgb(red, green, blue);
                                     if (y > 0 && x > 0 && y < maxHeight && x < maxWidth)
                                     {
                                         // ReSharper disable once AccessToDisposedClosure

--- a/src/ImageProcessor/Imaging/Filters/EdgeDetection/KayyaliEdgeFilter.cs
+++ b/src/ImageProcessor/Imaging/Filters/EdgeDetection/KayyaliEdgeFilter.cs
@@ -20,20 +20,20 @@ namespace ImageProcessor.Imaging.Filters.EdgeDetection
         /// <summary>
         /// Gets the horizontal gradient operator.
         /// </summary>
-        public double[,] HorizontalGradientOperator => new double[,] 
+        public double[,] HorizontalGradientOperator => new double[,]
         {
-            { 6, 0, -6 }, 
-            { 0, 0, 0 }, 
+            { 6, 0, -6 },
+            { 0, 0, 0 },
             { -6, 0, 6 }
         };
 
         /// <summary>
         /// Gets the vertical gradient operator.
         /// </summary>
-        public double[,] VerticalGradientOperator => new double[,] 
+        public double[,] VerticalGradientOperator => new double[,]
         {
-            { -6, 0, 6 }, 
-            { 0, 0, 0 }, 
+            { -6, 0, 6 },
+            { 0, 0, 0 },
             { 6, 0, -6 }
         };
     }

--- a/src/ImageProcessor/Imaging/Filters/EdgeDetection/KirschEdgeFilter.cs
+++ b/src/ImageProcessor/Imaging/Filters/EdgeDetection/KirschEdgeFilter.cs
@@ -20,21 +20,21 @@ namespace ImageProcessor.Imaging.Filters.EdgeDetection
         /// <summary>
         /// Gets the horizontal gradient operator.
         /// </summary>
-        public double[,] HorizontalGradientOperator => new double[,] 
+        public double[,] HorizontalGradientOperator => new double[,]
         {
-            { 5, 5, 5 }, 
-            { -3, 0, -3 }, 
+            { 5, 5, 5 },
+            { -3, 0, -3 },
             { -3, -3, -3 }
         };
 
         /// <summary>
         /// Gets the vertical gradient operator.
         /// </summary>
-        public double[,] VerticalGradientOperator => new double[,] 
-        { 
-            { 5, -3, -3 }, 
-            { 5,  0, -3 }, 
-            { 5, -3, -3 } 
+        public double[,] VerticalGradientOperator => new double[,]
+        {
+            { 5, -3, -3 },
+            { 5,  0, -3 },
+            { 5, -3, -3 }
         };
     }
 }

--- a/src/ImageProcessor/Imaging/Filters/EdgeDetection/Laplacian3X3EdgeFilter.cs
+++ b/src/ImageProcessor/Imaging/Filters/EdgeDetection/Laplacian3X3EdgeFilter.cs
@@ -20,11 +20,11 @@ namespace ImageProcessor.Imaging.Filters.EdgeDetection
         /// <summary>
         /// Gets the horizontal gradient operator.
         /// </summary>
-        public double[,] HorizontalGradientOperator => new double[,]  
-        { 
-            { -1, -1, -1 }, 
-            { -1,  8, -1 }, 
-            { -1, -1, -1 } 
+        public double[,] HorizontalGradientOperator => new double[,]
+        {
+            { -1, -1, -1 },
+            { -1,  8, -1 },
+            { -1, -1, -1 }
         };
     }
 }

--- a/src/ImageProcessor/Imaging/Filters/EdgeDetection/Laplacian5X5EdgeFilter.cs
+++ b/src/ImageProcessor/Imaging/Filters/EdgeDetection/Laplacian5X5EdgeFilter.cs
@@ -20,12 +20,12 @@ namespace ImageProcessor.Imaging.Filters.EdgeDetection
         /// <summary>
         /// Gets the horizontal gradient operator.
         /// </summary>
-        public double[,] HorizontalGradientOperator => new double[,] 
-        { 
-            { -1, -1, -1, -1, -1 }, 
-            { -1, -1, -1, -1, -1 }, 
-            { -1, -1, 24, -1, -1 }, 
-            { -1, -1, -1, -1, -1 }, 
+        public double[,] HorizontalGradientOperator => new double[,]
+        {
+            { -1, -1, -1, -1, -1 },
+            { -1, -1, -1, -1, -1 },
+            { -1, -1, 24, -1, -1 },
+            { -1, -1, -1, -1, -1 },
             { -1, -1, -1, -1, -1 }
         };
     }

--- a/src/ImageProcessor/Imaging/Filters/EdgeDetection/LaplacianOfGaussianEdgeFilter.cs
+++ b/src/ImageProcessor/Imaging/Filters/EdgeDetection/LaplacianOfGaussianEdgeFilter.cs
@@ -20,10 +20,10 @@ namespace ImageProcessor.Imaging.Filters.EdgeDetection
         /// <summary>
         /// Gets the horizontal gradient operator.
         /// </summary>
-        public double[,] HorizontalGradientOperator => new double[,]  
-        { 
-            { 0, 0, -1,  0,  0 }, 
-            { 0, -1, -2, -1,  0 }, 
+        public double[,] HorizontalGradientOperator => new double[,]
+        {
+            { 0, 0, -1,  0,  0 },
+            { 0, -1, -2, -1,  0 },
             { -1, -2, 16, -2, -1 },
             { 0, -1, -2, -1,  0 },
             { 0, 0, -1,  0,  0 }

--- a/src/ImageProcessor/Imaging/Filters/EdgeDetection/PrewittEdgeFilter.cs
+++ b/src/ImageProcessor/Imaging/Filters/EdgeDetection/PrewittEdgeFilter.cs
@@ -22,8 +22,8 @@ namespace ImageProcessor.Imaging.Filters.EdgeDetection
         /// </summary>
         public double[,] HorizontalGradientOperator => new double[,]
         {
-            { -1, 0, 1 }, 
-            { -1, 0, 1 }, 
+            { -1, 0, 1 },
+            { -1, 0, 1 },
             { -1, 0, 1 }
         };
 
@@ -32,8 +32,8 @@ namespace ImageProcessor.Imaging.Filters.EdgeDetection
         /// </summary>
         public double[,] VerticalGradientOperator => new double[,]
         {
-            { 1, 1, 1 }, 
-            { 0, 0, 0 }, 
+            { 1, 1, 1 },
+            { 0, 0, 0 },
             { -1, -1, -1 }
         };
     }

--- a/src/ImageProcessor/Imaging/Filters/EdgeDetection/RobertsCrossEdgeFilter.cs
+++ b/src/ImageProcessor/Imaging/Filters/EdgeDetection/RobertsCrossEdgeFilter.cs
@@ -22,7 +22,7 @@ namespace ImageProcessor.Imaging.Filters.EdgeDetection
         /// </summary>
         public double[,] HorizontalGradientOperator => new double[,]
         {
-            { 1, 0 }, 
+            { 1, 0 },
             { 0, -1 }
         };
 
@@ -31,7 +31,7 @@ namespace ImageProcessor.Imaging.Filters.EdgeDetection
         /// </summary>
         public double[,] VerticalGradientOperator => new double[,]
         {
-            { 0, 1 }, 
+            { 0, 1 },
             { -1, 0 }
         };
     }

--- a/src/ImageProcessor/Imaging/Filters/EdgeDetection/ScharrEdgeFilter.cs
+++ b/src/ImageProcessor/Imaging/Filters/EdgeDetection/ScharrEdgeFilter.cs
@@ -22,8 +22,8 @@ namespace ImageProcessor.Imaging.Filters.EdgeDetection
         /// </summary>
         public double[,] HorizontalGradientOperator => new double[,]
         {
-            { -3, 0, 3 }, 
-            { -10, 0, 10 }, 
+            { -3, 0, 3 },
+            { -10, 0, 10 },
             { -3, 0, 3 }
         };
 
@@ -32,8 +32,8 @@ namespace ImageProcessor.Imaging.Filters.EdgeDetection
         /// </summary>
         public double[,] VerticalGradientOperator => new double[,]
         {
-            { 3, 10, 3 }, 
-            { 0, 0, 0 }, 
+            { 3, 10, 3 },
+            { 0, 0, 0 },
             { -3, -10, -3 }
         };
     }

--- a/src/ImageProcessor/Imaging/Filters/EdgeDetection/SobelEdgeFilter.cs
+++ b/src/ImageProcessor/Imaging/Filters/EdgeDetection/SobelEdgeFilter.cs
@@ -22,8 +22,8 @@ namespace ImageProcessor.Imaging.Filters.EdgeDetection
         /// </summary>
         public double[,] HorizontalGradientOperator => new double[,]
         {
-            { -1, 0, 1 }, 
-            { -2, 0, 2 }, 
+            { -1, 0, 1 },
+            { -2, 0, 2 },
             { -1, 0, 1 }
         };
 
@@ -32,8 +32,8 @@ namespace ImageProcessor.Imaging.Filters.EdgeDetection
         /// </summary>
         public double[,] VerticalGradientOperator => new double[,]
         {
-            { 1, 2, 1 }, 
-            { 0, 0, 0 }, 
+            { 1, 2, 1 },
+            { 0, 0, 0 },
             { -1, -2, -1 }
         };
     }

--- a/src/ImageProcessor/Imaging/Filters/Photo/BlackWhiteMatrixFilter.cs
+++ b/src/ImageProcessor/Imaging/Filters/Photo/BlackWhiteMatrixFilter.cs
@@ -33,13 +33,13 @@ namespace ImageProcessor.Imaging.Filters.Photo
         /// </returns>
         public override Bitmap TransformImage(Image source, Image destination)
         {
-            using (Graphics graphics = Graphics.FromImage(destination))
+            using (var graphics = Graphics.FromImage(destination))
             {
-                using (ImageAttributes attributes = new ImageAttributes())
+                using (var attributes = new ImageAttributes())
                 {
                     attributes.SetColorMatrix(this.Matrix);
 
-                    Rectangle rectangle = new Rectangle(0, 0, source.Width, source.Height);
+                    var rectangle = new Rectangle(0, 0, source.Width, source.Height);
 
                     graphics.DrawImage(source, rectangle, 0, 0, source.Width, source.Height, GraphicsUnit.Pixel, attributes);
                 }

--- a/src/ImageProcessor/Imaging/Filters/Photo/ColorMatrixes.cs
+++ b/src/ImageProcessor/Imaging/Filters/Photo/ColorMatrixes.cs
@@ -172,7 +172,7 @@ namespace ImageProcessor.Imaging.Filters.Photo
         /// <summary>
         /// Gets the <see cref="T:System.Drawing.Imaging.ColorMatrix"/> for generating the low saturation filter.
         /// </summary>
-        internal static ColorMatrix LoSatch => 
+        internal static ColorMatrix LoSatch =>
             loSatch ?? (loSatch = new ColorMatrix(
             new[]
                 {
@@ -186,7 +186,7 @@ namespace ImageProcessor.Imaging.Filters.Photo
         /// <summary>
         /// Gets the <see cref="T:System.Drawing.Imaging.ColorMatrix"/> for generating the polaroid filter.
         /// </summary>
-        internal static ColorMatrix Polaroid => 
+        internal static ColorMatrix Polaroid =>
             polaroid ?? (polaroid = new ColorMatrix(
             new[]
                 {
@@ -200,7 +200,7 @@ namespace ImageProcessor.Imaging.Filters.Photo
         /// <summary>
         /// Gets the <see cref="T:System.Drawing.Imaging.ColorMatrix"/> for generating the sepia filter.
         /// </summary>
-        internal static ColorMatrix Sepia => 
+        internal static ColorMatrix Sepia =>
             sepia ?? (sepia = new ColorMatrix(
             new[]
                 {

--- a/src/ImageProcessor/Imaging/Filters/Photo/ComicMatrixFilter.cs
+++ b/src/ImageProcessor/Imaging/Filters/Photo/ComicMatrixFilter.cs
@@ -29,69 +29,69 @@ namespace ImageProcessor.Imaging.Filters.Photo
         /// <summary>
         /// Processes the image.
         /// </summary>
-        /// <param name="image">The current image to process</param>
-        /// <param name="newImage">The new Image to return</param>
+        /// <param name="source">The current image to process</param>
+        /// <param name="destination">The new Image to return</param>
         /// <returns>
         /// The processed <see cref="System.Drawing.Bitmap"/>.
         /// </returns>
-        public override Bitmap TransformImage(Image image, Image newImage)
+        public override Bitmap TransformImage(Image source, Image destination)
         {
             // Bitmaps for comic pattern
             Bitmap highBitmap = null;
             Bitmap lowBitmap = null;
             Bitmap patternBitmap = null;
             Bitmap edgeBitmap = null;
-            int width = image.Width;
-            int height = image.Height;
+            int width = source.Width;
+            int height = source.Height;
 
             try
             {
-                using (ImageAttributes attributes = new ImageAttributes())
+                using (var attributes = new ImageAttributes())
                 {
-                    Rectangle rectangle = new Rectangle(0, 0, image.Width, image.Height);
+                    var rectangle = new Rectangle(0, 0, source.Width, source.Height);
 
                     attributes.SetColorMatrix(ColorMatrixes.ComicHigh);
 
                     // Draw the image with the high comic colormatrix.
                     highBitmap = new Bitmap(rectangle.Width, rectangle.Height, PixelFormat.Format32bppPArgb);
-                    highBitmap.SetResolution(image.HorizontalResolution, image.VerticalResolution);
+                    highBitmap.SetResolution(source.HorizontalResolution, source.VerticalResolution);
 
                     // Apply a oil painting filter to the image.
-                    highBitmap = new OilPaintingFilter(3, 5).ApplyFilter((Bitmap)image);
+                    highBitmap = new OilPaintingFilter(3, 5).ApplyFilter((Bitmap)source);
 
                     // Draw the edges.
                     edgeBitmap = new Bitmap(width, height, PixelFormat.Format32bppPArgb);
-                    edgeBitmap.SetResolution(image.HorizontalResolution, image.VerticalResolution);
-                    edgeBitmap = Effects.Trace(image, edgeBitmap, 120);
+                    edgeBitmap.SetResolution(source.HorizontalResolution, source.VerticalResolution);
+                    edgeBitmap = Effects.Trace(source, edgeBitmap, 120);
 
-                    using (Graphics graphics = Graphics.FromImage(highBitmap))
+                    using (var graphics = Graphics.FromImage(highBitmap))
                     {
-                        graphics.DrawImage(highBitmap, rectangle, 0, 0, image.Width, image.Height, GraphicsUnit.Pixel, attributes);
+                        graphics.DrawImage(highBitmap, rectangle, 0, 0, source.Width, source.Height, GraphicsUnit.Pixel, attributes);
                     }
 
                     // Create a bitmap for overlaying.
                     lowBitmap = new Bitmap(rectangle.Width, rectangle.Height, PixelFormat.Format32bppPArgb);
-                    lowBitmap.SetResolution(image.HorizontalResolution, image.VerticalResolution);
+                    lowBitmap.SetResolution(source.HorizontalResolution, source.VerticalResolution);
 
                     // Set the color matrix
                     attributes.SetColorMatrix(this.Matrix);
 
                     // Draw the image with the losatch colormatrix.
-                    using (Graphics graphics = Graphics.FromImage(lowBitmap))
+                    using (var graphics = Graphics.FromImage(lowBitmap))
                     {
-                        graphics.DrawImage(highBitmap, rectangle, 0, 0, image.Width, image.Height, GraphicsUnit.Pixel, attributes);
+                        graphics.DrawImage(highBitmap, rectangle, 0, 0, source.Width, source.Height, GraphicsUnit.Pixel, attributes);
                     }
 
                     // We need to create a new image now with a pattern mask to paint it
                     // onto the other image with.
                     patternBitmap = new Bitmap(rectangle.Width, rectangle.Height, PixelFormat.Format32bppPArgb);
-                    patternBitmap.SetResolution(image.HorizontalResolution, image.VerticalResolution);
+                    patternBitmap.SetResolution(source.HorizontalResolution, source.VerticalResolution);
 
                     // Create the pattern mask.
-                    using (Graphics graphics = Graphics.FromImage(patternBitmap))
+                    using (var graphics = Graphics.FromImage(patternBitmap))
                     {
                         graphics.Clear(Color.Transparent);
-                   
+
                         for (int y = 0; y < height; y += 8)
                         {
                             for (int x = 0; x < width; x += 4)
@@ -105,7 +105,7 @@ namespace ImageProcessor.Imaging.Filters.Photo
                     // Transfer the alpha channel from the mask to the low saturation image.
                     lowBitmap = Effects.ApplyMask(lowBitmap, patternBitmap);
 
-                    using (Graphics graphics = Graphics.FromImage(newImage))
+                    using (var graphics = Graphics.FromImage(destination))
                     {
                         graphics.Clear(Color.Transparent);
 
@@ -115,7 +115,7 @@ namespace ImageProcessor.Imaging.Filters.Photo
                         graphics.DrawImage(edgeBitmap, 0, 0);
 
                         // Draw an edge around the image.
-                        using (Pen blackPen = new Pen(Color.Black))
+                        using (var blackPen = new Pen(Color.Black))
                         {
                             blackPen.Width = 4;
                             graphics.DrawRectangle(blackPen, rectangle);
@@ -130,12 +130,12 @@ namespace ImageProcessor.Imaging.Filters.Photo
                 }
 
                 // Reassign the image.
-                image.Dispose();
-                image = newImage;
+                source.Dispose();
+                source = destination;
             }
             catch
             {
-                newImage?.Dispose();
+                destination?.Dispose();
 
                 highBitmap?.Dispose();
 
@@ -146,7 +146,7 @@ namespace ImageProcessor.Imaging.Filters.Photo
                 edgeBitmap?.Dispose();
             }
 
-            return (Bitmap)image;
+            return (Bitmap)source;
         }
     }
 }

--- a/src/ImageProcessor/Imaging/Filters/Photo/GothamMatrixFilter.cs
+++ b/src/ImageProcessor/Imaging/Filters/Photo/GothamMatrixFilter.cs
@@ -32,28 +32,28 @@ namespace ImageProcessor.Imaging.Filters.Photo
         /// <param name="source">The current image to process</param>
         /// <param name="destination">The new Image to return</param>
         /// <returns>
-        /// The processed <see cref="System.Drawing.Bitmap"/>.
+        /// The processed <see cref="Bitmap"/>.
         /// </returns>
         public override Bitmap TransformImage(Image source, Image destination)
         {
-            using (Graphics graphics = Graphics.FromImage(destination))
+            using (var graphics = Graphics.FromImage(destination))
             {
-                using (ImageAttributes attributes = new ImageAttributes())
+                using (var attributes = new ImageAttributes())
                 {
                     attributes.SetColorMatrix(this.Matrix);
 
-                    Rectangle rectangle = new Rectangle(0, 0, source.Width, source.Height);
+                    var rectangle = new Rectangle(0, 0, source.Width, source.Height);
 
                     graphics.DrawImage(source, rectangle, 0, 0, source.Width, source.Height, GraphicsUnit.Pixel, attributes);
 
                     // Overlay the image with some semi-transparent colors to finish the effect.
-                    using (GraphicsPath path = new GraphicsPath())
+                    using (var path = new GraphicsPath())
                     {
                         path.AddRectangle(rectangle);
 
                         // Paint a burgundy rectangle with a transparency of ~30% over the image.
                         // Paint a blue rectangle with a transparency of 20% over the image.
-                        using (SolidBrush brush = new SolidBrush(Color.FromArgb(77, 38, 14, 28)))
+                        using (var brush = new SolidBrush(Color.FromArgb(77, 38, 14, 28)))
                         {
                             Region oldClip = graphics.Clip;
                             graphics.Clip = new Region(rectangle);

--- a/src/ImageProcessor/Imaging/Filters/Photo/GreyScaleMatrixFilter.cs
+++ b/src/ImageProcessor/Imaging/Filters/Photo/GreyScaleMatrixFilter.cs
@@ -33,13 +33,13 @@ namespace ImageProcessor.Imaging.Filters.Photo
         /// </returns>
         public override Bitmap TransformImage(Image source, Image destination)
         {
-            using (Graphics graphics = Graphics.FromImage(destination))
+            using (var graphics = Graphics.FromImage(destination))
             {
-                using (ImageAttributes attributes = new ImageAttributes())
+                using (var attributes = new ImageAttributes())
                 {
                     attributes.SetColorMatrix(this.Matrix);
 
-                    Rectangle rectangle = new Rectangle(0, 0, source.Width, source.Height);
+                    var rectangle = new Rectangle(0, 0, source.Width, source.Height);
 
                     graphics.DrawImage(source, rectangle, 0, 0, source.Width, source.Height, GraphicsUnit.Pixel, attributes);
                 }

--- a/src/ImageProcessor/Imaging/Filters/Photo/HiSatchMatrixFilter.cs
+++ b/src/ImageProcessor/Imaging/Filters/Photo/HiSatchMatrixFilter.cs
@@ -33,13 +33,13 @@ namespace ImageProcessor.Imaging.Filters.Photo
         /// </returns>
         public override Bitmap TransformImage(Image source, Image destination)
         {
-            using (Graphics graphics = Graphics.FromImage(destination))
+            using (var graphics = Graphics.FromImage(destination))
             {
-                using (ImageAttributes attributes = new ImageAttributes())
+                using (var attributes = new ImageAttributes())
                 {
                     attributes.SetColorMatrix(this.Matrix);
 
-                    Rectangle rectangle = new Rectangle(0, 0, source.Width, source.Height);
+                    var rectangle = new Rectangle(0, 0, source.Width, source.Height);
 
                     graphics.DrawImage(source, rectangle, 0, 0, source.Width, source.Height, GraphicsUnit.Pixel, attributes);
                 }

--- a/src/ImageProcessor/Imaging/Filters/Photo/IMatrixFilter.cs
+++ b/src/ImageProcessor/Imaging/Filters/Photo/IMatrixFilter.cs
@@ -27,9 +27,9 @@ namespace ImageProcessor.Imaging.Filters.Photo
         /// Processes the image.
         /// </summary>
         /// <param name="source">The current image to process</param>
-        /// <param name="destination">The new Image to return</param>
+        /// <param name="destination">The new image to return</param>
         /// <returns>
-        /// The processed <see cref="System.Drawing.Bitmap"/>.
+        /// The processed <see cref="Bitmap"/>.
         /// </returns>
         Bitmap TransformImage(Image source, Image destination);
     }

--- a/src/ImageProcessor/Imaging/Filters/Photo/InvertMatrixFilter.cs
+++ b/src/ImageProcessor/Imaging/Filters/Photo/InvertMatrixFilter.cs
@@ -33,13 +33,13 @@ namespace ImageProcessor.Imaging.Filters.Photo
         /// </returns>
         public override Bitmap TransformImage(Image source, Image destination)
         {
-            using (Graphics graphics = Graphics.FromImage(destination))
+            using (var graphics = Graphics.FromImage(destination))
             {
-                using (ImageAttributes attributes = new ImageAttributes())
+                using (var attributes = new ImageAttributes())
                 {
                     attributes.SetColorMatrix(this.Matrix);
 
-                    Rectangle rectangle = new Rectangle(0, 0, source.Width, source.Height);
+                    var rectangle = new Rectangle(0, 0, source.Width, source.Height);
 
                     graphics.DrawImage(source, rectangle, 0, 0, source.Width, source.Height, GraphicsUnit.Pixel, attributes);
                 }

--- a/src/ImageProcessor/Imaging/Filters/Photo/LoSatchMatrixFilter.cs
+++ b/src/ImageProcessor/Imaging/Filters/Photo/LoSatchMatrixFilter.cs
@@ -33,13 +33,13 @@ namespace ImageProcessor.Imaging.Filters.Photo
         /// </returns>
         public override Bitmap TransformImage(Image source, Image destination)
         {
-            using (Graphics graphics = Graphics.FromImage(destination))
+            using (var graphics = Graphics.FromImage(destination))
             {
-                using (ImageAttributes attributes = new ImageAttributes())
+                using (var attributes = new ImageAttributes())
                 {
                     attributes.SetColorMatrix(this.Matrix);
 
-                    Rectangle rectangle = new Rectangle(0, 0, source.Width, source.Height);
+                    var rectangle = new Rectangle(0, 0, source.Width, source.Height);
 
                     graphics.DrawImage(source, rectangle, 0, 0, source.Width, source.Height, GraphicsUnit.Pixel, attributes);
                 }

--- a/src/ImageProcessor/Imaging/Filters/Photo/LomographMatrixFilter.cs
+++ b/src/ImageProcessor/Imaging/Filters/Photo/LomographMatrixFilter.cs
@@ -35,13 +35,13 @@ namespace ImageProcessor.Imaging.Filters.Photo
         /// </returns>
         public override Bitmap TransformImage(Image source, Image destination)
         {
-            using (Graphics graphics = Graphics.FromImage(destination))
+            using (var graphics = Graphics.FromImage(destination))
             {
-                using (ImageAttributes attributes = new ImageAttributes())
+                using (var attributes = new ImageAttributes())
                 {
                     attributes.SetColorMatrix(this.Matrix);
 
-                    Rectangle rectangle = new Rectangle(0, 0, source.Width, source.Height);
+                    var rectangle = new Rectangle(0, 0, source.Width, source.Height);
                     graphics.DrawImage(source, rectangle, 0, 0, source.Width, source.Height, GraphicsUnit.Pixel, attributes);
                 }
             }

--- a/src/ImageProcessor/Imaging/Filters/Photo/MatrixFilterBase.cs
+++ b/src/ImageProcessor/Imaging/Filters/Photo/MatrixFilterBase.cs
@@ -26,12 +26,12 @@ namespace ImageProcessor.Imaging.Filters.Photo
         /// <summary>
         /// Processes the image.
         /// </summary>
-        /// <param name="image">The current image to process</param>
-        /// <param name="newImage">The new Image to return</param>
+        /// <param name="source">The current image to process</param>
+        /// <param name="destination">The new image to return</param>
         /// <returns>
         /// The processed <see cref="System.Drawing.Bitmap"/>.
         /// </returns>
-        public abstract Bitmap TransformImage(Image image, Image newImage);
+        public abstract Bitmap TransformImage(Image source, Image destination);
 
         /// <summary>
         /// Determines whether the specified <see cref="IMatrixFilter" />, is equal to this instance.
@@ -42,9 +42,7 @@ namespace ImageProcessor.Imaging.Filters.Photo
         /// </returns>
         public override bool Equals(object obj)
         {
-            IMatrixFilter filter = obj as IMatrixFilter;
-
-            if (filter == null)
+            if (!(obj is IMatrixFilter filter))
             {
                 return false;
             }
@@ -64,8 +62,7 @@ namespace ImageProcessor.Imaging.Filters.Photo
             unchecked
             {
                 int hashCode = this.GetType().Name.GetHashCode();
-                hashCode = (hashCode * 397) ^ this.Matrix.GetHashCode();
-                return hashCode;
+                return (hashCode * 397) ^ this.Matrix.GetHashCode();
             }
         }
     }

--- a/src/ImageProcessor/Imaging/Filters/Photo/PolaroidMatrixFilter.cs
+++ b/src/ImageProcessor/Imaging/Filters/Photo/PolaroidMatrixFilter.cs
@@ -35,13 +35,13 @@ namespace ImageProcessor.Imaging.Filters.Photo
         /// </returns>
         public override Bitmap TransformImage(Image source, Image destination)
         {
-            using (Graphics graphics = Graphics.FromImage(destination))
+            using (var graphics = Graphics.FromImage(destination))
             {
-                using (ImageAttributes attributes = new ImageAttributes())
+                using (var attributes = new ImageAttributes())
                 {
                     attributes.SetColorMatrix(this.Matrix);
 
-                    Rectangle rectangle = new Rectangle(0, 0, source.Width, source.Height);
+                    var rectangle = new Rectangle(0, 0, source.Width, source.Height);
 
                     graphics.DrawImage(source, rectangle, 0, 0, source.Width, source.Height, GraphicsUnit.Pixel, attributes);
                 }

--- a/src/ImageProcessor/Imaging/Filters/Photo/SepiaMatrixFilter.cs
+++ b/src/ImageProcessor/Imaging/Filters/Photo/SepiaMatrixFilter.cs
@@ -33,13 +33,13 @@ namespace ImageProcessor.Imaging.Filters.Photo
         /// </returns>
         public override Bitmap TransformImage(Image source, Image destination)
         {
-            using (Graphics graphics = Graphics.FromImage(destination))
+            using (var graphics = Graphics.FromImage(destination))
             {
-                using (ImageAttributes attributes = new ImageAttributes())
+                using (var attributes = new ImageAttributes())
                 {
                     attributes.SetColorMatrix(this.Matrix);
 
-                    Rectangle rectangle = new Rectangle(0, 0, source.Width, source.Height);
+                    var rectangle = new Rectangle(0, 0, source.Width, source.Height);
 
                     graphics.DrawImage(source, rectangle, 0, 0, source.Width, source.Height, GraphicsUnit.Pixel, attributes);
                 }

--- a/src/ImageProcessor/Imaging/Formats/FormatBase.cs
+++ b/src/ImageProcessor/Imaging/Formats/FormatBase.cs
@@ -23,10 +23,7 @@ namespace ImageProcessor.Imaging.Formats
         /// <summary>
         /// Initializes a new instance of the <see cref="FormatBase"/> class.
         /// </summary>
-        protected FormatBase()
-        {
-            this.Quality = 90;
-        }
+        protected FormatBase() => this.Quality = 90;
 
         /// <summary>
         /// Gets the file headers.
@@ -68,10 +65,7 @@ namespace ImageProcessor.Imaging.Formats
         /// </summary>
         /// <param name="processor">The processor delegate.</param>
         /// <param name="factory">The <see cref="ImageFactory" />.</param>
-        public virtual void ApplyProcessor(Func<ImageFactory, Image> processor, ImageFactory factory)
-        {
-            factory.Image = processor.Invoke(factory);
-        }
+        public virtual void ApplyProcessor(Func<ImageFactory, Image> processor, ImageFactory factory) => factory.Image = processor.Invoke(factory);
 
         /// <summary>
         /// Decodes the image to process.
@@ -129,17 +123,15 @@ namespace ImageProcessor.Imaging.Formats
         }
 
         /// <summary>
-        /// Determines whether the specified <see cref="System.Object" />, is equal to this instance.
+        /// Determines whether the specified <see cref="object" />, is equal to this instance.
         /// </summary>
-        /// <param name="obj">The <see cref="System.Object" /> to compare with this instance.</param>
+        /// <param name="obj">The <see cref="object" /> to compare with this instance.</param>
         /// <returns>
-        ///   <c>true</c> if the specified <see cref="System.Object" /> is equal to this instance; otherwise, <c>false</c>.
+        ///   <c>true</c> if the specified <see cref="object" /> is equal to this instance; otherwise, <c>false</c>.
         /// </returns>
         public override bool Equals(object obj)
         {
-            ISupportedImageFormat format = obj as ISupportedImageFormat;
-
-            if (format == null)
+            if (!(obj is ISupportedImageFormat format))
             {
                 return false;
             }
@@ -159,8 +151,7 @@ namespace ImageProcessor.Imaging.Formats
             {
                 int hashCode = this.MimeType.GetHashCode();
                 hashCode = (hashCode * 397) ^ this.IsIndexed.GetHashCode();
-                hashCode = (hashCode * 397) ^ this.Quality;
-                return hashCode;
+                return (hashCode * 397) ^ this.Quality;
             }
         }
     }

--- a/src/ImageProcessor/Imaging/Formats/FormatUtilities.cs
+++ b/src/ImageProcessor/Imaging/Formats/FormatUtilities.cs
@@ -48,7 +48,7 @@ namespace ImageProcessor.Imaging.Formats
 
             // It's actually a list.
             // ReSharper disable once PossibleMultipleEnumeration
-            int numberOfBytesToRead = supportedImageFormats.Max(f => f.FileHeaders.Max(h=>h.Length));
+            int numberOfBytesToRead = supportedImageFormats.Max(f => f.FileHeaders.Max(h => h.Length));
 
             byte[] buffer = new byte[numberOfBytesToRead];
             stream.Read(buffer, 0, buffer.Length);
@@ -95,7 +95,9 @@ namespace ImageProcessor.Imaging.Formats
         {
             // Test value of flags using bitwise AND.
             // ReSharper disable once BitwiseOperatorOnEnumWithoutFlags
+#pragma warning disable RCS1130 // Bitwise operation on enum without Flags attribute.
             return (image.PixelFormat & PixelFormat.Indexed) != 0;
+#pragma warning restore RCS1130 // Bitwise operation on enum without Flags attribute.
         }
 
         /// <summary>
@@ -107,10 +109,7 @@ namespace ImageProcessor.Imaging.Formats
         /// <returns>
         /// The true if the image has an alpha channel; otherwise, false.
         /// </returns>
-        public static bool HasAlpha(Image image)
-        {
-            return ((ImageFlags)image.Flags & ImageFlags.HasAlpha) == ImageFlags.HasAlpha;
-        }
+        public static bool HasAlpha(Image image) => ((ImageFlags)image.Flags & ImageFlags.HasAlpha) == ImageFlags.HasAlpha;
 
         /// <summary>
         /// Returns a value indicating whether the given image is animated.
@@ -121,10 +120,7 @@ namespace ImageProcessor.Imaging.Formats
         /// <returns>
         /// The true if the image is animated; otherwise, false.
         /// </returns>
-        public static bool IsAnimated(Image image)
-        {
-            return ImageAnimator.CanAnimate(image);
-        }
+        public static bool IsAnimated(Image image) => ImageAnimator.CanAnimate(image);
 
         /// <summary>
         /// Returns an instance of EncodingParameters for jpeg compression.

--- a/src/ImageProcessor/Imaging/Formats/GifDecoder.cs
+++ b/src/ImageProcessor/Imaging/Formats/GifDecoder.cs
@@ -100,7 +100,7 @@ namespace ImageProcessor.Imaging.Formats
         {
             // Find the frame
             image.SelectActiveFrame(FrameDimension.Time, index);
-            Bitmap frame = new Bitmap(image);
+            var frame = new Bitmap(image);
             frame.SetResolution(image.HorizontalResolution, image.VerticalResolution);
 
             // Reset the image
@@ -113,7 +113,7 @@ namespace ImageProcessor.Imaging.Formats
 
             // Convert each 4-byte chunk into an integer.
             // GDI returns a single array with all delays, while Mono returns a different array for each frame.
-            TimeSpan delay = TimeSpan.FromMilliseconds(BitConverter.ToInt32(times, (4 * index) % times.Length) * 10);
+            var delay = TimeSpan.FromMilliseconds(BitConverter.ToInt32(times, (4 * index) % times.Length) * 10);
 
             return new GifFrame { Delay = delay, Image = frame };
         }

--- a/src/ImageProcessor/Imaging/Formats/GifEncoder.cs
+++ b/src/ImageProcessor/Imaging/Formats/GifEncoder.cs
@@ -31,7 +31,6 @@ namespace ImageProcessor.Imaging.Formats
     /// </summary>
     public class GifEncoder
     {
-        #region Constants
         /// <summary>
         /// The application block size.
         /// </summary>
@@ -106,9 +105,7 @@ namespace ImageProcessor.Imaging.Formats
         /// The source image block position.
         /// </summary>
         private const long SourceImageBlockPosition = 789;
-        #endregion
 
-        #region Fields
         /// <summary>
         /// The converter for creating the output image from a byte array.
         /// </summary>
@@ -118,7 +115,7 @@ namespace ImageProcessor.Imaging.Formats
         /// The stream.
         /// </summary>
         // ReSharper disable once FieldCanBeMadeReadOnly.Local
-        private MemoryStream imageStream;
+        private readonly MemoryStream imageStream;
 
         /// <summary>
         /// The height.
@@ -144,9 +141,7 @@ namespace ImageProcessor.Imaging.Formats
         /// Whether the gif has has the last terminated byte written.
         /// </summary>
         private bool terminated;
-        #endregion
 
-        #region Constructors
         /// <summary>
         /// Initializes a new instance of the <see cref="GifEncoder"/> class.
         /// </summary>
@@ -166,14 +161,12 @@ namespace ImageProcessor.Imaging.Formats
             this.height = height;
             this.repeatCount = repeatCount;
         }
-        #endregion
 
         /// <summary>
         /// Gets or sets the image bytes.
         /// </summary>
         public byte[] ImageBytes { get; set; }
 
-        #region Public Methods and Operators
         /// <summary>
         /// Adds a frame to the gif.
         /// </summary>
@@ -182,7 +175,7 @@ namespace ImageProcessor.Imaging.Formats
         /// </param>
         public void AddFrame(GifFrame frame)
         {
-            using (MemoryStream gifStream = new MemoryStream())
+            using (var gifStream = new MemoryStream())
             {
                 frame.Image.Save(gifStream, ImageFormat.Gif);
                 if (this.isFirstImage)
@@ -245,9 +238,7 @@ namespace ImageProcessor.Imaging.Formats
 
             this.imageStream.Position = 0;
         }
-        #endregion
 
-        #region Methods
         /// <summary>
         /// Writes the header block of the animated gif to the stream.
         /// </summary>
@@ -302,10 +293,7 @@ namespace ImageProcessor.Imaging.Formats
         /// <param name="value">
         /// The value.
         /// </param>
-        private void WriteByte(int value)
-        {
-            this.imageStream.WriteByte(Convert.ToByte(value));
-        }
+        private void WriteByte(int value) => this.imageStream.WriteByte(Convert.ToByte(value));
 
         /// <summary>
         /// Writes the color table.
@@ -334,7 +322,7 @@ namespace ImageProcessor.Imaging.Formats
 
             this.WriteShort(GraphicControlExtensionBlockIdentifier); // Identifier
             this.WriteByte(GraphicControlExtensionBlockSize); // Block Size
-            this.WriteByte(blockhead[3] & 0xf7 | 0x08); // Setting disposal flag
+            this.WriteByte((blockhead[3] & 0xf7) | 0x08); // Setting disposal flag
             this.WriteShort(frameDelay); // Setting frame delay
             this.WriteByte(255); // Transparent color index
             this.WriteByte(0); // Terminator
@@ -367,12 +355,12 @@ namespace ImageProcessor.Imaging.Formats
             {
                 // If first frame, use global color table - else use local
                 sourceGif.Position = SourceGlobalColorInfoPosition;
-                this.WriteByte(sourceGif.ReadByte() & 0x3f | 0x80); // Enabling local color table
+                this.WriteByte((sourceGif.ReadByte() & 0x3f) | 0x80); // Enabling local color table
                 this.WriteColorTable(sourceGif);
             }
             else
             {
-                this.WriteByte(header[9] & 0x07 | 0x07); // Disabling local color table
+                this.WriteByte((header[9] & 0x07) | 0x07); // Disabling local color table
             }
 
             this.WriteByte(header[10]); // LZW Min Code Size
@@ -413,10 +401,6 @@ namespace ImageProcessor.Imaging.Formats
         /// <param name="value">
         /// The value.
         /// </param>
-        private void WriteString(string value)
-        {
-            this.imageStream.Write(value.ToArray().Select(c => (byte)c).ToArray(), 0, value.Length);
-        }
-        #endregion
+        private void WriteString(string value) => this.imageStream.Write(value.ToArray().Select(c => (byte)c).ToArray(), 0, value.Length);
     }
 }

--- a/src/ImageProcessor/Imaging/Formats/GifFormat.cs
+++ b/src/ImageProcessor/Imaging/Formats/GifFormat.cs
@@ -60,9 +60,9 @@ namespace ImageProcessor.Imaging.Formats
         /// <param name="factory">The <see cref="ImageFactory" />.</param>
         public override void ApplyProcessor(Func<ImageFactory, Image> processor, ImageFactory factory)
         {
-            GifDecoder decoder = new GifDecoder(factory.Image, factory.AnimationProcessMode);
+            var decoder = new GifDecoder(factory.Image, factory.AnimationProcessMode);
             Image factoryImage = factory.Image;
-            GifEncoder encoder = new GifEncoder(null, null, decoder.LoopCount);
+            var encoder = new GifEncoder(null, null, decoder.LoopCount);
 
             for (int i = 0; i < decoder.FrameCount; i++)
             {
@@ -80,8 +80,8 @@ namespace ImageProcessor.Imaging.Formats
         public override Image Save(Stream stream, Image image, long bitDepth)
         {
             // Never use default save for gifs. It's terrible.
-            GifDecoder decoder = new GifDecoder(image, AnimationProcessMode.All);
-            GifEncoder encoder = new GifEncoder(null, null, decoder.LoopCount);
+            var decoder = new GifDecoder(image, AnimationProcessMode.All);
+            var encoder = new GifEncoder(null, null, decoder.LoopCount);
 
             for (int i = 0; i < decoder.FrameCount; i++)
             {
@@ -100,8 +100,8 @@ namespace ImageProcessor.Imaging.Formats
             // Never use default save for gifs. It's terrible.
             using (FileStream fs = File.OpenWrite(path))
             {
-                GifDecoder decoder = new GifDecoder(image, AnimationProcessMode.All);
-                GifEncoder encoder = new GifEncoder(null, null, decoder.LoopCount);
+                var decoder = new GifDecoder(image, AnimationProcessMode.All);
+                var encoder = new GifEncoder(null, null, decoder.LoopCount);
 
                 for (int i = 0; i < decoder.FrameCount; i++)
                 {

--- a/src/ImageProcessor/Imaging/Formats/ISupportedImageFormat.cs
+++ b/src/ImageProcessor/Imaging/Formats/ISupportedImageFormat.cs
@@ -55,7 +55,6 @@ namespace ImageProcessor.Imaging.Formats
         /// </summary>
         int Quality { get; set; }
 
-        #region Methods
         /// <summary>
         /// Applies the given processor the current image.
         /// </summary>
@@ -109,6 +108,5 @@ namespace ImageProcessor.Imaging.Formats
         /// The <see cref="T:System.Drawing.Image"/>.
         /// </returns>
         Image Save(string path, Image image, long bitDepth);
-        #endregion
     }
 }

--- a/src/ImageProcessor/Imaging/Formats/JpegFormat.cs
+++ b/src/ImageProcessor/Imaging/Formats/JpegFormat.cs
@@ -14,7 +14,6 @@ namespace ImageProcessor.Imaging.Formats
     using System.Drawing;
     using System.Drawing.Imaging;
     using System.IO;
-    using System.Linq;
     using System.Text;
 
     /// <summary>
@@ -72,8 +71,7 @@ namespace ImageProcessor.Imaging.Formats
             using (EncoderParameters encoderParameters = FormatUtilities.GetEncodingParameters(this.Quality))
             {
                 ImageCodecInfo imageCodecInfo =
-                    ImageCodecInfo.GetImageEncoders()
-                        .FirstOrDefault(ici => ici.MimeType.Equals(this.MimeType, StringComparison.OrdinalIgnoreCase));
+                    Array.Find(ImageCodecInfo.GetImageEncoders(), ici => ici.MimeType.Equals(this.MimeType, StringComparison.OrdinalIgnoreCase));
 
                 if (imageCodecInfo != null)
                 {
@@ -104,8 +102,7 @@ namespace ImageProcessor.Imaging.Formats
             using (EncoderParameters encoderParameters = FormatUtilities.GetEncodingParameters(this.Quality))
             {
                 ImageCodecInfo imageCodecInfo =
-                    ImageCodecInfo.GetImageEncoders()
-                        .FirstOrDefault(ici => ici.MimeType.Equals(this.MimeType, StringComparison.OrdinalIgnoreCase));
+                    Array.Find(ImageCodecInfo.GetImageEncoders(), ici => ici.MimeType.Equals(this.MimeType, StringComparison.OrdinalIgnoreCase));
 
                 if (imageCodecInfo != null)
                 {

--- a/src/ImageProcessor/Imaging/Formats/TiffFormat.cs
+++ b/src/ImageProcessor/Imaging/Formats/TiffFormat.cs
@@ -15,7 +15,6 @@ namespace ImageProcessor.Imaging.Formats
     using System.Drawing;
     using System.Drawing.Imaging;
     using System.IO;
-    using System.Linq;
 
     /// <summary>
     /// Provides the necessary information to support tiff images.
@@ -88,14 +87,13 @@ namespace ImageProcessor.Imaging.Formats
         public override Image Save(Stream stream, Image image, long bitDepth)
         {
             // Tiffs can be saved with different bit depths.
-            using (EncoderParameters encoderParameters = new EncoderParameters(2))
+            using (var encoderParameters = new EncoderParameters(2))
             {
                 encoderParameters.Param[0] = new EncoderParameter(Encoder.Compression, (long)(bitDepth == 1 ? EncoderValue.CompressionCCITT4 : EncoderValue.CompressionLZW));
                 encoderParameters.Param[1] = new EncoderParameter(Encoder.ColorDepth, Math.Min(32, bitDepth));
 
                 ImageCodecInfo imageCodecInfo =
-                    ImageCodecInfo.GetImageEncoders()
-                        .FirstOrDefault(ici => ici.MimeType.Equals(this.MimeType, StringComparison.OrdinalIgnoreCase));
+                    Array.Find(ImageCodecInfo.GetImageEncoders(), ici => ici.MimeType.Equals(this.MimeType, StringComparison.OrdinalIgnoreCase));
 
                 if (imageCodecInfo != null)
                 {
@@ -122,14 +120,13 @@ namespace ImageProcessor.Imaging.Formats
         public override Image Save(string path, Image image, long bitDepth)
         {
             // Tiffs can be saved with different bit depths.
-            using (EncoderParameters encoderParameters = new EncoderParameters(2))
+            using (var encoderParameters = new EncoderParameters(2))
             {
                 encoderParameters.Param[0] = new EncoderParameter(Encoder.Compression, (long)(bitDepth == 1 ? EncoderValue.CompressionCCITT4 : EncoderValue.CompressionLZW));
                 encoderParameters.Param[1] = new EncoderParameter(Encoder.ColorDepth, Math.Min(32, bitDepth));
 
                 ImageCodecInfo imageCodecInfo =
-                    ImageCodecInfo.GetImageEncoders()
-                        .FirstOrDefault(ici => ici.MimeType.Equals(this.MimeType, StringComparison.OrdinalIgnoreCase));
+                    Array.Find(ImageCodecInfo.GetImageEncoders(), ici => ici.MimeType.Equals(this.MimeType, StringComparison.OrdinalIgnoreCase));
 
                 if (imageCodecInfo != null)
                 {

--- a/src/ImageProcessor/Imaging/GaussianLayer.cs
+++ b/src/ImageProcessor/Imaging/GaussianLayer.cs
@@ -71,10 +71,7 @@ namespace ImageProcessor.Imaging
         /// </summary>
         public int Size
         {
-            get
-            {
-                return this.size;
-            }
+            get => this.size;
 
             set
             {
@@ -97,10 +94,7 @@ namespace ImageProcessor.Imaging
         /// </summary>
         public double Sigma
         {
-            get
-            {
-                return this.sigma;
-            }
+            get => this.sigma;
 
             set
             {
@@ -123,10 +117,7 @@ namespace ImageProcessor.Imaging
         /// </summary>
         public int Threshold
         {
-            get
-            {
-                return this.threshold;
-            }
+            get => this.threshold;
 
             set
             {
@@ -153,9 +144,7 @@ namespace ImageProcessor.Imaging
         /// </returns>
         public override bool Equals(object obj)
         {
-            GaussianLayer gaussianLayer = obj as GaussianLayer;
-
-            if (gaussianLayer == null)
+            if (!(obj is GaussianLayer gaussianLayer))
             {
                 return false;
             }
@@ -177,8 +166,7 @@ namespace ImageProcessor.Imaging
             {
                 int hashCode = this.Size;
                 hashCode = (hashCode * 397) ^ this.Size.GetHashCode();
-                hashCode = (hashCode * 397) ^ this.Threshold;
-                return hashCode;
+                return (hashCode * 397) ^ this.Threshold;
             }
         }
     }

--- a/src/ImageProcessor/Imaging/Helpers/Adjustments.cs
+++ b/src/ImageProcessor/Imaging/Helpers/Adjustments.cs
@@ -59,19 +59,19 @@ namespace ImageProcessor.Imaging.Helpers
             }
 
             float factor = (float)percentage / 100;
-            int width = source.Width;
-            int height = source.Height;
+
+            Rectangle bounds = rectangle ?? new Rectangle(0, 0, source.Width, source.Height);
 
             // Traditional examples using a color matrix alter the rgb values also.
-            using (FastBitmap bitmap = new FastBitmap(source))
+            using (var bitmap = new FastBitmap(source))
             {
                 // Loop through the pixels.
                 Parallel.For(
-                    0,
-                    height,
+                    bounds.Y,
+                    bounds.Bottom,
                     y =>
                     {
-                        for (int x = 0; x < width; x++)
+                        for (int x = bounds.X; x < bounds.Right; x++)
                         {
                             // ReSharper disable AccessToDisposedClosure
                             Color color = bitmap.GetPixel(x, y);
@@ -111,7 +111,7 @@ namespace ImageProcessor.Imaging.Helpers
             float brightnessFactor = (float)threshold / 100;
             Rectangle bounds = rectangle ?? new Rectangle(0, 0, source.Width, source.Height);
 
-            ColorMatrix colorMatrix =
+            var colorMatrix =
                 new ColorMatrix(
                     new[]
                         {
@@ -122,9 +122,9 @@ namespace ImageProcessor.Imaging.Helpers
                             new[] { brightnessFactor, brightnessFactor, brightnessFactor, 0, 1 }
                         });
 
-            using (Graphics graphics = Graphics.FromImage(source))
+            using (var graphics = Graphics.FromImage(source))
             {
-                using (ImageAttributes imageAttributes = new ImageAttributes())
+                using (var imageAttributes = new ImageAttributes())
                 {
                     imageAttributes.SetColorMatrix(colorMatrix);
                     graphics.DrawImage(source, bounds, 0, 0, source.Width, source.Height, GraphicsUnit.Pixel, imageAttributes);
@@ -166,7 +166,7 @@ namespace ImageProcessor.Imaging.Helpers
             contrastFactor++;
             float factorTransform = 0.5f * (1.0f - contrastFactor);
 
-            ColorMatrix colorMatrix =
+            var colorMatrix =
                 new ColorMatrix(
                     new[]
                     {
@@ -177,9 +177,9 @@ namespace ImageProcessor.Imaging.Helpers
                         new[] { factorTransform, factorTransform, factorTransform, 0, 1 }
                     });
 
-            using (Graphics graphics = Graphics.FromImage(source))
+            using (var graphics = Graphics.FromImage(source))
             {
-                using (ImageAttributes imageAttributes = new ImageAttributes())
+                using (var imageAttributes = new ImageAttributes())
                 {
                     imageAttributes.SetColorMatrix(colorMatrix);
                     graphics.DrawImage(source, bounds, 0, 0, source.Width, source.Height, GraphicsUnit.Pixel, imageAttributes);
@@ -214,14 +214,13 @@ namespace ImageProcessor.Imaging.Helpers
             byte[] ramp = new byte[256];
             for (int x = 0; x < 256; ++x)
             {
-                byte val = ((255.0 * Math.Pow(x / 255.0, value)) + 0.5).ToByte();
-                ramp[x] = val;
+                ramp[x] = ((255.0 * Math.Pow(x / 255.0, value)) + 0.5).ToByte();
             }
 
             int width = source.Width;
             int height = source.Height;
 
-            using (FastBitmap bitmap = new FastBitmap(source))
+            using (var bitmap = new FastBitmap(source))
             {
                 Parallel.For(
                     0,
@@ -232,7 +231,7 @@ namespace ImageProcessor.Imaging.Helpers
                         {
                             // ReSharper disable once AccessToDisposedClosure
                             Color composite = bitmap.GetPixel(x, y);
-                            Color linear = Color.FromArgb(composite.A, ramp[composite.R], ramp[composite.G], ramp[composite.B]);
+                            var linear = Color.FromArgb(composite.A, ramp[composite.R], ramp[composite.G], ramp[composite.B]);
                             // ReSharper disable once AccessToDisposedClosure
                             bitmap.SetPixel(x, y, linear);
                         }
@@ -259,7 +258,7 @@ namespace ImageProcessor.Imaging.Helpers
             int width = source.Width;
             int height = source.Height;
 
-            using (FastBitmap bitmap = new FastBitmap(source))
+            using (var bitmap = new FastBitmap(source))
             {
                 Parallel.For(
                     0,
@@ -270,7 +269,7 @@ namespace ImageProcessor.Imaging.Helpers
                         {
                             // ReSharper disable once AccessToDisposedClosure
                             Color composite = bitmap.GetPixel(x, y);
-                            Color linear = Color.FromArgb(composite.A, ramp[composite.R], ramp[composite.G], ramp[composite.B]);
+                            var linear = Color.FromArgb(composite.A, ramp[composite.R], ramp[composite.G], ramp[composite.B]);
                             // ReSharper disable once AccessToDisposedClosure
                             bitmap.SetPixel(x, y, linear);
                         }
@@ -297,7 +296,7 @@ namespace ImageProcessor.Imaging.Helpers
             int width = source.Width;
             int height = source.Height;
 
-            using (FastBitmap bitmap = new FastBitmap(source))
+            using (var bitmap = new FastBitmap(source))
             {
                 Parallel.For(
                     0,
@@ -308,7 +307,7 @@ namespace ImageProcessor.Imaging.Helpers
                         {
                             // ReSharper disable once AccessToDisposedClosure
                             Color composite = bitmap.GetPixel(x, y);
-                            Color linear = Color.FromArgb(composite.A, ramp[composite.R], ramp[composite.G], ramp[composite.B]);
+                            var linear = Color.FromArgb(composite.A, ramp[composite.R], ramp[composite.G], ramp[composite.B]);
                             // ReSharper disable once AccessToDisposedClosure
                             bitmap.SetPixel(x, y, linear);
                         }
@@ -330,8 +329,7 @@ namespace ImageProcessor.Imaging.Helpers
             byte[] ramp = new byte[256];
             for (int x = 0; x < 256; ++x)
             {
-                byte val = (255f * SRGBToLinear(x / 255f)).ToByte();
-                ramp[x] = val;
+                ramp[x] = (255f * SRGBToLinear(x / 255f)).ToByte();
             }
 
             return ramp;
@@ -349,8 +347,7 @@ namespace ImageProcessor.Imaging.Helpers
             byte[] ramp = new byte[256];
             for (int x = 0; x < 256; ++x)
             {
-                byte val = (255f * LinearToSRGB(x / 255f)).ToByte();
-                ramp[x] = val;
+                ramp[x] = (255f * LinearToSRGB(x / 255f)).ToByte();
             }
 
             return ramp;
@@ -367,7 +364,7 @@ namespace ImageProcessor.Imaging.Helpers
         /// </returns>
         private static float SRGBToLinear(float signal)
         {
-            float a = 0.055f;
+            const float a = 0.055f;
 
             if (signal <= 0.04045)
             {
@@ -388,7 +385,7 @@ namespace ImageProcessor.Imaging.Helpers
         /// </returns>
         private static float LinearToSRGB(float signal)
         {
-            float a = 0.055f;
+            const float a = 0.055f;
 
             if (signal <= 0.0031308)
             {

--- a/src/ImageProcessor/Imaging/Helpers/Converters/BigEndianBitConverter.cs
+++ b/src/ImageProcessor/Imaging/Helpers/Converters/BigEndianBitConverter.cs
@@ -40,10 +40,7 @@ namespace ImageProcessor.Imaging.Helpers
         /// most significant byte is on the right end of a word.
         /// </remarks>
         /// <returns>true if this converter is little-endian, false otherwise.</returns>
-        public override bool IsLittleEndian()
-        {
-            return false;
-        }
+        public override bool IsLittleEndian() => false;
 
         /// <summary>
         /// Copies the specified number of bytes from value to buffer, starting at index.
@@ -58,7 +55,7 @@ namespace ImageProcessor.Imaging.Helpers
             for (int i = 0; i < bytes; i++)
             {
                 buffer[endOffset - i] = unchecked((byte)(value & 0xff));
-                value = value >> 8;
+                value >>= 8;
             }
         }
 
@@ -66,16 +63,16 @@ namespace ImageProcessor.Imaging.Helpers
         /// Returns a value built from the specified number of bytes from the given buffer,
         /// starting at index.
         /// </summary>
-        /// <param name="buffer">The data in byte array format</param>
+        /// <param name="value">The data in byte array format</param>
         /// <param name="startIndex">The first index to use</param>
         /// <param name="bytesToConvert">The number of bytes to use</param>
         /// <returns>The value built from the given bytes</returns>
-        protected internal override long FromBytes(byte[] buffer, int startIndex, int bytesToConvert)
+        protected internal override long FromBytes(byte[] value, int startIndex, int bytesToConvert)
         {
             long ret = 0;
             for (int i = 0; i < bytesToConvert; i++)
             {
-                ret = unchecked((ret << 8) | buffer[startIndex + i]);
+                ret = unchecked((ret << 8) | value[startIndex + i]);
             }
 
             return ret;

--- a/src/ImageProcessor/Imaging/Helpers/Converters/EndianBitConverter.cs
+++ b/src/ImageProcessor/Imaging/Helpers/Converters/EndianBitConverter.cs
@@ -32,7 +32,6 @@ namespace ImageProcessor.Imaging.Helpers
     [SuppressMessage("StyleCop.CSharp.OrderingRules", "SA1204:StaticElementsMustAppearBeforeInstanceElements", Justification = "Reviewed. Suppression is OK here. Better readability.")]
     internal abstract class EndianBitConverter
     {
-        #region Endianness of this converter
         /// <summary>
         /// Indicates the byte order ("endianness") in which data is converted using this class.
         /// </summary>
@@ -48,9 +47,6 @@ namespace ImageProcessor.Imaging.Helpers
         /// Gets the byte order ("endianness") in which data is converted using this class.
         /// </summary>
         public abstract Endianness Endianness { get; }
-        #endregion
-
-        #region Factory properties
 
         /// <summary>
         /// Gets a little-endian bit converter instance. The same instance is
@@ -64,9 +60,6 @@ namespace ImageProcessor.Imaging.Helpers
         /// </summary>
         public static BigEndianBitConverter Big { get; } = new BigEndianBitConverter();
 
-        #endregion
-
-        #region Double/primitive conversions
         /// <summary>
         /// Converts the specified double-precision floating point number to a 
         /// 64-bit signed integer. Note: the endianness of this converter does not
@@ -74,10 +67,7 @@ namespace ImageProcessor.Imaging.Helpers
         /// </summary>
         /// <param name="value">The number to convert. </param>
         /// <returns>A 64-bit signed integer whose value is equivalent to value.</returns>
-        public long DoubleToInt64Bits(double value)
-        {
-            return BitConverter.DoubleToInt64Bits(value);
-        }
+        public long DoubleToInt64Bits(double value) => BitConverter.DoubleToInt64Bits(value);
 
         /// <summary>
         /// Converts the specified 64-bit signed integer to a double-precision 
@@ -86,10 +76,7 @@ namespace ImageProcessor.Imaging.Helpers
         /// </summary>
         /// <param name="value">The number to convert. </param>
         /// <returns>A double-precision floating point number whose value is equivalent to value.</returns>
-        public double Int64BitsToDouble(long value)
-        {
-            return BitConverter.Int64BitsToDouble(value);
-        }
+        public double Int64BitsToDouble(long value) => BitConverter.Int64BitsToDouble(value);
 
         /// <summary>
         /// Converts the specified single-precision floating point number to a 
@@ -98,10 +85,7 @@ namespace ImageProcessor.Imaging.Helpers
         /// </summary>
         /// <param name="value">The number to convert. </param>
         /// <returns>A 32-bit signed integer whose value is equivalent to value.</returns>
-        public int SingleToInt32Bits(float value)
-        {
-            return new Int32SingleUnion(value).AsInt32;
-        }
+        public int SingleToInt32Bits(float value) => new Int32SingleUnion(value).AsInt32;
 
         /// <summary>
         /// Converts the specified 32-bit signed integer to a single-precision floating point 
@@ -110,13 +94,8 @@ namespace ImageProcessor.Imaging.Helpers
         /// </summary>
         /// <param name="value">The number to convert. </param>
         /// <returns>A single-precision floating point number whose value is equivalent to value.</returns>
-        public float Int32BitsToSingle(int value)
-        {
-            return new Int32SingleUnion(value).AsSingle;
-        }
-        #endregion
+        public float Int32BitsToSingle(int value) => new Int32SingleUnion(value).AsSingle;
 
-        #region To(PrimitiveType) conversions
         /// <summary>
         /// Returns a Boolean value converted from one byte at a specified position in a byte array.
         /// </summary>
@@ -135,10 +114,7 @@ namespace ImageProcessor.Imaging.Helpers
         /// <param name="value">An array of bytes.</param>
         /// <param name="startIndex">The starting position within value.</param>
         /// <returns>A character formed by two bytes beginning at startIndex.</returns>
-        public char ToChar(byte[] value, int startIndex)
-        {
-            return unchecked((char)this.CheckedFromBytes(value, startIndex, 2));
-        }
+        public char ToChar(byte[] value, int startIndex) => unchecked((char)this.CheckedFromBytes(value, startIndex, 2));
 
         /// <summary>
         /// Returns a double-precision floating point number converted from eight bytes 
@@ -147,10 +123,7 @@ namespace ImageProcessor.Imaging.Helpers
         /// <param name="value">An array of bytes.</param>
         /// <param name="startIndex">The starting position within value.</param>
         /// <returns>A double precision floating point number formed by eight bytes beginning at startIndex.</returns>
-        public double ToDouble(byte[] value, int startIndex)
-        {
-            return this.Int64BitsToDouble(this.ToInt64(value, startIndex));
-        }
+        public double ToDouble(byte[] value, int startIndex) => this.Int64BitsToDouble(this.ToInt64(value, startIndex));
 
         /// <summary>
         /// Returns a single-precision floating point number converted from four bytes 
@@ -159,10 +132,7 @@ namespace ImageProcessor.Imaging.Helpers
         /// <param name="value">An array of bytes.</param>
         /// <param name="startIndex">The starting position within value.</param>
         /// <returns>A single precision floating point number formed by four bytes beginning at startIndex.</returns>
-        public float ToSingle(byte[] value, int startIndex)
-        {
-            return this.Int32BitsToSingle(this.ToInt32(value, startIndex));
-        }
+        public float ToSingle(byte[] value, int startIndex) => this.Int32BitsToSingle(this.ToInt32(value, startIndex));
 
         /// <summary>
         /// Returns a 16-bit signed integer converted from two bytes at a specified position in a byte array.
@@ -170,10 +140,7 @@ namespace ImageProcessor.Imaging.Helpers
         /// <param name="value">An array of bytes.</param>
         /// <param name="startIndex">The starting position within value.</param>
         /// <returns>A 16-bit signed integer formed by two bytes beginning at startIndex.</returns>
-        public short ToInt16(byte[] value, int startIndex)
-        {
-            return unchecked((short)this.CheckedFromBytes(value, startIndex, 2));
-        }
+        public short ToInt16(byte[] value, int startIndex) => unchecked((short)this.CheckedFromBytes(value, startIndex, 2));
 
         /// <summary>
         /// Returns a 32-bit signed integer converted from four bytes at a specified position in a byte array.
@@ -181,10 +148,7 @@ namespace ImageProcessor.Imaging.Helpers
         /// <param name="value">An array of bytes.</param>
         /// <param name="startIndex">The starting position within value.</param>
         /// <returns>A 32-bit signed integer formed by four bytes beginning at startIndex.</returns>
-        public int ToInt32(byte[] value, int startIndex)
-        {
-            return unchecked((int)this.CheckedFromBytes(value, startIndex, 4));
-        }
+        public int ToInt32(byte[] value, int startIndex) => unchecked((int)this.CheckedFromBytes(value, startIndex, 4));
 
         /// <summary>
         /// Returns a 64-bit signed integer converted from eight bytes at a specified position in a byte array.
@@ -192,10 +156,7 @@ namespace ImageProcessor.Imaging.Helpers
         /// <param name="value">An array of bytes.</param>
         /// <param name="startIndex">The starting position within value.</param>
         /// <returns>A 64-bit signed integer formed by eight bytes beginning at startIndex.</returns>
-        public long ToInt64(byte[] value, int startIndex)
-        {
-            return this.CheckedFromBytes(value, startIndex, 8);
-        }
+        public long ToInt64(byte[] value, int startIndex) => this.CheckedFromBytes(value, startIndex, 8);
 
         /// <summary>
         /// Returns a 16-bit unsigned integer converted from two bytes at a specified position in a byte array.
@@ -203,10 +164,7 @@ namespace ImageProcessor.Imaging.Helpers
         /// <param name="value">An array of bytes.</param>
         /// <param name="startIndex">The starting position within value.</param>
         /// <returns>A 16-bit unsigned integer formed by two bytes beginning at startIndex.</returns>
-        public ushort ToUInt16(byte[] value, int startIndex)
-        {
-            return unchecked((ushort)this.CheckedFromBytes(value, startIndex, 2));
-        }
+        public ushort ToUInt16(byte[] value, int startIndex) => unchecked((ushort)this.CheckedFromBytes(value, startIndex, 2));
 
         /// <summary>
         /// Returns a 32-bit unsigned integer converted from four bytes at a specified position in a byte array.
@@ -214,10 +172,7 @@ namespace ImageProcessor.Imaging.Helpers
         /// <param name="value">An array of bytes.</param>
         /// <param name="startIndex">The starting position within value.</param>
         /// <returns>A 32-bit unsigned integer formed by four bytes beginning at startIndex.</returns>
-        public uint ToUInt32(byte[] value, int startIndex)
-        {
-            return unchecked((uint)this.CheckedFromBytes(value, startIndex, 4));
-        }
+        public uint ToUInt32(byte[] value, int startIndex) => unchecked((uint)this.CheckedFromBytes(value, startIndex, 4));
 
         /// <summary>
         /// Returns a 64-bit unsigned integer converted from eight bytes at a specified position in a byte array.
@@ -225,10 +180,7 @@ namespace ImageProcessor.Imaging.Helpers
         /// <param name="value">An array of bytes.</param>
         /// <param name="startIndex">The starting position within value.</param>
         /// <returns>A 64-bit unsigned integer formed by eight bytes beginning at startIndex.</returns>
-        public ulong ToUInt64(byte[] value, int startIndex)
-        {
-            return unchecked((ulong)this.CheckedFromBytes(value, startIndex, 8));
-        }
+        public ulong ToUInt64(byte[] value, int startIndex) => unchecked((ulong)this.CheckedFromBytes(value, startIndex, 8));
 
         /// <summary>
         /// Convert the given number of bytes from the given array, from the given start
@@ -278,9 +230,7 @@ namespace ImageProcessor.Imaging.Helpers
             CheckByteArgument(value, startIndex, bytesToConvert);
             return this.FromBytes(value, startIndex, bytesToConvert);
         }
-        #endregion
 
-        #region ToString conversions
         /// <summary>
         /// Returns a String converted from the elements of a byte array.
         /// </summary>
@@ -290,10 +240,7 @@ namespace ImageProcessor.Imaging.Helpers
         /// A String of hexadecimal pairs separated by hyphens, where each pair 
         /// represents the corresponding element in value; for example, "7F-2C-4A".
         /// </returns>
-        public static string ToString(byte[] value)
-        {
-            return BitConverter.ToString(value);
-        }
+        public static string ToString(byte[] value) => BitConverter.ToString(value);
 
         /// <summary>
         /// Returns a String converted from the elements of a byte array starting at a specified array position.
@@ -305,10 +252,7 @@ namespace ImageProcessor.Imaging.Helpers
         /// A String of hexadecimal pairs separated by hyphens, where each pair 
         /// represents the corresponding element in value; for example, "7F-2C-4A".
         /// </returns>
-        public static string ToString(byte[] value, int startIndex)
-        {
-            return BitConverter.ToString(value, startIndex);
-        }
+        public static string ToString(byte[] value, int startIndex) => BitConverter.ToString(value, startIndex);
 
         /// <summary>
         /// Returns a String converted from a specified number of bytes at a specified position in a byte array.
@@ -321,13 +265,8 @@ namespace ImageProcessor.Imaging.Helpers
         /// A String of hexadecimal pairs separated by hyphens, where each pair 
         /// represents the corresponding element in value; for example, "7F-2C-4A".
         /// </returns>
-        public static string ToString(byte[] value, int startIndex, int length)
-        {
-            return BitConverter.ToString(value, startIndex, length);
-        }
-        #endregion
+        public static string ToString(byte[] value, int startIndex, int length) => BitConverter.ToString(value, startIndex, length);
 
-        #region	Decimal conversions
         /// <summary>
         /// Returns a decimal value converted from sixteen bytes 
         /// at a specified position in a byte array.
@@ -381,9 +320,7 @@ namespace ImageProcessor.Imaging.Helpers
                 this.CopyBytesImpl(parts[i], 4, buffer, (i * 4) + index);
             }
         }
-        #endregion
 
-        #region GetBytes conversions
         /// <summary>
         /// Returns an array with the given number of bytes formed
         /// from the least significant bytes of the specified value.
@@ -409,10 +346,7 @@ namespace ImageProcessor.Imaging.Helpers
         /// <returns>
         /// The <see cref="T:byte[]"/>.
         /// </returns>
-        public byte[] GetBytes(bool value)
-        {
-            return BitConverter.GetBytes(value);
-        }
+        public byte[] GetBytes(bool value) => BitConverter.GetBytes(value);
 
         /// <summary>
         /// Returns the specified Unicode character value as an array of bytes.
@@ -422,94 +356,64 @@ namespace ImageProcessor.Imaging.Helpers
         /// <returns>
         /// The <see cref="T:byte[]"/>.
         /// </returns>
-        public byte[] GetBytes(char value)
-        {
-            return this.GetBytes(value, 2);
-        }
+        public byte[] GetBytes(char value) => this.GetBytes(value, 2);
 
         /// <summary>
         /// Returns the specified double-precision floating point value as an array of bytes.
         /// </summary>
         /// <param name="value">The number to convert.</param>
         /// <returns>An array of bytes with length 8.</returns>
-        public byte[] GetBytes(double value)
-        {
-            return this.GetBytes(this.DoubleToInt64Bits(value), 8);
-        }
+        public byte[] GetBytes(double value) => this.GetBytes(this.DoubleToInt64Bits(value), 8);
 
         /// <summary>
         /// Returns the specified 16-bit signed integer value as an array of bytes.
         /// </summary>
         /// <param name="value">The number to convert.</param>
         /// <returns>An array of bytes with length 2.</returns>
-        public byte[] GetBytes(short value)
-        {
-            return this.GetBytes(value, 2);
-        }
+        public byte[] GetBytes(short value) => this.GetBytes(value, 2);
 
         /// <summary>
         /// Returns the specified 32-bit signed integer value as an array of bytes.
         /// </summary>
         /// <param name="value">The number to convert.</param>
         /// <returns>An array of bytes with length 4.</returns>
-        public byte[] GetBytes(int value)
-        {
-            return this.GetBytes(value, 4);
-        }
+        public byte[] GetBytes(int value) => this.GetBytes(value, 4);
 
         /// <summary>
         /// Returns the specified 64-bit signed integer value as an array of bytes.
         /// </summary>
         /// <param name="value">The number to convert.</param>
         /// <returns>An array of bytes with length 8.</returns>
-        public byte[] GetBytes(long value)
-        {
-            return this.GetBytes(value, 8);
-        }
+        public byte[] GetBytes(long value) => this.GetBytes(value, 8);
 
         /// <summary>
         /// Returns the specified single-precision floating point value as an array of bytes.
         /// </summary>
         /// <param name="value">The number to convert.</param>
         /// <returns>An array of bytes with length 4.</returns>
-        public byte[] GetBytes(float value)
-        {
-            return this.GetBytes(this.SingleToInt32Bits(value), 4);
-        }
+        public byte[] GetBytes(float value) => this.GetBytes(this.SingleToInt32Bits(value), 4);
 
         /// <summary>
         /// Returns the specified 16-bit unsigned integer value as an array of bytes.
         /// </summary>
         /// <param name="value">The number to convert.</param>
         /// <returns>An array of bytes with length 2.</returns>
-        public byte[] GetBytes(ushort value)
-        {
-            return this.GetBytes(value, 2);
-        }
+        public byte[] GetBytes(ushort value) => this.GetBytes(value, 2);
 
         /// <summary>
         /// Returns the specified 32-bit unsigned integer value as an array of bytes.
         /// </summary>
         /// <param name="value">The number to convert.</param>
         /// <returns>An array of bytes with length 4.</returns>
-        public byte[] GetBytes(uint value)
-        {
-            return this.GetBytes(value, 4);
-        }
+        public byte[] GetBytes(uint value) => this.GetBytes(value, 4);
 
         /// <summary>
         /// Returns the specified 64-bit unsigned integer value as an array of bytes.
         /// </summary>
         /// <param name="value">The number to convert.</param>
         /// <returns>An array of bytes with length 8.</returns>
-        public byte[] GetBytes(ulong value)
-        {
-            return this.GetBytes(unchecked((long)value), 8);
-        }
+        public byte[] GetBytes(ulong value) => this.GetBytes(unchecked((long)value), 8);
 
-        #endregion
-
-        #region CopyBytes conversions
         /// <summary>
         /// Copies the given number of bytes from the least-specific
         /// end of the specified value into the specified byte array, beginning
@@ -555,10 +459,7 @@ namespace ImageProcessor.Imaging.Helpers
         /// <param name="value">A Boolean value.</param>
         /// <param name="buffer">The byte array to copy the bytes into</param>
         /// <param name="index">The first index into the array to copy the bytes into</param>
-        public void CopyBytes(bool value, byte[] buffer, int index)
-        {
-            this.CopyBytes(value ? 1 : 0, 1, buffer, index);
-        }
+        public void CopyBytes(bool value, byte[] buffer, int index) => this.CopyBytes(value ? 1 : 0, 1, buffer, index);
 
         /// <summary>
         /// Copies the specified Unicode character value into the specified byte array,
@@ -567,10 +468,7 @@ namespace ImageProcessor.Imaging.Helpers
         /// <param name="value">A character to convert.</param>
         /// <param name="buffer">The byte array to copy the bytes into</param>
         /// <param name="index">The first index into the array to copy the bytes into</param>
-        public void CopyBytes(char value, byte[] buffer, int index)
-        {
-            this.CopyBytes(value, 2, buffer, index);
-        }
+        public void CopyBytes(char value, byte[] buffer, int index) => this.CopyBytes(value, 2, buffer, index);
 
         /// <summary>
         /// Copies the specified double-precision floating point value into the specified byte array,
@@ -579,10 +477,7 @@ namespace ImageProcessor.Imaging.Helpers
         /// <param name="value">The number to convert.</param>
         /// <param name="buffer">The byte array to copy the bytes into</param>
         /// <param name="index">The first index into the array to copy the bytes into</param>
-        public void CopyBytes(double value, byte[] buffer, int index)
-        {
-            this.CopyBytes(this.DoubleToInt64Bits(value), 8, buffer, index);
-        }
+        public void CopyBytes(double value, byte[] buffer, int index) => this.CopyBytes(this.DoubleToInt64Bits(value), 8, buffer, index);
 
         /// <summary>
         /// Copies the specified 16-bit signed integer value into the specified byte array,
@@ -591,10 +486,7 @@ namespace ImageProcessor.Imaging.Helpers
         /// <param name="value">The number to convert.</param>
         /// <param name="buffer">The byte array to copy the bytes into</param>
         /// <param name="index">The first index into the array to copy the bytes into</param>
-        public void CopyBytes(short value, byte[] buffer, int index)
-        {
-            this.CopyBytes(value, 2, buffer, index);
-        }
+        public void CopyBytes(short value, byte[] buffer, int index) => this.CopyBytes(value, 2, buffer, index);
 
         /// <summary>
         /// Copies the specified 32-bit signed integer value into the specified byte array,
@@ -603,10 +495,7 @@ namespace ImageProcessor.Imaging.Helpers
         /// <param name="value">The number to convert.</param>
         /// <param name="buffer">The byte array to copy the bytes into</param>
         /// <param name="index">The first index into the array to copy the bytes into</param>
-        public void CopyBytes(int value, byte[] buffer, int index)
-        {
-            this.CopyBytes(value, 4, buffer, index);
-        }
+        public void CopyBytes(int value, byte[] buffer, int index) => this.CopyBytes(value, 4, buffer, index);
 
         /// <summary>
         /// Copies the specified 64-bit signed integer value into the specified byte array,
@@ -615,10 +504,7 @@ namespace ImageProcessor.Imaging.Helpers
         /// <param name="value">The number to convert.</param>
         /// <param name="buffer">The byte array to copy the bytes into</param>
         /// <param name="index">The first index into the array to copy the bytes into</param>
-        public void CopyBytes(long value, byte[] buffer, int index)
-        {
-            this.CopyBytes(value, 8, buffer, index);
-        }
+        public void CopyBytes(long value, byte[] buffer, int index) => this.CopyBytes(value, 8, buffer, index);
 
         /// <summary>
         /// Copies the specified single-precision floating point value into the specified byte array,
@@ -627,10 +513,7 @@ namespace ImageProcessor.Imaging.Helpers
         /// <param name="value">The number to convert.</param>
         /// <param name="buffer">The byte array to copy the bytes into</param>
         /// <param name="index">The first index into the array to copy the bytes into</param>
-        public void CopyBytes(float value, byte[] buffer, int index)
-        {
-            this.CopyBytes(this.SingleToInt32Bits(value), 4, buffer, index);
-        }
+        public void CopyBytes(float value, byte[] buffer, int index) => this.CopyBytes(this.SingleToInt32Bits(value), 4, buffer, index);
 
         /// <summary>
         /// Copies the specified 16-bit unsigned integer value into the specified byte array,
@@ -639,10 +522,7 @@ namespace ImageProcessor.Imaging.Helpers
         /// <param name="value">The number to convert.</param>
         /// <param name="buffer">The byte array to copy the bytes into</param>
         /// <param name="index">The first index into the array to copy the bytes into</param>
-        public void CopyBytes(ushort value, byte[] buffer, int index)
-        {
-            this.CopyBytes(value, 2, buffer, index);
-        }
+        public void CopyBytes(ushort value, byte[] buffer, int index) => this.CopyBytes(value, 2, buffer, index);
 
         /// <summary>
         /// Copies the specified 32-bit unsigned integer value into the specified byte array,
@@ -651,10 +531,7 @@ namespace ImageProcessor.Imaging.Helpers
         /// <param name="value">The number to convert.</param>
         /// <param name="buffer">The byte array to copy the bytes into</param>
         /// <param name="index">The first index into the array to copy the bytes into</param>
-        public void CopyBytes(uint value, byte[] buffer, int index)
-        {
-            this.CopyBytes(value, 4, buffer, index);
-        }
+        public void CopyBytes(uint value, byte[] buffer, int index) => this.CopyBytes(value, 4, buffer, index);
 
         /// <summary>
         /// Copies the specified 64-bit unsigned integer value into the specified byte array,
@@ -663,19 +540,13 @@ namespace ImageProcessor.Imaging.Helpers
         /// <param name="value">The number to convert.</param>
         /// <param name="buffer">The byte array to copy the bytes into</param>
         /// <param name="index">The first index into the array to copy the bytes into</param>
-        public void CopyBytes(ulong value, byte[] buffer, int index)
-        {
-            this.CopyBytes(unchecked((long)value), 8, buffer, index);
-        }
+        public void CopyBytes(ulong value, byte[] buffer, int index) => this.CopyBytes(unchecked((long)value), 8, buffer, index);
 
-        #endregion
-
-        #region Private struct used for Single/Int32 conversions
         /// <summary>
         /// Union used solely for the equivalent of DoubleToInt64Bits and vice versa.
         /// </summary>
         [StructLayout(LayoutKind.Explicit)]
-        private struct Int32SingleUnion
+        private readonly struct Int32SingleUnion
         {
             /// <summary>
             /// Int32 version of the value.
@@ -721,6 +592,5 @@ namespace ImageProcessor.Imaging.Helpers
             /// </summary>
             internal float AsSingle => this.f;
         }
-        #endregion
     }
 }

--- a/src/ImageProcessor/Imaging/Helpers/Converters/LittleEndianBitConverter.cs
+++ b/src/ImageProcessor/Imaging/Helpers/Converters/LittleEndianBitConverter.cs
@@ -41,10 +41,7 @@ namespace ImageProcessor.Imaging.Helpers
         /// most significant byte is on the right end of a word.
         /// </remarks>
         /// <returns>true if this converter is little-endian, false otherwise.</returns>
-        public override bool IsLittleEndian()
-        {
-            return true;
-        }
+        public override bool IsLittleEndian() => true;
 
         /// <summary>
         /// Copies the specified number of bytes from value to buffer, starting at index.
@@ -58,7 +55,7 @@ namespace ImageProcessor.Imaging.Helpers
             for (int i = 0; i < bytes; i++)
             {
                 buffer[i + index] = unchecked((byte)(value & 0xff));
-                value = value >> 8;
+                value >>= 8;
             }
         }
 
@@ -66,16 +63,16 @@ namespace ImageProcessor.Imaging.Helpers
         /// Returns a value built from the specified number of bytes from the given buffer,
         /// starting at index.
         /// </summary>
-        /// <param name="buffer">The data in byte array format</param>
+        /// <param name="value">The data in byte array format</param>
         /// <param name="startIndex">The first index to use</param>
         /// <param name="bytesToConvert">The number of bytes to use</param>
         /// <returns>The value built from the given bytes</returns>
-        protected internal override long FromBytes(byte[] buffer, int startIndex, int bytesToConvert)
+        protected internal override long FromBytes(byte[] value, int startIndex, int bytesToConvert)
         {
             long ret = 0;
             for (int i = 0; i < bytesToConvert; i++)
             {
-                ret = unchecked((ret << 8) | buffer[startIndex + bytesToConvert - 1 - i]);
+                ret = unchecked((ret << 8) | value[startIndex + bytesToConvert - 1 - i]);
             }
 
             return ret;

--- a/src/ImageProcessor/Imaging/Helpers/Effects.cs
+++ b/src/ImageProcessor/Imaging/Helpers/Effects.cs
@@ -45,7 +45,7 @@ namespace ImageProcessor.Imaging.Helpers
         /// </returns>
         public static Bitmap Vignette(Image source, Color baseColor, Rectangle? rectangle = null, bool invert = false)
         {
-            using (Graphics graphics = Graphics.FromImage(source))
+            using (var graphics = Graphics.FromImage(source))
             {
                 Rectangle bounds = rectangle ?? new Rectangle(0, 0, source.Width, source.Height);
                 Rectangle ellipsebounds = bounds;
@@ -58,10 +58,10 @@ namespace ImageProcessor.Imaging.Helpers
                 int y = ellipsebounds.Height - (int)Math.Floor(.70712 * ellipsebounds.Height);
                 ellipsebounds.Inflate(x, y);
 
-                using (GraphicsPath path = new GraphicsPath())
+                using (var path = new GraphicsPath())
                 {
                     path.AddEllipse(ellipsebounds);
-                    using (PathGradientBrush brush = new PathGradientBrush(path))
+                    using (var brush = new PathGradientBrush(path))
                     {
                         // Fill a rectangle with an elliptical gradient brush that goes from transparent to opaque. 
                         // This has the effect of painting the far corners with the given color and shade less on the way in to the centre.
@@ -82,7 +82,7 @@ namespace ImageProcessor.Imaging.Helpers
                         brush.CenterColor = centerColor;
                         brush.SurroundColors = new[] { edgeColor };
 
-                        Blend blend = new Blend
+                        var blend = new Blend
                         {
                             Positions = new[] { 0.0f, 0.2f, 0.4f, 0.6f, 0.8f, 1.0F },
                             Factors = new[] { 0.0f, 0.5f, 1f, 1f, 1.0f, 1.0f }
@@ -109,10 +109,7 @@ namespace ImageProcessor.Imaging.Helpers
         /// <param name="rectangle">The rectangle to define the bounds of the area to vignette. If null then the effect is applied
         /// to the entire image.</param>
         /// <returns>The <see cref="Bitmap"/> with the vignette applied.</returns>
-        public static Bitmap Glow(Image source, Color baseColor, Rectangle? rectangle = null)
-        {
-            return Vignette(source, baseColor, rectangle, true);
-        }
+        public static Bitmap Glow(Image source, Color baseColor, Rectangle? rectangle = null) => Vignette(source, baseColor, rectangle, true);
 
         /// <summary>
         /// Applies the given image mask to the source.
@@ -139,13 +136,13 @@ namespace ImageProcessor.Imaging.Helpers
             int width = mask.Width;
             int height = mask.Height;
 
-            Bitmap toMask = new Bitmap(source);
+            var toMask = new Bitmap(source);
             toMask.SetResolution(source.HorizontalResolution, source.VerticalResolution);
 
             // Loop through and replace the alpha channel
-            using (FastBitmap maskBitmap = new FastBitmap(mask))
+            using (var maskBitmap = new FastBitmap(mask))
             {
-                using (FastBitmap sourceBitmap = new FastBitmap(toMask))
+                using (var sourceBitmap = new FastBitmap(toMask))
                 {
                     Parallel.For(
                         0,
@@ -170,9 +167,9 @@ namespace ImageProcessor.Imaging.Helpers
             }
 
             // Ensure the background is cleared out on non alpha supporting formats.
-            Bitmap clear = new Bitmap(width, height, PixelFormat.Format32bppPArgb);
+            var clear = new Bitmap(width, height, PixelFormat.Format32bppPArgb);
             clear.SetResolution(source.HorizontalResolution, source.VerticalResolution);
-            using (Graphics graphics = Graphics.FromImage(clear))
+            using (var graphics = Graphics.FromImage(clear))
             {
                 GraphicsHelper.SetGraphicsOptions(graphics, true);
                 graphics.Clear(Color.Transparent);
@@ -205,7 +202,7 @@ namespace ImageProcessor.Imaging.Helpers
             int height = source.Height;
 
             // Grab the edges converting to greyscale, and invert the colors.
-            ConvolutionFilter filter = new ConvolutionFilter(new SobelEdgeFilter(), true);
+            var filter = new ConvolutionFilter(new SobelEdgeFilter(), true);
 
             using (Bitmap temp = filter.Process2DFilter(source))
             {
@@ -217,7 +214,7 @@ namespace ImageProcessor.Imaging.Helpers
 
             // Loop through and replace any colors more white than the threshold
             // with a transparent one. 
-            using (FastBitmap destinationBitmap = new FastBitmap(destination))
+            using (var destinationBitmap = new FastBitmap(destination))
             {
                 Parallel.For(
                     0,

--- a/src/ImageProcessor/Imaging/Helpers/ImageMaths.cs
+++ b/src/ImageProcessor/Imaging/Helpers/ImageMaths.cs
@@ -105,10 +105,7 @@ namespace ImageProcessor.Imaging.Helpers
         /// <returns>
         /// The <see cref="double"/> representing the degree as radians.
         /// </returns>
-        public static double DegreesToRadians(double angleInDegrees)
-        {
-            return angleInDegrees * (Math.PI / 180);
-        }
+        public static double DegreesToRadians(double angleInDegrees) => angleInDegrees * (Math.PI / 180);
 
         /// <summary>
         /// Gets the bounding <see cref="Rectangle"/> from the given points.
@@ -122,10 +119,7 @@ namespace ImageProcessor.Imaging.Helpers
         /// <returns>
         /// The bounding <see cref="Rectangle"/>.
         /// </returns>
-        public static Rectangle GetBoundingRectangle(Point topLeft, Point bottomRight)
-        {
-            return new Rectangle(topLeft.X, topLeft.Y, bottomRight.X - topLeft.X, bottomRight.Y - topLeft.Y);
-        }
+        public static Rectangle GetBoundingRectangle(Point topLeft, Point bottomRight) => new Rectangle(topLeft.X, topLeft.Y, bottomRight.X - topLeft.X, bottomRight.Y - topLeft.Y);
 
         /// <summary>
         /// Calculates the new size after rotation.
@@ -150,7 +144,7 @@ namespace ImageProcessor.Imaging.Helpers
             double height2 = (width * radiansSin) + (height * radiansCos);
 
             // Get the external vertex for the rotation
-            Rectangle result = new Rectangle(
+            var result = new Rectangle(
                 0,
                 0,
                 Convert.ToInt32(Math.Max(Math.Abs(width1), Math.Abs(width2))),
@@ -179,8 +173,8 @@ namespace ImageProcessor.Imaging.Helpers
         {
             int width = bitmap.Width;
             int height = bitmap.Height;
-            Point topLeft = new Point();
-            Point bottomRight = new Point();
+            var topLeft = new Point();
+            var bottomRight = new Point();
 
             Func<FastBitmap, int, int, byte, bool> delegateFunc;
 
@@ -204,7 +198,7 @@ namespace ImageProcessor.Imaging.Helpers
                     break;
             }
 
-            Func<FastBitmap, int> getMinY = fastBitmap =>
+            int getMinY(FastBitmap fastBitmap)
             {
                 for (int y = 0; y < height; y++)
                 {
@@ -218,9 +212,9 @@ namespace ImageProcessor.Imaging.Helpers
                 }
 
                 return 0;
-            };
+            }
 
-            Func<FastBitmap, int> getMaxY = fastBitmap =>
+            int getMaxY(FastBitmap fastBitmap)
             {
                 for (int y = height - 1; y > -1; y--)
                 {
@@ -234,9 +228,9 @@ namespace ImageProcessor.Imaging.Helpers
                 }
 
                 return height;
-            };
+            }
 
-            Func<FastBitmap, int> getMinX = fastBitmap =>
+            int getMinX(FastBitmap fastBitmap)
             {
                 for (int x = 0; x < width; x++)
                 {
@@ -250,9 +244,9 @@ namespace ImageProcessor.Imaging.Helpers
                 }
 
                 return 0;
-            };
+            }
 
-            Func<FastBitmap, int> getMaxX = fastBitmap =>
+            int getMaxX(FastBitmap fastBitmap)
             {
                 for (int x = width - 1; x > -1; x--)
                 {
@@ -266,9 +260,9 @@ namespace ImageProcessor.Imaging.Helpers
                 }
 
                 return height;
-            };
+            }
 
-            using (FastBitmap fastBitmap = new FastBitmap(bitmap))
+            using (var fastBitmap = new FastBitmap(bitmap))
             {
                 topLeft.Y = getMinY(fastBitmap);
                 topLeft.X = getMinX(fastBitmap);
@@ -300,12 +294,12 @@ namespace ImageProcessor.Imaging.Helpers
             {
                 X =
                     (int)
-                    (cosTheta * (pointToRotate.X - center.X) -
-                    sinTheta * (pointToRotate.Y - center.Y) + center.X),
+                    ((cosTheta * (pointToRotate.X - center.X))
+                    - (sinTheta * (pointToRotate.Y - center.Y)) + center.X),
                 Y =
                     (int)
-                    (sinTheta * (pointToRotate.X - center.X) +
-                    cosTheta * (pointToRotate.Y - center.Y) + center.Y)
+                    ((sinTheta * (pointToRotate.X - center.X))
+                    + (cosTheta * (pointToRotate.Y - center.Y)) + center.Y)
             };
         }
 

--- a/src/ImageProcessor/Imaging/Helpers/PixelOperations.cs
+++ b/src/ImageProcessor/Imaging/Helpers/PixelOperations.cs
@@ -68,8 +68,7 @@ namespace ImageProcessor.Imaging.Helpers
             byte[] ramp = new byte[256];
             for (int x = 0; x < 256; ++x)
             {
-                byte val = ((255.0 * Math.Pow(x / 255.0, value)) + 0.5).ToByte();
-                ramp[x] = val;
+                ramp[x] = ((255.0 * Math.Pow(x / 255.0, value)) + 0.5).ToByte();
             }
 
             byte r = ramp[color.R];
@@ -159,8 +158,7 @@ namespace ImageProcessor.Imaging.Helpers
             byte[] ramp = new byte[256];
             for (int x = 0; x < 256; ++x)
             {
-                byte val = (255f * Math.Pow(x / 255f, 2.2)).ToByte();
-                ramp[x] = val;
+                ramp[x] = (255f * Math.Pow(x / 255f, 2.2)).ToByte();
             }
 
             return ramp;
@@ -178,8 +176,7 @@ namespace ImageProcessor.Imaging.Helpers
             byte[] ramp = new byte[256];
             for (int x = 0; x < 256; ++x)
             {
-                byte val = (255f * Math.Pow(x / 255f, 1 / 2.2)).ToByte();
-                ramp[x] = val;
+                ramp[x] = (255f * Math.Pow(x / 255f, 1 / 2.2)).ToByte();
             }
 
             return ramp;
@@ -197,8 +194,7 @@ namespace ImageProcessor.Imaging.Helpers
             byte[] ramp = new byte[256];
             for (int x = 0; x < 256; ++x)
             {
-                byte val = (255f * SRGBToLinear(x / 255f)).ToByte();
-                ramp[x] = val;
+                ramp[x] = (255f * SRGBToLinear(x / 255f)).ToByte();
             }
 
             return ramp;
@@ -216,8 +212,7 @@ namespace ImageProcessor.Imaging.Helpers
             byte[] ramp = new byte[256];
             for (int x = 0; x < 256; ++x)
             {
-                byte val = (255f * LinearToSRGB(x / 255f)).ToByte();
-                ramp[x] = val;
+                ramp[x] = (255f * LinearToSRGB(x / 255f)).ToByte();
             }
 
             return ramp;
@@ -234,7 +229,7 @@ namespace ImageProcessor.Imaging.Helpers
         /// </returns>
         private static float SRGBToLinear(float signal)
         {
-            float a = 0.055f;
+            const float a = 0.055f;
 
             if (signal <= 0.04045)
             {
@@ -255,7 +250,7 @@ namespace ImageProcessor.Imaging.Helpers
         /// </returns>
         private static float LinearToSRGB(float signal)
         {
-            float a = 0.055f;
+            const float a = 0.055f;
 
             if (signal <= 0.0031308)
             {

--- a/src/ImageProcessor/Imaging/ImageLayer.cs
+++ b/src/ImageProcessor/Imaging/ImageLayer.cs
@@ -64,9 +64,7 @@ namespace ImageProcessor.Imaging
         /// </returns>
         public override bool Equals(object obj)
         {
-            ImageLayer imageLayer = obj as ImageLayer;
-
-            if (imageLayer == null)
+            if (!(obj is ImageLayer imageLayer))
             {
                 return false;
             }
@@ -90,18 +88,14 @@ namespace ImageProcessor.Imaging
                 int hashCode = this.Image.GetHashCode();
                 hashCode = (hashCode * 397) ^ this.Size.GetHashCode();
                 hashCode = (hashCode * 397) ^ this.Opacity;
-                hashCode = (hashCode * 397) ^ this.Position.GetHashCode();
-                return hashCode;
+                return (hashCode * 397) ^ this.Position.GetHashCode();
             }
         }
 
         /// <summary>
         /// Disposes the object and frees resources for the Garbage Collector.
         /// </summary>
-        public void Dispose()
-        {
-            this.Dispose(true);
-        }
+        public void Dispose() => this.Dispose(true);
 
         /// <summary>
         /// Disposes the object and frees resources for the Garbage Collector.

--- a/src/ImageProcessor/Imaging/Interpolation.cs
+++ b/src/ImageProcessor/Imaging/Interpolation.cs
@@ -32,25 +32,23 @@ namespace ImageProcessor.Imaging
         public static double BiCubicKernel(double x)
         {
             // The coefficient.
-            double a = -0.5;
+            const double a = -0.5;
 
             if (x < 0)
             {
                 x = -x;
             }
 
-            double bicubicCoeffient = 0;
-
             if (x <= 1)
             {
-                bicubicCoeffient = (((1.5 * x) - 2.5) * x * x) + 1;
+                return (((1.5 * x) - 2.5) * x * x) + 1;
             }
             else if (x < 2)
             {
-                bicubicCoeffient = (((((a * x) + 2.5) * x) - 4) * x) + 2;
+                return (((((a * x) + 2.5) * x) - 4) * x) + 2;
             }
 
-            return bicubicCoeffient;
+            return 0;
         }
 
         /// <summary>

--- a/src/ImageProcessor/Imaging/MetaData/ExifBitConverter.cs
+++ b/src/ImageProcessor/Imaging/MetaData/ExifBitConverter.cs
@@ -31,10 +31,7 @@ namespace ImageProcessor.Imaging.MetaData
         /// <param name="computerArchitectureInfo">
         /// The computer architecture info.
         /// </param>
-        public ExifBitConverter(IComputerArchitectureInfo computerArchitectureInfo)
-        {
-            this.computerArchitectureInfo = computerArchitectureInfo;
-        }
+        public ExifBitConverter(IComputerArchitectureInfo computerArchitectureInfo) => this.computerArchitectureInfo = computerArchitectureInfo;
 
         /// <summary>
         /// Indicates the byte order ("endianness") in which data is converted using this class.
@@ -50,10 +47,7 @@ namespace ImageProcessor.Imaging.MetaData
         /// most significant byte is on the right end of a word.
         /// </remarks>
         /// <returns>true if this converter is little-endian, false otherwise.</returns>
-        public override bool IsLittleEndian()
-        {
-            return this.computerArchitectureInfo.IsLittleEndian();
-        }
+        public override bool IsLittleEndian() => this.computerArchitectureInfo.IsLittleEndian();
 
         /// <summary>
         /// Converts the given ascii string to an array of bytes optionally adding a null terminator.
@@ -87,10 +81,7 @@ namespace ImageProcessor.Imaging.MetaData
         /// <returns>
         /// The <see cref="T:byte[]"/>.
         /// </returns>
-        public byte[] GetBytes(string value)
-        {
-            return this.GetBytes(value, false);
-        }
+        public byte[] GetBytes(string value) => this.GetBytes(value, false);
 
         /// <summary>
         /// Converts the given unsigned rational number to an array of bytes.

--- a/src/ImageProcessor/Imaging/MetaData/ExifPropertyTag.cs
+++ b/src/ImageProcessor/Imaging/MetaData/ExifPropertyTag.cs
@@ -17,9 +17,173 @@ namespace ImageProcessor.Imaging.MetaData
     public enum ExifPropertyTag
     {
         /// <summary>
-        /// Null-terminated character string that specifies the name of the person who created the image.
+        /// Version of the Global Positioning Systems (GPS) IFD, given as 2.0.0.0. This tag is mandatory when 
+        /// the <see cref="ExifPropertyTag.GpsIFD"/> tag is present. When the version is 2.0.0.0, the tag value is 0x02000000.
         /// </summary>
-        Artist = 0x013B,
+        GpsVer = 0x0000,
+
+        /// <summary>
+        /// Null-terminated character string that specifies whether the longitude is east or west longitude. 
+        /// E specifies east longitude, and W specifies west longitude.
+        /// </summary>
+        GpsLatitudeRef = 0x0001,
+
+        /// <summary>
+        /// Latitude. Latitude is expressed as three rational values giving the degrees, minutes, and seconds respectively. When degrees, minutes, and seconds are expressed, the format is dd/1, mm/1, ss/1. When degrees and minutes are used and, for example, fractions of minutes are given up to two decimal places, the format is dd/1, mmmm/100, 0/1.
+        /// </summary>
+        GpsLatitude = 0x0002,
+
+        /// <summary>
+        /// Null-terminated character string that specifies whether the longitude is east or west longitude. 
+        /// E specifies east longitude, and W specifies west longitude.
+        /// </summary>
+        GpsLongitudeRef = 0x0003,
+
+        /// <summary>
+        /// Longitude. Longitude is expressed as three rational values giving the degrees, minutes, and seconds 
+        /// respectively. When degrees, minutes and seconds are expressed, the format is ddd/1, mm/1, ss/1. 
+        /// When degrees and minutes are used and, for example, fractions of minutes are given up to two 
+        /// decimal places, the format is ddd/1, mmmm/100, 0/1.
+        /// </summary>
+        GpsLongitude = 0x0004,
+
+        /// <summary>
+        /// Reference altitude, in meters.
+        /// </summary>
+        GpsAltitudeRef = 0x0005,
+
+        /// <summary>
+        /// Altitude, in meters, based on the reference altitude specified by <see cref="ExifPropertyTag.GpsAltitudeRef"/>.
+        /// </summary>
+        GpsAltitude = 0x0006,
+
+        /// <summary>
+        /// Time as coordinated universal time (UTC). The value is expressed as three rational numbers that give the hour, minute, and second.
+        /// </summary>
+        GpsGpsTime = 0x0007,
+
+        /// <summary>
+        /// Null-terminated character string that specifies the GPS satellites used for measurements. This tag can be used to specify the ID number, angle of elevation, azimuth, SNR, and other information about each satellite. The format is not specified. If the GPS receiver is incapable of taking measurements, the value of the tag must be set to NULL.
+        /// </summary>
+        GpsGpsSatellites = 0x0008,
+
+        /// <summary>
+        /// Null-terminated character string that specifies the status of the GPS receiver when the image is recorded. A means measurement is in progress, and V means the measurement is Interoperability.
+        /// </summary>
+        GpsGpsStatus = 0x0009,
+
+        /// <summary>
+        /// Null-terminated character string that specifies the GPS measurement mode. 2 specifies 2-D measurement, and 3 specifies 3-D measurement.
+        /// </summary>
+        GpsGpsMeasureMode = 0x000A,
+
+        /// <summary>
+        /// GPS DOP (data degree of precision). An HDOP value is written during 2-D measurement, and a PDOP value is written during 3-D measurement.
+        /// </summary>
+        GpsGpsDop = 0x000B,
+
+        /// <summary>
+        /// Null-terminated character string that specifies the unit used to express the GPS receiver speed of movement. 
+        /// K, M, and N represent kilometers per hour, miles per hour, and knots respectively.
+        /// </summary>
+        GpsSpeedRef = 0x000C,
+
+        /// <summary>
+        /// Speed of the GPS receiver movement.
+        /// </summary>
+        GpsSpeed = 0x000D,
+
+        /// <summary>
+        /// Null-terminated character string that specifies the reference for giving the direction of 
+        /// GPS receiver movement. T specifies true direction, and M specifies magnetic direction.
+        /// </summary>
+        GpsTrackRef = 0x000E,
+
+        /// <summary>
+        /// Direction of GPS receiver movement. The range of values is from 0.00 to 359.99.
+        /// </summary>
+        GpsTrack = 0x000F,
+
+        /// <summary>
+        /// Null-terminated character string that specifies the reference for the direction of the image when it is captured. T specifies true direction, and M specifies magnetic direction.
+        /// </summary>
+        GpsImgDirRef = 0x0010,
+
+        /// <summary>
+        /// Direction of the image when it was captured. The range of values is from 0.00 to 359.99.
+        /// </summary>
+        GpsImgDir = 0x0011,
+
+        /// <summary>
+        /// Null-terminated character string that specifies geodetic survey data used by the GPS receiver. 
+        /// If the survey data is restricted to Japan, the value of this tag is TOKYO or WGS-84.
+        /// </summary>
+        GpsMapDatum = 0x0012,
+
+        /// <summary>
+        /// Null-terminated character string that specifies whether the latitude of the destination point is north or south 
+        /// latitude. N specifies north latitude, and S specifies south latitude.
+        /// </summary>
+        GpsDestLatRef = 0x0013,
+
+        /// <summary>
+        /// Latitude of the destination point. The latitude is expressed as three rational values giving the degrees, 
+        /// minutes, and seconds respectively. When degrees, minutes, and seconds are expressed, the format is 
+        /// dd/1, mm/1, ss/1. When degrees and minutes are used and, for example, fractions of minutes are given up to 
+        /// two decimal places, the format is dd/1, mmmm/100, 0/1.
+        /// </summary>
+        GpsDestLat = 0x0014,
+
+        /// <summary>
+        /// Null-terminated character string that specifies whether the longitude of the destination point is east or west longitude. E specifies east longitude, and W specifies west longitude.
+        /// </summary>
+        GpsDestLongRef = 0x0015,
+
+        /// <summary>
+        /// Longitude of the destination point. The longitude is expressed as three rational values giving the degrees, minutes, and seconds respectively. When degrees, minutes, and seconds are expressed, the format is ddd/1, mm/1, ss/1. When degrees and minutes are used and, for example, fractions of minutes are given up to two decimal places, the format is ddd/1, mmmm/100, 0/1.
+        /// </summary>
+        GpsDestLong = 0x0016,
+
+        /// <summary>
+        /// Null-terminated character string that specifies the reference used for giving the bearing to the destination point. T specifies true direction, and M specifies magnetic direction.
+        /// </summary>
+        GpsDestBearRef = 0x0017,
+
+        /// <summary>
+        /// Bearing to the destination point. The range of values is from 0.00 to 359.99.
+        /// </summary>
+        GpsDestBear = 0x0018,
+
+        /// <summary>
+        /// Null-terminated character string that specifies the unit used to express the distance to the destination point. 
+        /// K, M, and N represent kilometers, miles, and knots respectively.
+        /// </summary>
+        GpsDestDistRef = 0x0019,
+
+        /// <summary>
+        /// Distance to the destination point.
+        /// </summary>
+        GpsDestDist = 0x001A,
+
+        /// <summary>
+        /// Type of data in a subfile.
+        /// </summary>
+        NewSubfileType = 0x00FE,
+
+        /// <summary>
+        /// The type of data in a subfile.
+        /// </summary>
+        SubfileType = 0x00FF,
+
+        /// <summary>
+        /// Number of pixels per row.
+        /// </summary>
+        ImageWidth = 0x0100,
+
+        /// <summary>
+        /// Number of pixel rows.
+        /// </summary>
+        ImageHeight = 0x0101,
 
         /// <summary>
         /// Number of bits per color component. See also <see cref="SamplesPerPixel"/>
@@ -27,9 +191,19 @@ namespace ImageProcessor.Imaging.MetaData
         BitsPerSample = 0x0102,
 
         /// <summary>
-        /// Height of the dithering or halftoning matrix.
+        /// Compression scheme used for the image data.
         /// </summary>
-        CellHeight = 0x0109,
+        Compression = 0x0103,
+
+        /// <summary>
+        /// How pixel data will be interpreted.
+        /// </summary>
+        PhotometricInterp = 0x0106,
+
+        /// <summary>
+        /// Technique used to convert from gray pixels to black and white pixels.
+        /// </summary>
+        ThreshHolding = 0x0107,
 
         /// <summary>
         /// Width of the dithering or halftoning matrix.
@@ -37,36 +211,14 @@ namespace ImageProcessor.Imaging.MetaData
         CellWidth = 0x0108,
 
         /// <summary>
-        /// Chrominance table. The luminance table and the chrominance table are used to control JPEG quality. 
-        /// A valid luminance or chrominance table has 64 entries. 
-        /// If an image has either a luminance table or a chrominance table, then it must have both tables.
+        /// Height of the dithering or halftoning matrix.
         /// </summary>
-        ChrominanceTable = 0x5091,
+        CellHeight = 0x0109,
 
         /// <summary>
-        /// Color palette (lookup table) for a palette-indexed image.
+        /// Logical order of bits in a byte.
         /// </summary>
-        ColorMap = 0x0140,
-
-        /// <summary>
-        /// Table of values that specify color transfer functions.
-        /// </summary>
-        ColorTransferFunction = 0x501A,
-
-        /// <summary>
-        /// Compression scheme used for the image data.
-        /// </summary>
-        Compression = 0x0103,
-
-        /// <summary>
-        /// Null-terminated character string that contains copyright information.
-        /// </summary>
-        Copyright = 0x8298,
-
-        /// <summary>
-        /// Date and time the image was created.
-        /// </summary>
-        DateTime = 0x0132,
+        FillOrder = 0x010A,
 
         /// <summary>
         /// Null-terminated character string that specifies the name of the document from 
@@ -75,9 +227,9 @@ namespace ImageProcessor.Imaging.MetaData
         DocumentName = 0x010D,
 
         /// <summary>
-        /// Color component values that correspond to a 0 percent dot and a 100 percent dot.
+        /// Null-terminated character string that specifies the title of the image.
         /// </summary>
-        DotRange = 0x0150,
+        ImageDescription = 0x010E,
 
         /// <summary>
         /// Null-terminated character string that specifies the manufacturer of the 
@@ -92,35 +244,758 @@ namespace ImageProcessor.Imaging.MetaData
         EquipModel = 0x0110,
 
         /// <summary>
-        /// Lens aperture. The unit is the APEX value.
+        /// For each strip, the byte offset of that strip. See also <see cref="ExifPropertyTag.RowsPerStrip"/> 
+        /// and <see cref="ExifPropertyTag.StripBytesCount"/>.
         /// </summary>
-        ExifAperture = 0x9202,
+        StripOffsets = 0x0111,
 
         /// <summary>
-        /// Brightness value. The unit is the APEX value. Ordinarily it is given 
-        /// in the range of -99.99 to 99.99.
+        /// Image orientation viewed in terms of rows and columns.
         /// </summary>
-        ExifBrightness = 0x9203,
+        Orientation = 0x0112,
 
         /// <summary>
-        /// The color filter array (CFA) geometric pattern of the image sensor when a one-chip color 
-        /// area sensor is used. It does not apply to all sensing methods.
+        /// Number of color components per pixel.
         /// </summary>
-        ExifCfaPattern = 0xA302,
+        SamplesPerPixel = 0x0115,
 
         /// <summary>
-        /// Color space specifier. Normally sRGB (=1) is used to define the color space 
-        /// based on the PC monitor conditions and environment. If a color space other 
-        /// than sRGB is used, Uncalibrated (=0xFFFF) is set. Image data recorded as 
-        /// Uncalibrated can be treated as sRGB when it is converted to FlashPix.
+        /// Number of rows per strip. See also <see cref="ExifPropertyTag.StripBytesCount"/> and <see cref="ExifPropertyTag.StripOffsets"/>.
         /// </summary>
-        ExifColorSpace = 0xA001,
+        RowsPerStrip = 0x0116,
 
         /// <summary>
-        /// Information specific to compressed data. The compression mode used for a 
-        /// compressed image is indicated in unit BPP.
+        /// For each strip, the total number of bytes in that strip.
         /// </summary>
-        ExifCompBPP = 0x9102,
+        StripBytesCount = 0x0117,
+
+        /// <summary>
+        /// For each color component, the minimum value assigned to that component. 
+        /// See also <see cref="ExifPropertyTag.SamplesPerPixel"/>.
+        /// </summary>
+        MinSampleValue = 0x0118,
+
+        /// <summary>
+        /// For each color component, the maximum value assigned to that component. 
+        /// See also <see cref="ExifPropertyTag.SamplesPerPixel"/>.
+        /// </summary>
+        MaxSampleValue = 0x0119,
+
+        /// <summary>
+        /// Number of pixels per unit in the image width (x) direction. 
+        /// The unit is specified by <see cref="ExifPropertyTag.ResolutionUnit"/>.
+        /// </summary>
+        XResolution = 0x011A,
+
+        /// <summary>
+        /// Number of pixels per unit in the image height (y) direction. The unit is specified 
+        /// by <see cref="ExifPropertyTag.ResolutionUnit"/>.
+        /// </summary>
+        YResolution = 0x011B,
+
+        /// <summary>
+        /// Whether pixel components are recorded in chunky or planar format.
+        /// </summary>
+        PlanarConfig = 0x011C,
+
+        /// <summary>
+        /// Null-terminated character string that specifies the name of the page from which the image was scanned.
+        /// </summary>
+        PageName = 0x011D,
+
+        /// <summary>
+        /// Offset from the left side of the page to the left side of the image. 
+        /// The unit of measure is specified by <see cref="ExifPropertyTag.ResolutionUnit"/>.
+        /// </summary>
+        XPosition = 0x011E,
+
+        /// <summary>
+        /// Offset from the top of the page to the top of the image. The unit of measure 
+        /// is specified by <see cref="ExifPropertyTag.ResolutionUnit"/>.
+        /// </summary>
+        YPosition = 0x011F,
+
+        /// <summary>
+        /// For each string of contiguous unused bytes, the byte offset of that string.
+        /// </summary>
+        FreeOffset = 0x0120,
+
+        /// <summary>
+        /// For each string of contiguous unused bytes, the number of bytes in that string.
+        /// </summary>
+        FreeByteCounts = 0x0121,
+
+        /// <summary>
+        /// Precision of the number specified by <see cref="ExifPropertyTag.GrayResponseCurve"/>. 1 specifies tenths, 
+        /// 2 specifies hundredths, 3 specifies thousandths, and so on.
+        /// </summary>
+        GrayResponseUnit = 0x0122,
+
+        /// <summary>
+        /// For each possible pixel value in a grayscale image, the optical density of that pixel value.
+        /// </summary>
+        GrayResponseCurve = 0x0123,
+
+        /// <summary>
+        /// Set of flags that relate to T4 encoding.
+        /// </summary>
+        T4Option = 0x0124,
+
+        /// <summary>
+        /// Set of flags that relate to T6 encoding.
+        /// </summary>
+        T6Option = 0x0125,
+
+        /// <summary>
+        /// Unit of measure for the horizontal resolution and the vertical resolution.
+        /// </summary>
+        ResolutionUnit = 0x0128,
+
+        /// <summary>
+        /// Page number of the page from which the image was scanned.
+        /// </summary>
+        PageNumber = 0x0129,
+
+        /// <summary>
+        /// Tables that specify transfer functions for the image.
+        /// </summary>
+        TransferFunction = 0x012D,
+
+        /// <summary>
+        /// Null-terminated character string that specifies the name and version of the software or 
+        /// firmware of the device used to generate the image.
+        /// </summary>
+        SoftwareUsed = 0x0131,
+
+        /// <summary>
+        /// Date and time the image was created.
+        /// </summary>
+        DateTime = 0x0132,
+
+        /// <summary>
+        /// Null-terminated character string that specifies the name of the person who created the image.
+        /// </summary>
+        Artist = 0x013B,
+
+        /// <summary>
+        /// Null-terminated character string that specifies the computer and/or operating system used to create the image.
+        /// </summary>
+        HostComputer = 0x013C,
+
+        /// <summary>
+        /// TType of prediction scheme that was applied to the image data before the encoding scheme was applied.
+        /// </summary>
+        Predictor = 0x013D,
+
+        /// <summary>
+        /// Chromaticity of the white point of the image.
+        /// </summary>
+        WhitePoint = 0x013E,
+
+        /// <summary>
+        /// For each of the three primary colors in the image, the chromaticity of that color.
+        /// </summary>
+        PrimaryChromaticities = 0x013F,
+
+        /// <summary>
+        /// Color palette (lookup table) for a palette-indexed image.
+        /// </summary>
+        ColorMap = 0x0140,
+
+        /// <summary>
+        /// Information used by the halftone function.
+        /// </summary>
+        HalftoneHints = 0x0141,
+
+        /// <summary>
+        /// Number of pixel columns in each tile.
+        /// </summary>
+        TileWidth = 0x0142,
+
+        /// <summary>
+        /// Number of pixel rows in each tile.
+        /// </summary>
+        TileLength = 0x0143,
+
+        /// <summary>
+        /// For each tile, the byte offset of that tile.
+        /// </summary>
+        TileOffset = 0x0144,
+
+        /// <summary>
+        /// For each tile, the number of bytes in that tile.
+        /// </summary>
+        TileByteCounts = 0x0145,
+
+        /// <summary>
+        /// Set of inks used in a separated image.
+        /// </summary>
+        InkSet = 0x014C,
+
+        /// <summary>
+        /// Sequence of concatenated, null-terminated, character strings that specify the names of the 
+        /// inks used in a separated image.
+        /// </summary>
+        InkNames = 0x014D,
+
+        /// <summary>
+        /// The number of inks.
+        /// </summary>
+        NumberOfInks = 0x014E,
+
+        /// <summary>
+        /// Color component values that correspond to a 0 percent dot and a 100 percent dot.
+        /// </summary>
+        DotRange = 0x0150,
+
+        /// <summary>
+        /// Null-terminated character string that describes the intended printing environment.
+        /// </summary>
+        TargetPrinter = 0x0151,
+
+        /// <summary>
+        /// Number of extra color components. For example, one extra component might hold an alpha value.
+        /// </summary>
+        ExtraSamples = 0x0152,
+
+        /// <summary>
+        /// For each color component, the numerical format (unsigned, signed, floating point) of that component. 
+        /// See also <see cref="ExifPropertyTag.SamplesPerPixel"/>.
+        /// </summary>
+        SampleFormat = 0x0153,
+
+        /// <summary>
+        /// For each color component, the minimum value of that component. See also <see cref="ExifPropertyTag.SamplesPerPixel"/>.
+        /// </summary>
+        SMinSampleValue = 0x0154,
+
+        /// <summary>
+        /// For each color component, the maximum value of that component. See also <see cref="ExifPropertyTag.SamplesPerPixel"/>.
+        /// </summary>
+        SMaxSampleValue = 0x0155,
+
+        /// <summary>
+        /// Table of values that extends the range of the transfer function.
+        /// </summary>
+        TransferRange = 0x0156,
+
+        /// <summary>
+        /// JPEG compression process.
+        /// </summary>
+        JPEGProc = 0x0200,
+
+        /// <summary>
+        /// Offset to the start of a JPEG bitstream.
+        /// </summary>
+        JPEGInterFormat = 0x0201,
+
+        /// <summary>
+        /// Length, in bytes, of the JPEG bitstream.
+        /// </summary>
+        JPEGInterLength = 0x0202,
+
+        /// <summary>
+        /// Length of the restart interval.
+        /// </summary>
+        JPEGRestartInterval = 0x0203,
+
+        /// <summary>
+        /// For each color component, a lossless predictor-selection value for that component. 
+        /// See also <see cref="ExifPropertyTag.SamplesPerPixel"/>.
+        /// </summary>
+        JPEGLosslessPredictors = 0x0205,
+
+        /// <summary>
+        /// For each color component, a point transformation value for that component. 
+        /// See also <see cref="ExifPropertyTag.SamplesPerPixel"/>.
+        /// </summary>
+        JPEGPointTransforms = 0x0206,
+
+        /// <summary>
+        /// For each color component, the offset to the quantization table for that 
+        /// component. See also <see cref="ExifPropertyTag.SamplesPerPixel"/>.
+        /// </summary>
+        JPEGQTables = 0x0207,
+
+        /// <summary>
+        /// For each color component, the offset to the DC Huffman table (or lossless Huffman table) for that 
+        /// component. See also <see cref="ExifPropertyTag.SamplesPerPixel"/>.
+        /// </summary>
+        JPEGDCTables = 0x0208,
+
+        /// <summary>
+        /// For each color component, the offset to the AC Huffman table for that component. 
+        /// See also <see cref="ExifPropertyTag.SamplesPerPixel"/>.
+        /// </summary>
+        JPEGACTables = 0x0209,
+
+        /// <summary>
+        /// Coefficients for transformation from RGB to YCbCr image data.
+        /// </summary>
+        YCbCrCoefficients = 0x0211,
+
+        /// <summary>
+        /// Sampling ratio of chrominance components in relation to the luminance component.
+        /// </summary>
+        YCbCrSubsampling = 0x0212,
+
+        /// <summary>
+        /// Position of chrominance components in relation to the luminance component.
+        /// </summary>
+        YCbCrPositioning = 0x0213,
+
+        /// <summary>
+        /// Reference black point value and reference white point value.
+        /// </summary>
+        REFBlackWhite = 0x0214,
+
+        /// <summary>
+        /// Gamma value attached to the image. The gamma value is stored as a rational number (pair of long) with a numerator of 100000. For example, a gamma value of 2.2 is stored as the pair (100000, 45455).
+        /// </summary>
+        Gamma = 0x0301,
+
+        /// <summary>
+        /// Null-terminated character string that identifies an ICC profile.
+        /// </summary>
+        ICCProfileDescriptor = 0x0302,
+
+        /// <summary>
+        /// How the image should be displayed as defined by the International Color Consortium (ICC). If a GDI+ Image object
+        /// is constructed with the useEmbeddedColorManagement parameter set to TRUE, then GDI+ renders the image 
+        /// according to the specified rendering intent. The intent can be set to perceptual, relative colorimetric, 
+        /// saturation, or absolute colorimetric.
+        /// </summary>
+        SRGBRenderingIntent = 0x0303,
+
+        /// <summary>
+        /// Null-terminated character string that specifies the title of the image.
+        /// </summary>
+        ImageTitle = 0x0320,
+
+        /// <summary>
+        /// Units in which to display horizontal resolution.
+        /// </summary>
+        ResolutionXUnit = 0x5001,
+
+        /// <summary>
+        /// Units in which to display vertical resolution.
+        /// </summary>
+        ResolutionYUnit = 0x5002,
+
+        /// <summary>
+        /// Units in which to display the image width.
+        /// </summary>
+        ResolutionXLengthUnit = 0x5003,
+
+        /// <summary>
+        /// Units in which to display the image height.
+        /// </summary>
+        ResolutionYLengthUnit = 0x5004,
+
+        /// <summary>
+        /// Sequence of one-byte Boolean values that specify printing options.
+        /// </summary>
+        PrintFlags = 0x5005,
+
+        /// <summary>
+        /// The print flags version.
+        /// </summary>
+        PrintFlagsVersion = 0x5006,
+
+        /// <summary>
+        /// The print flags crop marks.
+        /// </summary>
+        PrintFlagsCrop = 0x5007,
+
+        /// <summary>
+        /// The print flags bleed width.
+        /// </summary>
+        PrintFlagsBleedWidth = 0x5008,
+
+        /// <summary>
+        /// The print flags bleed width scale.
+        /// </summary>
+        PrintFlagsBleedWidthScale = 0x5009,
+
+        /// <summary>
+        /// Ink's screen frequency, in lines per inch.
+        /// </summary>
+        HalftoneLPI = 0x500A,
+
+        /// <summary>
+        /// Units for the screen frequency.
+        /// </summary>
+        HalftoneLPIUnit = 0x500B,
+
+        /// <summary>
+        /// Angle for screen.
+        /// </summary>
+        HalftoneDegree = 0x500C,
+
+        /// <summary>
+        /// Shape of the halftone dots.
+        /// </summary>
+        HalftoneShape = 0x500D,
+
+        /// <summary>
+        /// Miscellaneous halftone information.
+        /// </summary>
+        HalftoneMisc = 0x500E,
+
+        /// <summary>
+        /// Boolean value that specifies whether to use the printer's default screens.
+        /// </summary>
+        HalftoneScreen = 0x500F,
+
+        /// <summary>
+        /// Private tag used by the Adobe Photoshop format. Not for public use.
+        /// </summary>
+        JPEGQuality = 0x5010,
+
+        /// <summary>
+        /// Block of information about grids and guides.
+        /// </summary>
+        GridSize = 0x5011,
+
+        /// <summary>
+        /// Format of the thumbnail image.
+        /// </summary>
+        ThumbnailFormat = 0x5012,
+
+        /// <summary>
+        /// Width, in pixels, of the thumbnail image.
+        /// </summary>
+        ThumbnailWidth = 0x5013,
+
+        /// <summary>
+        /// Height, in pixels, of the thumbnail image.
+        /// </summary>
+        ThumbnailHeight = 0x5014,
+
+        /// <summary>
+        /// Bits per pixel (BPP) for the thumbnail image.
+        /// </summary>
+        ThumbnailColorDepth = 0x5015,
+
+        /// <summary>
+        /// Number of color planes for the thumbnail image.
+        /// </summary>
+        ThumbnailPlanes = 0x5016,
+
+        /// <summary>
+        /// Byte offset between rows of pixel data.
+        /// </summary>
+        ThumbnailRawBytes = 0x5017,
+
+        /// <summary>
+        /// Total size, in bytes, of the thumbnail image.
+        /// </summary>
+        ThumbnailSize = 0x5018,
+
+        /// <summary>
+        /// Compressed size, in bytes, of the thumbnail image.
+        /// </summary>
+        ThumbnailCompressedSize = 0x5019,
+
+        /// <summary>
+        /// Table of values that specify color transfer functions.
+        /// </summary>
+        ColorTransferFunction = 0x501A,
+
+        /// <summary>
+        /// Raw thumbnail bits in JPEG or RGB format. Depends on <see cref="ExifPropertyTag.ThumbnailFormat"/>.
+        /// </summary>
+        ThumbnailData = 0x501B,
+
+        /// <summary>
+        /// Number of pixels per row in the thumbnail image.
+        /// </summary>
+        ThumbnailImageWidth = 0x5020,
+
+        /// <summary>
+        /// Number of pixel rows in the thumbnail image.
+        /// </summary>
+        ThumbnailImageHeight = 0x5021,
+
+        /// <summary>
+        /// Number of bits per color component in the thumbnail image. See also <see cref="ExifPropertyTag.ThumbnailSamplesPerPixel"/>.
+        /// </summary>
+        ThumbnailBitsPerSample = 0x5022,
+
+        /// <summary>
+        /// Compression scheme used for thumbnail image data.
+        /// </summary>
+        ThumbnailCompression = 0x5023,
+
+        /// <summary>
+        /// How thumbnail pixel data will be interpreted.
+        /// </summary>
+        ThumbnailPhotometricInterp = 0x5024,
+
+        /// <summary>
+        /// Null-terminated character string that specifies the title of the image.
+        /// </summary>
+        ThumbnailImageDescription = 0x5025,
+
+        /// <summary>
+        /// Null-terminated character string that specifies the manufacturer of the equipment used to 
+        /// record the thumbnail image.
+        /// </summary>
+        ThumbnailEquipMake = 0x5026,
+
+        /// <summary>
+        /// Null-terminated character string that specifies the model name or model number of the 
+        /// equipment used to record the thumbnail image.
+        /// </summary>
+        ThumbnailEquipModel = 0x5027,
+
+        /// <summary>
+        /// For each strip in the thumbnail image, the byte offset of that strip. See also <see cref="ExifPropertyTag.ThumbnailRowsPerStrip"/> 
+        /// and <see cref="ExifPropertyTag.ThumbnailStripBytesCount"/>.
+        /// </summary>
+        ThumbnailStripOffsets = 0x5028,
+
+        /// <summary>
+        /// Thumbnail image orientation in terms of rows and columns. See also <see cref="ExifPropertyTag.Orientation"/>.
+        /// </summary>
+        ThumbnailOrientation = 0x5029,
+
+        /// <summary>
+        /// Number of color components per pixel in the thumbnail image.
+        /// </summary>
+        ThumbnailSamplesPerPixel = 0x502A,
+
+        /// <summary>
+        /// Number of rows per strip in the thumbnail image. See also <see cref="ExifPropertyTag.ThumbnailStripBytesCount"/> 
+        /// and <see cref="ExifPropertyTag.ThumbnailStripOffsets"/>.
+        /// </summary>
+        ThumbnailRowsPerStrip = 0x502B,
+
+        /// <summary>
+        /// For each thumbnail image strip, the total number of bytes in that strip.
+        /// </summary>
+        ThumbnailStripBytesCount = 0x502C,
+
+        /// <summary>
+        /// Thumbnail resolution in the width direction. 
+        /// The resolution unit is given in <see cref="ExifPropertyTag.ThumbnailResolutionUnit"/>.
+        /// </summary>
+        ThumbnailResolutionX = 0x502D,
+
+        /// <summary>
+        /// Thumbnail resolution in the height direction. The resolution unit is given 
+        /// in <see cref="ExifPropertyTag.ThumbnailResolutionUnit"/>.
+        /// </summary>
+        ThumbnailResolutionY = 0x502E,
+
+        /// <summary>
+        /// Whether pixel components in the thumbnail image are recorded in chunky or planar format. 
+        /// See also <see cref="ExifPropertyTag.PlanarConfig"/>.
+        /// </summary>
+        ThumbnailPlanarConfig = 0x502F,
+
+        /// <summary>
+        /// Unit of measure for the horizontal resolution and the vertical resolution of 
+        /// the thumbnail image. See also <see cref="ExifPropertyTag.ResolutionUnit"/>.
+        /// </summary>
+        ThumbnailResolutionUnit = 0x5030,
+
+        /// <summary>
+        /// Tables that specify transfer functions for the thumbnail image. See also <see cref="ExifPropertyTag.TransferFunction"/>.
+        /// </summary>
+        ThumbnailTransferFunction = 0x5031,
+
+        /// <summary>
+        /// Null-terminated character string that specifies the name and version of the software 
+        /// or firmware of the device used to generate the thumbnail image.
+        /// </summary>
+        ThumbnailSoftwareUsed = 0x5032,
+
+        /// <summary>
+        /// Date and time the thumbnail image was created. See also <see cref="ExifPropertyTag.DateTime"/>.
+        /// </summary>
+        ThumbnailDateTime = 0x5033,
+
+        /// <summary>
+        /// Null-terminated character string that specifies the name of the person who created the thumbnail image.
+        /// </summary>
+        ThumbnailArtist = 0x5034,
+
+        /// <summary>
+        /// Chromaticity of the white point of the thumbnail image. See also <see cref="ExifPropertyTag.WhitePoint"/>.
+        /// </summary>
+        ThumbnailWhitePoint = 0x5035,
+
+        /// <summary>
+        /// For each of the three primary colors in the thumbnail image, the chromaticity 
+        /// of that color. See also <see cref="ExifPropertyTag.PrimaryChromaticities"/>.
+        /// </summary>
+        ThumbnailPrimaryChromaticities = 0x5036,
+
+        /// <summary>
+        /// Coefficients for transformation from RGB to YCbCr data for the thumbnail image. 
+        /// See also <see cref="ExifPropertyTag.YCbCrCoefficients"/>.
+        /// </summary>
+        ThumbnailYCbCrCoefficients = 0x5037,
+
+        /// <summary>
+        /// Sampling ratio of chrominance components in relation to the luminance component for 
+        /// the thumbnail image. See also <see cref="ExifPropertyTag.YCbCrSubsampling"/>.
+        /// </summary>
+        ThumbnailYCbCrSubsampling = 0x5038,
+
+        /// <summary>
+        /// Position of chrominance components in relation to the luminance component for 
+        /// the thumbnail image. See also <see cref="ExifPropertyTag.YCbCrPositioning"/>.
+        /// </summary>
+        ThumbnailYCbCrPositioning = 0x5039,
+
+        /// <summary>
+        /// Reference black point value and reference white point value 
+        /// for the thumbnail image. See also <see cref="ExifPropertyTag.REFBlackWhite"/>.
+        /// </summary>
+        ThumbnailRefBlackWhite = 0x503A,
+
+        /// <summary>
+        /// Null-terminated character string that contains copyright information for the thumbnail image.
+        /// </summary>
+        ThumbnailCopyRight = 0x503B,
+
+        /// <summary>
+        /// Luminance table. The luminance table and the chrominance table are used to control JPEG quality. 
+        /// A valid luminance or chrominance table has 64 entries of type <see cref="ExifPropertyTagType.UShort"/>. 
+        /// If an image has either a luminance table or a chrominance table, then it must have both tables.
+        /// </summary>
+        LuminanceTable = 0x5090,
+
+        /// <summary>
+        /// Chrominance table. The luminance table and the chrominance table are used to control JPEG quality. 
+        /// A valid luminance or chrominance table has 64 entries. 
+        /// If an image has either a luminance table or a chrominance table, then it must have both tables.
+        /// </summary>
+        ChrominanceTable = 0x5091,
+
+        /// <summary>
+        /// Time delay, in hundredths of a second, between two frames in an animated GIF image.
+        /// </summary>
+        FrameDelay = 0x5100,
+
+        /// <summary>
+        /// For an animated GIF image, the number of times to display the animation. 
+        /// A value of 0 specifies that the animation should be displayed infinitely.
+        /// </summary>
+        LoopCount = 0x5101,
+
+        /// <summary>
+        /// Color palette for an indexed bitmap in a GIF image.
+        /// </summary>
+        GlobalPalette = 0x5102,
+
+        /// <summary>
+        /// Index of the background color in the palette of a GIF image.
+        /// </summary>
+        IndexBackground = 0x5103,
+
+        /// <summary>
+        /// Index of the transparent color in the palette of a GIF image.
+        /// </summary>
+        IndexTransparent = 0x5104,
+
+        /// <summary>
+        /// Unit for <see cref="ExifPropertyTag.PixelPerUnitX"/> and <see cref="ExifPropertyTag.PixelPerUnitY"/>.
+        /// </summary>
+        PixelUnit = 0x5110,
+
+        /// <summary>
+        /// Pixels per unit in the x direction.
+        /// </summary>
+        PixelPerUnitX = 0x5111,
+
+        /// <summary>
+        /// Pixels per unit in the y direction.
+        /// </summary>
+        PixelPerUnitY = 0x5112,
+
+        /// <summary>
+        /// The palette histogram.
+        /// </summary>
+        PaletteHistogram = 0x5113,
+
+        /// <summary>
+        /// Null-terminated character string that contains copyright information.
+        /// </summary>
+        Copyright = 0x8298,
+
+        /// <summary>
+        /// Exposure time, measured in seconds.
+        /// </summary>
+        ExifExposureTime = 0x829A,
+
+        /// <summary>
+        /// F number.
+        /// </summary>
+        ExifFNumber = 0x829D,
+
+        /// <summary>
+        /// Private tag used by GDI+. Not for public use. GDI+ uses this tag to locate Exif specific information.
+        /// </summary>
+        ExifIFD = 0x8769,
+
+        /// <summary>
+        /// ICC profile embedded in the image.
+        /// </summary>
+        ICCProfile = 0x8773,
+
+        /// <summary>
+        /// Class of the program used by the camera to set exposure when the picture is taken.
+        /// </summary>
+        ExifExposureProg = 0x8822,
+
+        /// <summary>
+        /// Null-terminated character string that specifies the spectral sensitivity of each channel of the camera used. The string is compatible with the standard developed by the ASTM Technical Committee.
+        /// </summary>
+        ExifSpectralSense = 0x8824,
+
+        /// <summary>
+        /// Offset to a block of GPS property items. Property items whose tags have the prefix Gps are stored in the GPS block. 
+        /// The GPS property items are defined in the EXIF specification. GDI+ uses this tag to locate GPS information, 
+        /// but GDI+ does not expose this tag for public use.
+        /// </summary>
+        GpsIFD = 0x8825,
+
+        /// <summary>
+        /// ISO speed and ISO latitude of the camera or input device as specified in ISO 12232.
+        /// </summary>
+        ExifISOSpeed = 0x8827,
+
+        /// <summary>
+        /// Optoelectronic conversion function (OECF) specified in ISO 14524. The OECF is the relationship between the camera optical input and the image values.
+        /// </summary>
+        ExifOECF = 0x8828,
+
+        /// <summary>
+        /// Version of the EXIF standard supported. Nonexistence of this field is taken to mean non-conformance to the 
+        /// standard. Conformance to the standard is indicated by recording 0210 as a 4-byte ASCII string. 
+        /// Because the type is <see cref="ExifPropertyTagType.Undefined"/>, there is no NULL terminator.
+        /// </summary>
+        ExifVer = 0x9000,
+
+        /// <summary>
+        /// Date and time when the original image data was generated. For a DSC, the date and time when the picture was taken. The format is YYYY:MM:DD HH:MM:SS with time shown in 24-hour format and the date and time separated by one blank character (0x2000). The character string length is 20 bytes including the NULL terminator. When the field is empty, it is treated as unknown.
+        /// </summary>
+        ExifDTOrig = 0x9003,
+
+        /// <summary>
+        /// Date and time when the image was stored as digital data. If, for example, an image 
+        /// was captured by DSC and at the same time the file was recorded, then DateTimeOriginal 
+        /// and DateTimeDigitized will have the same contents.
+        /// <para>
+        /// The format is YYYY:MM:DD HH:MM:SS with time shown in 24-hour format and the date and 
+        /// time separated by one blank character (0x2000). The character string length is 20 bytes 
+        /// including the NULL terminator. When the field is empty, it is treated as unknown.
+        /// </para>
+        /// </summary>
+        ExifDTDigitized = 0x9004,
 
         /// <summary>
         /// Information specific to compressed data. The channels of each component are 
@@ -136,36 +1011,26 @@ namespace ImageProcessor.Imaging.MetaData
         ExifCompConfig = 0x9101,
 
         /// <summary>
-        /// Date and time when the image was stored as digital data. If, for example, an image 
-        /// was captured by DSC and at the same time the file was recorded, then DateTimeOriginal 
-        /// and DateTimeDigitized will have the same contents.
-        /// <para>
-        /// The format is YYYY:MM:DD HH:MM:SS with time shown in 24-hour format and the date and 
-        /// time separated by one blank character (0x2000). The character string length is 20 bytes 
-        /// including the NULL terminator. When the field is empty, it is treated as unknown.
-        /// </para>
+        /// Information specific to compressed data. The compression mode used for a 
+        /// compressed image is indicated in unit BPP.
         /// </summary>
-        ExifDTDigitized = 0x9004,
+        ExifCompBPP = 0x9102,
 
         /// <summary>
-        /// Null-terminated character string that specifies a fraction of a second for the ExifDTDigitized tag.
+        /// Shutter speed. The unit is the Additive System of Photographic Exposure (APEX) value.
         /// </summary>
-        ExifDTDigSS = 0x9292,
+        ExifShutterSpeed = 0x9201,
 
         /// <summary>
-        /// Date and time when the original image data was generated. For a DSC, the date and time when the picture was taken. The format is YYYY:MM:DD HH:MM:SS with time shown in 24-hour format and the date and time separated by one blank character (0x2000). The character string length is 20 bytes including the NULL terminator. When the field is empty, it is treated as unknown.
+        /// Lens aperture. The unit is the APEX value.
         /// </summary>
-        ExifDTOrig = 0x9003,
+        ExifAperture = 0x9202,
 
         /// <summary>
-        /// Null-terminated character string that specifies a fraction of a second for the <see cref="ExifPropertyTag.ExifDTOrig"/> tag.
+        /// Brightness value. The unit is the APEX value. Ordinarily it is given 
+        /// in the range of -99.99 to 99.99.
         /// </summary>
-        ExifDTOrigSS = 0x9291,
-
-        /// <summary>
-        /// Null-terminated character string that specifies a fraction of a second for the <see cref="ExifPropertyTag.DateTime"/> tag.
-        /// </summary>
-        ExifDTSubsec = 0x9290,
+        ExifBrightness = 0x9203,
 
         /// <summary>
         /// Exposure bias. The unit is the APEX value. Ordinarily it is given in the range -99.99 to 99.99.
@@ -173,24 +1038,24 @@ namespace ImageProcessor.Imaging.MetaData
         ExifExposureBias = 0x9204,
 
         /// <summary>
-        /// Exposure index selected on the camera or input device at the time the image was captured.
+        /// Smallest F number of the lens. The unit is the APEX value. Ordinarily it is given in the range of 00.00 to 99.99, but it is not limited to this range.
         /// </summary>
-        ExifExposureIndex = 0xA215,
+        ExifMaxAperture = 0x9205,
 
         /// <summary>
-        /// Class of the program used by the camera to set exposure when the picture is taken.
+        /// Distance to the subject, measured in meters.
         /// </summary>
-        ExifExposureProg = 0x8822,
+        ExifSubjectDist = 0x9206,
 
         /// <summary>
-        /// Exposure time, measured in seconds.
+        /// Metering mode.
         /// </summary>
-        ExifExposureTime = 0x829A,
+        ExifMeteringMode = 0x9207,
 
         /// <summary>
-        /// The image source. If a DSC recorded the image, the value of this tag is 3.
+        /// Type of light source.
         /// </summary>
-        ExifFileSource = 0xA300,
+        ExifLightSource = 0x9208,
 
         /// <summary>
         /// Flash status. This tag is recorded when an image is taken using a strobe light (flash). Bit 0 indicates the flash firing status, and bits 1 and 2 indicate the flash return status.
@@ -198,36 +1063,36 @@ namespace ImageProcessor.Imaging.MetaData
         ExifFlash = 0x9209,
 
         /// <summary>
-        /// Strobe energy, in Beam Candle Power Seconds (BCPS), at the time the image was captured.
-        /// </summary>
-        ExifFlashEnergy = 0xA20B,
-
-        /// <summary>
-        /// F number.
-        /// </summary>
-        ExifFNumber = 0x829D,
-
-        /// <summary>
         /// Actual focal length, in millimeters, of the lens. Conversion is not made to the focal length of a 35 millimeter film camera.
         /// </summary>
         ExifFocalLength = 0x920A,
 
         /// <summary>
-        /// Unit of measure for <see cref="ExifPropertyTag.ExifFocalXRes"/> and <see cref="ExifPropertyTag.ExifFocalYRes"/>.
+        /// Note tag. A tag used by manufacturers of EXIF writers to record information. The contents are up to the manufacturer.
         /// </summary>
-        ExifFocalResUnit = 0xA210,
+        ExifMakerNote = 0x927C,
 
         /// <summary>
-        /// Number of pixels in the image width (x) direction per unit on the camera focal plane. The unit is specified 
-        /// in <see cref="ExifPropertyTag.ExifFocalResUnit"/>.
+        /// Comment tag. A tag used by EXIF users to write keywords or comments about the image besides those 
+        /// in <see cref="ExifPropertyTag.ImageDescription"/> and without the character-code limitations of 
+        /// the <see cref="ExifPropertyTag.ImageDescription"/> tag.
         /// </summary>
-        ExifFocalXRes = 0xA20E,
+        ExifUserComment = 0x9286,
 
         /// <summary>
-        /// Number of pixels in the image height (y) direction per unit on the camera focal plane. The unit is specified 
-        /// in <see cref="ExifPropertyTag.ExifFocalResUnit"/>.
+        /// Null-terminated character string that specifies a fraction of a second for the <see cref="ExifPropertyTag.DateTime"/> tag.
         /// </summary>
-        ExifFocalYRes = 0xA20F,
+        ExifDTSubsec = 0x9290,
+
+        /// <summary>
+        /// Null-terminated character string that specifies a fraction of a second for the <see cref="ExifPropertyTag.ExifDTOrig"/> tag.
+        /// </summary>
+        ExifDTOrigSS = 0x9291,
+
+        /// <summary>
+        /// Null-terminated character string that specifies a fraction of a second for the ExifDTDigitized tag.
+        /// </summary>
+        ExifDTDigSS = 0x9292,
 
         /// <summary>
         /// FlashPix format version supported by an FPXR file. If the FPXR function supports FlashPix format version 1.0, 
@@ -237,44 +1102,12 @@ namespace ImageProcessor.Imaging.MetaData
         ExifFPXVer = 0xA000,
 
         /// <summary>
-        /// Private tag used by GDI+. Not for public use. GDI+ uses this tag to locate Exif specific information.
+        /// Color space specifier. Normally sRGB (=1) is used to define the color space 
+        /// based on the PC monitor conditions and environment. If a color space other 
+        /// than sRGB is used, Uncalibrated (=0xFFFF) is set. Image data recorded as 
+        /// Uncalibrated can be treated as sRGB when it is converted to FlashPix.
         /// </summary>
-        ExifIFD = 0x8769,
-
-        /// <summary>
-        /// Offset to a block of property items that contain interoperability information.
-        /// </summary>
-        ExifInterop = 0xA005,
-
-        /// <summary>
-        /// ISO speed and ISO latitude of the camera or input device as specified in ISO 12232.
-        /// </summary>
-        ExifISOSpeed = 0x8827,
-
-        /// <summary>
-        /// Type of light source.
-        /// </summary>
-        ExifLightSource = 0x9208,
-
-        /// <summary>
-        /// Note tag. A tag used by manufacturers of EXIF writers to record information. The contents are up to the manufacturer.
-        /// </summary>
-        ExifMakerNote = 0x927C,
-
-        /// <summary>
-        /// Smallest F number of the lens. The unit is the APEX value. Ordinarily it is given in the range of 00.00 to 99.99, but it is not limited to this range.
-        /// </summary>
-        ExifMaxAperture = 0x9205,
-
-        /// <summary>
-        /// Metering mode.
-        /// </summary>
-        ExifMeteringMode = 0x9207,
-
-        /// <summary>
-        /// Optoelectronic conversion function (OECF) specified in ISO 14524. The OECF is the relationship between the camera optical input and the image values.
-        /// </summary>
-        ExifOECF = 0x8828,
+        ExifColorSpace = 0xA001,
 
         /// <summary>
         /// Information specific to compressed data. When a compressed file is recorded, the valid width of the meaningful image must be recorded in this tag, whether or not there is padding data or a restart marker. This tag should not exist in an uncompressed file.
@@ -292,19 +1125,14 @@ namespace ImageProcessor.Imaging.MetaData
         ExifRelatedWav = 0xA004,
 
         /// <summary>
-        /// The type of scene. If a DSC recorded the image, the value of this tag must be set to 1, indicating that the image was directly photographed.
+        /// Offset to a block of property items that contain interoperability information.
         /// </summary>
-        ExifSceneType = 0xA301,
+        ExifInterop = 0xA005,
 
         /// <summary>
-        /// Image sensor type on the camera or input device.
+        /// Strobe energy, in Beam Candle Power Seconds (BCPS), at the time the image was captured.
         /// </summary>
-        ExifSensingMethod = 0xA217,
-
-        /// <summary>
-        /// Shutter speed. The unit is the Additive System of Photographic Exposure (APEX) value.
-        /// </summary>
-        ExifShutterSpeed = 0x9201,
+        ExifFlashEnergy = 0xA20B,
 
         /// <summary>
         /// Camera or input device spatial frequency table and SFR values in the image width, image height, and diagonal direction, as specified in ISO 12233.
@@ -312,14 +1140,21 @@ namespace ImageProcessor.Imaging.MetaData
         ExifSpatialFR = 0xA20C,
 
         /// <summary>
-        /// Null-terminated character string that specifies the spectral sensitivity of each channel of the camera used. The string is compatible with the standard developed by the ASTM Technical Committee.
+        /// Number of pixels in the image width (x) direction per unit on the camera focal plane. The unit is specified 
+        /// in <see cref="ExifPropertyTag.ExifFocalResUnit"/>.
         /// </summary>
-        ExifSpectralSense = 0x8824,
+        ExifFocalXRes = 0xA20E,
 
         /// <summary>
-        /// Distance to the subject, measured in meters.
+        /// Number of pixels in the image height (y) direction per unit on the camera focal plane. The unit is specified 
+        /// in <see cref="ExifPropertyTag.ExifFocalResUnit"/>.
         /// </summary>
-        ExifSubjectDist = 0x9206,
+        ExifFocalYRes = 0xA20F,
+
+        /// <summary>
+        /// Unit of measure for <see cref="ExifPropertyTag.ExifFocalXRes"/> and <see cref="ExifPropertyTag.ExifFocalYRes"/>.
+        /// </summary>
+        ExifFocalResUnit = 0xA210,
 
         /// <summary>
         /// Location of the main subject in the scene. The value of this tag represents the pixel at the center 
@@ -329,864 +1164,29 @@ namespace ImageProcessor.Imaging.MetaData
         ExifSubjectLoc = 0xA214,
 
         /// <summary>
-        /// Comment tag. A tag used by EXIF users to write keywords or comments about the image besides those 
-        /// in <see cref="ExifPropertyTag.ImageDescription"/> and without the character-code limitations of 
-        /// the <see cref="ExifPropertyTag.ImageDescription"/> tag.
+        /// Exposure index selected on the camera or input device at the time the image was captured.
         /// </summary>
-        ExifUserComment = 0x9286,
+        ExifExposureIndex = 0xA215,
 
         /// <summary>
-        /// Version of the EXIF standard supported. Nonexistence of this field is taken to mean non-conformance to the 
-        /// standard. Conformance to the standard is indicated by recording 0210 as a 4-byte ASCII string. 
-        /// Because the type is <see cref="ExifPropertyTagType.Undefined"/>, there is no NULL terminator.
+        /// Image sensor type on the camera or input device.
         /// </summary>
-        ExifVer = 0x9000,
+        ExifSensingMethod = 0xA217,
 
         /// <summary>
-        /// Number of extra color components. For example, one extra component might hold an alpha value.
+        /// The image source. If a DSC recorded the image, the value of this tag is 3.
         /// </summary>
-        ExtraSamples = 0x0152,
+        ExifFileSource = 0xA300,
 
         /// <summary>
-        /// Logical order of bits in a byte.
+        /// The type of scene. If a DSC recorded the image, the value of this tag must be set to 1, indicating that the image was directly photographed.
         /// </summary>
-        FillOrder = 0x010A,
+        ExifSceneType = 0xA301,
 
         /// <summary>
-        /// Time delay, in hundredths of a second, between two frames in an animated GIF image.
+        /// The color filter array (CFA) geometric pattern of the image sensor when a one-chip color 
+        /// area sensor is used. It does not apply to all sensing methods.
         /// </summary>
-        FrameDelay = 0x5100,
-
-        /// <summary>
-        /// For each string of contiguous unused bytes, the number of bytes in that string.
-        /// </summary>
-        FreeByteCounts = 0x0121,
-
-        /// <summary>
-        /// For each string of contiguous unused bytes, the byte offset of that string.
-        /// </summary>
-        FreeOffset = 0x0120,
-
-        /// <summary>
-        /// Gamma value attached to the image. The gamma value is stored as a rational number (pair of long) with a numerator of 100000. For example, a gamma value of 2.2 is stored as the pair (100000, 45455).
-        /// </summary>
-        Gamma = 0x0301,
-
-        /// <summary>
-        /// Color palette for an indexed bitmap in a GIF image.
-        /// </summary>
-        GlobalPalette = 0x5102,
-
-        /// <summary>
-        /// Altitude, in meters, based on the reference altitude specified by <see cref="ExifPropertyTag.GpsAltitudeRef"/>.
-        /// </summary>
-        GpsAltitude = 0x0006,
-
-        /// <summary>
-        /// Reference altitude, in meters.
-        /// </summary>
-        GpsAltitudeRef = 0x0005,
-
-        /// <summary>
-        /// Bearing to the destination point. The range of values is from 0.00 to 359.99.
-        /// </summary>
-        GpsDestBear = 0x0018,
-
-        /// <summary>
-        /// Null-terminated character string that specifies the reference used for giving the bearing to the destination point. T specifies true direction, and M specifies magnetic direction.
-        /// </summary>
-        GpsDestBearRef = 0x0017,
-
-        /// <summary>
-        /// Distance to the destination point.
-        /// </summary>
-        GpsDestDist = 0x001A,
-
-        /// <summary>
-        /// Null-terminated character string that specifies the unit used to express the distance to the destination point. 
-        /// K, M, and N represent kilometers, miles, and knots respectively.
-        /// </summary>
-        GpsDestDistRef = 0x0019,
-
-        /// <summary>
-        /// Latitude of the destination point. The latitude is expressed as three rational values giving the degrees, 
-        /// minutes, and seconds respectively. When degrees, minutes, and seconds are expressed, the format is 
-        /// dd/1, mm/1, ss/1. When degrees and minutes are used and, for example, fractions of minutes are given up to 
-        /// two decimal places, the format is dd/1, mmmm/100, 0/1.
-        /// </summary>
-        GpsDestLat = 0x0014,
-
-        /// <summary>
-        /// Null-terminated character string that specifies whether the latitude of the destination point is north or south 
-        /// latitude. N specifies north latitude, and S specifies south latitude.
-        /// </summary>
-        GpsDestLatRef = 0x0013,
-
-        /// <summary>
-        /// Longitude of the destination point. The longitude is expressed as three rational values giving the degrees, minutes, and seconds respectively. When degrees, minutes, and seconds are expressed, the format is ddd/1, mm/1, ss/1. When degrees and minutes are used and, for example, fractions of minutes are given up to two decimal places, the format is ddd/1, mmmm/100, 0/1.
-        /// </summary>
-        GpsDestLong = 0x0016,
-
-        /// <summary>
-        /// Null-terminated character string that specifies whether the longitude of the destination point is east or west longitude. E specifies east longitude, and W specifies west longitude.
-        /// </summary>
-        GpsDestLongRef = 0x0015,
-
-        /// <summary>
-        /// GPS DOP (data degree of precision). An HDOP value is written during 2-D measurement, and a PDOP value is written during 3-D measurement.
-        /// </summary>
-        GpsGpsDop = 0x000B,
-
-        /// <summary>
-        /// Null-terminated character string that specifies the GPS measurement mode. 2 specifies 2-D measurement, and 3 specifies 3-D measurement.
-        /// </summary>
-        GpsGpsMeasureMode = 0x000A,
-
-        /// <summary>
-        /// Null-terminated character string that specifies the GPS satellites used for measurements. This tag can be used to specify the ID number, angle of elevation, azimuth, SNR, and other information about each satellite. The format is not specified. If the GPS receiver is incapable of taking measurements, the value of the tag must be set to NULL.
-        /// </summary>
-        GpsGpsSatellites = 0x0008,
-
-        /// <summary>
-        /// Null-terminated character string that specifies the status of the GPS receiver when the image is recorded. A means measurement is in progress, and V means the measurement is Interoperability.
-        /// </summary>
-        GpsGpsStatus = 0x0009,
-
-        /// <summary>
-        /// Time as coordinated universal time (UTC). The value is expressed as three rational numbers that give the hour, minute, and second.
-        /// </summary>
-        GpsGpsTime = 0x0007,
-
-        /// <summary>
-        /// Offset to a block of GPS property items. Property items whose tags have the prefix Gps are stored in the GPS block. 
-        /// The GPS property items are defined in the EXIF specification. GDI+ uses this tag to locate GPS information, 
-        /// but GDI+ does not expose this tag for public use.
-        /// </summary>
-        GpsIFD = 0x8825,
-
-        /// <summary>
-        /// Direction of the image when it was captured. The range of values is from 0.00 to 359.99.
-        /// </summary>
-        GpsImgDir = 0x0011,
-
-        /// <summary>
-        /// Null-terminated character string that specifies the reference for the direction of the image when it is captured. T specifies true direction, and M specifies magnetic direction.
-        /// </summary>
-        GpsImgDirRef = 0x0010,
-
-        /// <summary>
-        /// Latitude. Latitude is expressed as three rational values giving the degrees, minutes, and seconds respectively. When degrees, minutes, and seconds are expressed, the format is dd/1, mm/1, ss/1. When degrees and minutes are used and, for example, fractions of minutes are given up to two decimal places, the format is dd/1, mmmm/100, 0/1.
-        /// </summary>
-        GpsLatitude = 0x0002,
-
-        /// <summary>
-        /// Null-terminated character string that specifies whether the longitude is east or west longitude. 
-        /// E specifies east longitude, and W specifies west longitude.
-        /// </summary>
-        GpsLatitudeRef = 0x0001,
-
-        /// <summary>
-        /// Longitude. Longitude is expressed as three rational values giving the degrees, minutes, and seconds 
-        /// respectively. When degrees, minutes and seconds are expressed, the format is ddd/1, mm/1, ss/1. 
-        /// When degrees and minutes are used and, for example, fractions of minutes are given up to two 
-        /// decimal places, the format is ddd/1, mmmm/100, 0/1.
-        /// </summary>
-        GpsLongitude = 0x0004,
-
-        /// <summary>
-        /// Null-terminated character string that specifies whether the longitude is east or west longitude. 
-        /// E specifies east longitude, and W specifies west longitude.
-        /// </summary>
-        GpsLongitudeRef = 0x0003,
-
-        /// <summary>
-        /// Null-terminated character string that specifies geodetic survey data used by the GPS receiver. 
-        /// If the survey data is restricted to Japan, the value of this tag is TOKYO or WGS-84.
-        /// </summary>
-        GpsMapDatum = 0x0012,
-
-        /// <summary>
-        /// Speed of the GPS receiver movement.
-        /// </summary>
-        GpsSpeed = 0x000D,
-
-        /// <summary>
-        /// Null-terminated character string that specifies the unit used to express the GPS receiver speed of movement. 
-        /// K, M, and N represent kilometers per hour, miles per hour, and knots respectively.
-        /// </summary>
-        GpsSpeedRef = 0x000C,
-
-        /// <summary>
-        /// Direction of GPS receiver movement. The range of values is from 0.00 to 359.99.
-        /// </summary>
-        GpsTrack = 0x000F,
-
-        /// <summary>
-        /// Null-terminated character string that specifies the reference for giving the direction of 
-        /// GPS receiver movement. T specifies true direction, and M specifies magnetic direction.
-        /// </summary>
-        GpsTrackRef = 0x000E,
-
-        /// <summary>
-        /// Version of the Global Positioning Systems (GPS) IFD, given as 2.0.0.0. This tag is mandatory when 
-        /// the <see cref="ExifPropertyTag.GpsIFD"/> tag is present. When the version is 2.0.0.0, the tag value is 0x02000000.
-        /// </summary>
-        GpsVer = 0x0000,
-
-        /// <summary>
-        /// For each possible pixel value in a grayscale image, the optical density of that pixel value.
-        /// </summary>
-        GrayResponseCurve = 0x0123,
-
-        /// <summary>
-        /// Precision of the number specified by <see cref="ExifPropertyTag.GrayResponseCurve"/>. 1 specifies tenths, 
-        /// 2 specifies hundredths, 3 specifies thousandths, and so on.
-        /// </summary>
-        GrayResponseUnit = 0x0122,
-
-        /// <summary>
-        /// Block of information about grids and guides.
-        /// </summary>
-        GridSize = 0x5011,
-
-        /// <summary>
-        /// Angle for screen.
-        /// </summary>
-        HalftoneDegree = 0x500C,
-
-        /// <summary>
-        /// Information used by the halftone function.
-        /// </summary>
-        HalftoneHints = 0x0141,
-
-        /// <summary>
-        /// Ink's screen frequency, in lines per inch.
-        /// </summary>
-        HalftoneLPI = 0x500A,
-
-        /// <summary>
-        /// Units for the screen frequency.
-        /// </summary>
-        HalftoneLPIUnit = 0x500B,
-
-        /// <summary>
-        /// Miscellaneous halftone information.
-        /// </summary>
-        HalftoneMisc = 0x500E,
-
-        /// <summary>
-        /// Boolean value that specifies whether to use the printer's default screens.
-        /// </summary>
-        HalftoneScreen = 0x500F,
-
-        /// <summary>
-        /// Shape of the halftone dots.
-        /// </summary>
-        HalftoneShape = 0x500D,
-
-        /// <summary>
-        /// Null-terminated character string that specifies the computer and/or operating system used to create the image.
-        /// </summary>
-        HostComputer = 0x013C,
-
-        /// <summary>
-        /// ICC profile embedded in the image.
-        /// </summary>
-        ICCProfile = 0x8773,
-
-        /// <summary>
-        /// Null-terminated character string that identifies an ICC profile.
-        /// </summary>
-        ICCProfileDescriptor = 0x0302,
-
-        /// <summary>
-        /// Null-terminated character string that specifies the title of the image.
-        /// </summary>
-        ImageDescription = 0x010E,
-
-        /// <summary>
-        /// Number of pixel rows.
-        /// </summary>
-        ImageHeight = 0x0101,
-
-        /// <summary>
-        /// Null-terminated character string that specifies the title of the image.
-        /// </summary>
-        ImageTitle = 0x0320,
-
-        /// <summary>
-        /// Number of pixels per row.
-        /// </summary>
-        ImageWidth = 0x0100,
-
-        /// <summary>
-        /// Index of the background color in the palette of a GIF image.
-        /// </summary>
-        IndexBackground = 0x5103,
-
-        /// <summary>
-        /// Index of the transparent color in the palette of a GIF image.
-        /// </summary>
-        IndexTransparent = 0x5104,
-
-        /// <summary>
-        /// Sequence of concatenated, null-terminated, character strings that specify the names of the 
-        /// inks used in a separated image.
-        /// </summary>
-        InkNames = 0x014D,
-
-        /// <summary>
-        /// Set of inks used in a separated image.
-        /// </summary>
-        InkSet = 0x014C,
-
-        /// <summary>
-        /// For each color component, the offset to the AC Huffman table for that component. 
-        /// See also <see cref="ExifPropertyTag.SamplesPerPixel"/>.
-        /// </summary>
-        JPEGACTables = 0x0209,
-
-        /// <summary>
-        /// For each color component, the offset to the DC Huffman table (or lossless Huffman table) for that 
-        /// component. See also <see cref="ExifPropertyTag.SamplesPerPixel"/>.
-        /// </summary>
-        JPEGDCTables = 0x0208,
-
-        /// <summary>
-        /// Offset to the start of a JPEG bitstream.
-        /// </summary>
-        JPEGInterFormat = 0x0201,
-
-        /// <summary>
-        /// Length, in bytes, of the JPEG bitstream.
-        /// </summary>
-        JPEGInterLength = 0x0202,
-
-        /// <summary>
-        /// For each color component, a lossless predictor-selection value for that component. 
-        /// See also <see cref="ExifPropertyTag.SamplesPerPixel"/>.
-        /// </summary>
-        JPEGLosslessPredictors = 0x0205,
-
-        /// <summary>
-        /// For each color component, a point transformation value for that component. 
-        /// See also <see cref="ExifPropertyTag.SamplesPerPixel"/>.
-        /// </summary>
-        JPEGPointTransforms = 0x0206,
-
-        /// <summary>
-        /// JPEG compression process.
-        /// </summary>
-        JPEGProc = 0x0200,
-
-        /// <summary>
-        /// For each color component, the offset to the quantization table for that 
-        /// component. See also <see cref="ExifPropertyTag.SamplesPerPixel"/>.
-        /// </summary>
-        JPEGQTables = 0x0207,
-
-        /// <summary>
-        /// Private tag used by the Adobe Photoshop format. Not for public use.
-        /// </summary>
-        JPEGQuality = 0x5010,
-
-        /// <summary>
-        /// Length of the restart interval.
-        /// </summary>
-        JPEGRestartInterval = 0x0203,
-
-        /// <summary>
-        /// For an animated GIF image, the number of times to display the animation. 
-        /// A value of 0 specifies that the animation should be displayed infinitely.
-        /// </summary>
-        LoopCount = 0x5101,
-
-        /// <summary>
-        /// Luminance table. The luminance table and the chrominance table are used to control JPEG quality. 
-        /// A valid luminance or chrominance table has 64 entries of type <see cref="ExifPropertyTagType.UShort"/>. 
-        /// If an image has either a luminance table or a chrominance table, then it must have both tables.
-        /// </summary>
-        LuminanceTable = 0x5090,
-
-        /// <summary>
-        /// For each color component, the maximum value assigned to that component. 
-        /// See also <see cref="ExifPropertyTag.SamplesPerPixel"/>.
-        /// </summary>
-        MaxSampleValue = 0x0119,
-
-        /// <summary>
-        /// For each color component, the minimum value assigned to that component. 
-        /// See also <see cref="ExifPropertyTag.SamplesPerPixel"/>.
-        /// </summary>
-        MinSampleValue = 0x0118,
-
-        /// <summary>
-        /// Type of data in a subfile.
-        /// </summary>
-        NewSubfileType = 0x00FE,
-
-        /// <summary>
-        /// The number of inks.
-        /// </summary>
-        NumberOfInks = 0x014E,
-
-        /// <summary>
-        /// Image orientation viewed in terms of rows and columns.
-        /// </summary>
-        Orientation = 0x0112,
-
-        /// <summary>
-        /// Null-terminated character string that specifies the name of the page from which the image was scanned.
-        /// </summary>
-        PageName = 0x011D,
-
-        /// <summary>
-        /// Page number of the page from which the image was scanned.
-        /// </summary>
-        PageNumber = 0x0129,
-
-        /// <summary>
-        /// The palette histogram.
-        /// </summary>
-        PaletteHistogram = 0x5113,
-
-        /// <summary>
-        /// How pixel data will be interpreted.
-        /// </summary>
-        PhotometricInterp = 0x0106,
-
-        /// <summary>
-        /// Pixels per unit in the x direction.
-        /// </summary>
-        PixelPerUnitX = 0x5111,
-
-        /// <summary>
-        /// Pixels per unit in the y direction.
-        /// </summary>
-        PixelPerUnitY = 0x5112,
-
-        /// <summary>
-        /// Unit for <see cref="ExifPropertyTag.PixelPerUnitX"/> and <see cref="ExifPropertyTag.PixelPerUnitY"/>.
-        /// </summary>
-        PixelUnit = 0x5110,
-
-        /// <summary>
-        /// Whether pixel components are recorded in chunky or planar format.
-        /// </summary>
-        PlanarConfig = 0x011C,
-
-        /// <summary>
-        /// TType of prediction scheme that was applied to the image data before the encoding scheme was applied.
-        /// </summary>
-        Predictor = 0x013D,
-
-        /// <summary>
-        /// For each of the three primary colors in the image, the chromaticity of that color.
-        /// </summary>
-        PrimaryChromaticities = 0x013F,
-
-        /// <summary>
-        /// Sequence of one-byte Boolean values that specify printing options.
-        /// </summary>
-        PrintFlags = 0x5005,
-
-        /// <summary>
-        /// The print flags bleed width.
-        /// </summary>
-        PrintFlagsBleedWidth = 0x5008,
-
-        /// <summary>
-        /// The print flags bleed width scale.
-        /// </summary>
-        PrintFlagsBleedWidthScale = 0x5009,
-
-        /// <summary>
-        /// The print flags crop marks.
-        /// </summary>
-        PrintFlagsCrop = 0x5007,
-
-        /// <summary>
-        /// The print flags version.
-        /// </summary>
-        PrintFlagsVersion = 0x5006,
-
-        /// <summary>
-        /// Reference black point value and reference white point value.
-        /// </summary>
-        REFBlackWhite = 0x0214,
-
-        /// <summary>
-        /// Unit of measure for the horizontal resolution and the vertical resolution.
-        /// </summary>
-        ResolutionUnit = 0x0128,
-
-        /// <summary>
-        /// Units in which to display the image width.
-        /// </summary>
-        ResolutionXLengthUnit = 0x5003,
-
-        /// <summary>
-        /// Units in which to display horizontal resolution.
-        /// </summary>
-        ResolutionXUnit = 0x5001,
-
-        /// <summary>
-        /// Units in which to display the image height.
-        /// </summary>
-        ResolutionYLengthUnit = 0x5004,
-
-        /// <summary>
-        /// Units in which to display vertical resolution.
-        /// </summary>
-        ResolutionYUnit = 0x5002,
-
-        /// <summary>
-        /// Number of rows per strip. See also <see cref="ExifPropertyTag.StripBytesCount"/> and <see cref="ExifPropertyTag.StripOffsets"/>.
-        /// </summary>
-        RowsPerStrip = 0x0116,
-
-        /// <summary>
-        /// For each color component, the numerical format (unsigned, signed, floating point) of that component. 
-        /// See also <see cref="ExifPropertyTag.SamplesPerPixel"/>.
-        /// </summary>
-        SampleFormat = 0x0153,
-
-        /// <summary>
-        /// Number of color components per pixel.
-        /// </summary>
-        SamplesPerPixel = 0x0115,
-
-        /// <summary>
-        /// For each color component, the maximum value of that component. See also <see cref="ExifPropertyTag.SamplesPerPixel"/>.
-        /// </summary>
-        SMaxSampleValue = 0x0155,
-
-        /// <summary>
-        /// For each color component, the minimum value of that component. See also <see cref="ExifPropertyTag.SamplesPerPixel"/>.
-        /// </summary>
-        SMinSampleValue = 0x0154,
-
-        /// <summary>
-        /// Null-terminated character string that specifies the name and version of the software or 
-        /// firmware of the device used to generate the image.
-        /// </summary>
-        SoftwareUsed = 0x0131,
-
-        /// <summary>
-        /// How the image should be displayed as defined by the International Color Consortium (ICC). If a GDI+ Image object
-        /// is constructed with the useEmbeddedColorManagement parameter set to TRUE, then GDI+ renders the image 
-        /// according to the specified rendering intent. The intent can be set to perceptual, relative colorimetric, 
-        /// saturation, or absolute colorimetric.
-        /// </summary>
-        SRGBRenderingIntent = 0x0303,
-
-        /// <summary>
-        /// For each strip, the total number of bytes in that strip.
-        /// </summary>
-        StripBytesCount = 0x0117,
-
-        /// <summary>
-        /// For each strip, the byte offset of that strip. See also <see cref="ExifPropertyTag.RowsPerStrip"/> 
-        /// and <see cref="ExifPropertyTag.StripBytesCount"/>.
-        /// </summary>
-        StripOffsets = 0x0111,
-
-        /// <summary>
-        /// The type of data in a subfile.
-        /// </summary>
-        SubfileType = 0x00FF,
-
-        /// <summary>
-        /// Set of flags that relate to T4 encoding.
-        /// </summary>
-        T4Option = 0x0124,
-
-        /// <summary>
-        /// Set of flags that relate to T6 encoding.
-        /// </summary>
-        T6Option = 0x0125,
-
-        /// <summary>
-        /// Null-terminated character string that describes the intended printing environment.
-        /// </summary>
-        TargetPrinter = 0x0151,
-
-        /// <summary>
-        /// Technique used to convert from gray pixels to black and white pixels.
-        /// </summary>
-        ThreshHolding = 0x0107,
-
-        /// <summary>
-        /// Null-terminated character string that specifies the name of the person who created the thumbnail image.
-        /// </summary>
-        ThumbnailArtist = 0x5034,
-
-        /// <summary>
-        /// Number of bits per color component in the thumbnail image. See also <see cref="ExifPropertyTag.ThumbnailSamplesPerPixel"/>.
-        /// </summary>
-        ThumbnailBitsPerSample = 0x5022,
-
-        /// <summary>
-        /// Bits per pixel (BPP) for the thumbnail image.
-        /// </summary>
-        ThumbnailColorDepth = 0x5015,
-
-        /// <summary>
-        /// Compressed size, in bytes, of the thumbnail image.
-        /// </summary>
-        ThumbnailCompressedSize = 0x5019,
-
-        /// <summary>
-        /// Compression scheme used for thumbnail image data.
-        /// </summary>
-        ThumbnailCompression = 0x5023,
-
-        /// <summary>
-        /// Null-terminated character string that contains copyright information for the thumbnail image.
-        /// </summary>
-        ThumbnailCopyRight = 0x503B,
-
-        /// <summary>
-        /// Raw thumbnail bits in JPEG or RGB format. Depends on <see cref="ExifPropertyTag.ThumbnailFormat"/>.
-        /// </summary>
-        ThumbnailData = 0x501B,
-
-        /// <summary>
-        /// Date and time the thumbnail image was created. See also <see cref="ExifPropertyTag.DateTime"/>.
-        /// </summary>
-        ThumbnailDateTime = 0x5033,
-
-        /// <summary>
-        /// Null-terminated character string that specifies the manufacturer of the equipment used to 
-        /// record the thumbnail image.
-        /// </summary>
-        ThumbnailEquipMake = 0x5026,
-
-        /// <summary>
-        /// Null-terminated character string that specifies the model name or model number of the 
-        /// equipment used to record the thumbnail image.
-        /// </summary>
-        ThumbnailEquipModel = 0x5027,
-
-        /// <summary>
-        /// Format of the thumbnail image.
-        /// </summary>
-        ThumbnailFormat = 0x5012,
-
-        /// <summary>
-        /// Height, in pixels, of the thumbnail image.
-        /// </summary>
-        ThumbnailHeight = 0x5014,
-
-        /// <summary>
-        /// Null-terminated character string that specifies the title of the image.
-        /// </summary>
-        ThumbnailImageDescription = 0x5025,
-
-        /// <summary>
-        /// Number of pixel rows in the thumbnail image.
-        /// </summary>
-        ThumbnailImageHeight = 0x5021,
-
-        /// <summary>
-        /// Number of pixels per row in the thumbnail image.
-        /// </summary>
-        ThumbnailImageWidth = 0x5020,
-
-        /// <summary>
-        /// Thumbnail image orientation in terms of rows and columns. See also <see cref="ExifPropertyTag.Orientation"/>.
-        /// </summary>
-        ThumbnailOrientation = 0x5029,
-
-        /// <summary>
-        /// How thumbnail pixel data will be interpreted.
-        /// </summary>
-        ThumbnailPhotometricInterp = 0x5024,
-
-        /// <summary>
-        /// Whether pixel components in the thumbnail image are recorded in chunky or planar format. 
-        /// See also <see cref="ExifPropertyTag.PlanarConfig"/>.
-        /// </summary>
-        ThumbnailPlanarConfig = 0x502F,
-
-        /// <summary>
-        /// Number of color planes for the thumbnail image.
-        /// </summary>
-        ThumbnailPlanes = 0x5016,
-
-        /// <summary>
-        /// For each of the three primary colors in the thumbnail image, the chromaticity 
-        /// of that color. See also <see cref="ExifPropertyTag.PrimaryChromaticities"/>.
-        /// </summary>
-        ThumbnailPrimaryChromaticities = 0x5036,
-
-        /// <summary>
-        /// Byte offset between rows of pixel data.
-        /// </summary>
-        ThumbnailRawBytes = 0x5017,
-
-        /// <summary>
-        /// Reference black point value and reference white point value 
-        /// for the thumbnail image. See also <see cref="ExifPropertyTag.REFBlackWhite"/>.
-        /// </summary>
-        ThumbnailRefBlackWhite = 0x503A,
-
-        /// <summary>
-        /// Unit of measure for the horizontal resolution and the vertical resolution of 
-        /// the thumbnail image. See also <see cref="ExifPropertyTag.ResolutionUnit"/>.
-        /// </summary>
-        ThumbnailResolutionUnit = 0x5030,
-
-        /// <summary>
-        /// Thumbnail resolution in the width direction. 
-        /// The resolution unit is given in <see cref="ExifPropertyTag.ThumbnailResolutionUnit"/>.
-        /// </summary>
-        ThumbnailResolutionX = 0x502D,
-
-        /// <summary>
-        /// Thumbnail resolution in the height direction. The resolution unit is given 
-        /// in <see cref="ExifPropertyTag.ThumbnailResolutionUnit"/>.
-        /// </summary>
-        ThumbnailResolutionY = 0x502E,
-
-        /// <summary>
-        /// Number of rows per strip in the thumbnail image. See also <see cref="ExifPropertyTag.ThumbnailStripBytesCount"/> 
-        /// and <see cref="ExifPropertyTag.ThumbnailStripOffsets"/>.
-        /// </summary>
-        ThumbnailRowsPerStrip = 0x502B,
-
-        /// <summary>
-        /// Number of color components per pixel in the thumbnail image.
-        /// </summary>
-        ThumbnailSamplesPerPixel = 0x502A,
-
-        /// <summary>
-        /// Total size, in bytes, of the thumbnail image.
-        /// </summary>
-        ThumbnailSize = 0x5018,
-
-        /// <summary>
-        /// Null-terminated character string that specifies the name and version of the software 
-        /// or firmware of the device used to generate the thumbnail image.
-        /// </summary>
-        ThumbnailSoftwareUsed = 0x5032,
-
-        /// <summary>
-        /// For each thumbnail image strip, the total number of bytes in that strip.
-        /// </summary>
-        ThumbnailStripBytesCount = 0x502C,
-
-        /// <summary>
-        /// For each strip in the thumbnail image, the byte offset of that strip. See also <see cref="ExifPropertyTag.ThumbnailRowsPerStrip"/> 
-        /// and <see cref="ExifPropertyTag.ThumbnailStripBytesCount"/>.
-        /// </summary>
-        ThumbnailStripOffsets = 0x5028,
-
-        /// <summary>
-        /// Tables that specify transfer functions for the thumbnail image. See also <see cref="ExifPropertyTag.TransferFunction"/>.
-        /// </summary>
-        ThumbnailTransferFunction = 0x5031,
-
-        /// <summary>
-        /// Chromaticity of the white point of the thumbnail image. See also <see cref="ExifPropertyTag.WhitePoint"/>.
-        /// </summary>
-        ThumbnailWhitePoint = 0x5035,
-
-        /// <summary>
-        /// Width, in pixels, of the thumbnail image.
-        /// </summary>
-        ThumbnailWidth = 0x5013,
-
-        /// <summary>
-        /// Coefficients for transformation from RGB to YCbCr data for the thumbnail image. 
-        /// See also <see cref="ExifPropertyTag.YCbCrCoefficients"/>.
-        /// </summary>
-        ThumbnailYCbCrCoefficients = 0x5037,
-
-        /// <summary>
-        /// Position of chrominance components in relation to the luminance component for 
-        /// the thumbnail image. See also <see cref="ExifPropertyTag.YCbCrPositioning"/>.
-        /// </summary>
-        ThumbnailYCbCrPositioning = 0x5039,
-
-        /// <summary>
-        /// Sampling ratio of chrominance components in relation to the luminance component for 
-        /// the thumbnail image. See also <see cref="ExifPropertyTag.YCbCrSubsampling"/>.
-        /// </summary>
-        ThumbnailYCbCrSubsampling = 0x5038,
-
-        /// <summary>
-        /// For each tile, the number of bytes in that tile.
-        /// </summary>
-        TileByteCounts = 0x0145,
-
-        /// <summary>
-        /// Number of pixel rows in each tile.
-        /// </summary>
-        TileLength = 0x0143,
-
-        /// <summary>
-        /// For each tile, the byte offset of that tile.
-        /// </summary>
-        TileOffset = 0x0144,
-
-        /// <summary>
-        /// Number of pixel columns in each tile.
-        /// </summary>
-        TileWidth = 0x0142,
-
-        /// <summary>
-        /// Tables that specify transfer functions for the image.
-        /// </summary>
-        TransferFunction = 0x012D,
-
-        /// <summary>
-        /// Table of values that extends the range of the transfer function.
-        /// </summary>
-        TransferRange = 0x0156,
-
-        /// <summary>
-        /// Chromaticity of the white point of the image.
-        /// </summary>
-        WhitePoint = 0x013E,
-
-        /// <summary>
-        /// Offset from the left side of the page to the left side of the image. 
-        /// The unit of measure is specified by <see cref="ExifPropertyTag.ResolutionUnit"/>.
-        /// </summary>
-        XPosition = 0x011E,
-
-        /// <summary>
-        /// Number of pixels per unit in the image width (x) direction. 
-        /// The unit is specified by <see cref="ExifPropertyTag.ResolutionUnit"/>.
-        /// </summary>
-        XResolution = 0x011A,
-
-        /// <summary>
-        /// Coefficients for transformation from RGB to YCbCr image data.
-        /// </summary>
-        YCbCrCoefficients = 0x0211,
-
-        /// <summary>
-        /// Position of chrominance components in relation to the luminance component.
-        /// </summary>
-        YCbCrPositioning = 0x0213,
-
-        /// <summary>
-        /// Sampling ratio of chrominance components in relation to the luminance component.
-        /// </summary>
-        YCbCrSubsampling = 0x0212,
-
-        /// <summary>
-        /// Offset from the top of the page to the top of the image. The unit of measure 
-        /// is specified by <see cref="ExifPropertyTag.ResolutionUnit"/>.
-        /// </summary>
-        YPosition = 0x011F,
-
-        /// <summary>
-        /// Number of pixels per unit in the image height (y) direction. The unit is specified 
-        /// by <see cref="ExifPropertyTag.ResolutionUnit"/>.
-        /// </summary>
-        YResolution = 0x011B
+        ExifCfaPattern = 0xA302
     }
 }

--- a/src/ImageProcessor/Imaging/MetaData/ExifPropertyTagConstants.cs
+++ b/src/ImageProcessor/Imaging/MetaData/ExifPropertyTagConstants.cs
@@ -13,7 +13,7 @@ namespace ImageProcessor.Imaging.MetaData
     /// <summary>
     /// Contains constants grouping together common property items.
     /// </summary>
-    public class ExifPropertyTagConstants
+    public static class ExifPropertyTagConstants
     {
         /// <summary>
         /// Gets all required property items. The Gif format specifically requires these properties.

--- a/src/ImageProcessor/Imaging/MetaData/ImageFactoryMetaExtensions.cs
+++ b/src/ImageProcessor/Imaging/MetaData/ImageFactoryMetaExtensions.cs
@@ -115,10 +115,7 @@ namespace ImageProcessor.Imaging.MetaData
         /// <returns>
         /// The <see cref="ImageFactory"/>.
         /// </returns>
-        public static ImageFactory SetPropertyItem(this ImageFactory imageFactory, ExifPropertyTag id, byte[] value)
-        {
-            return imageFactory.SetPropertyItem(id, ExifPropertyTagType.Undefined, value.Length, value);
-        }
+        public static ImageFactory SetPropertyItem(this ImageFactory imageFactory, ExifPropertyTag id, byte[] value) => imageFactory.SetPropertyItem(id, ExifPropertyTagType.Undefined, value.Length, value);
 
         /// <summary>
         /// Sets a property item with the given id to the collection within the current

--- a/src/ImageProcessor/Imaging/MetaData/Int32Converter.cs
+++ b/src/ImageProcessor/Imaging/MetaData/Int32Converter.cs
@@ -18,7 +18,7 @@ namespace ImageProcessor.Imaging.MetaData
     /// short term arrays.
     /// </summary>
     [StructLayout(LayoutKind.Explicit)]
-    internal struct Int32Converter
+    internal readonly struct Int32Converter
     {
         /// <summary>
         /// The value of the byte array as an integer.
@@ -57,10 +57,7 @@ namespace ImageProcessor.Imaging.MetaData
         /// The value to convert from.
         /// </param>
         public Int32Converter(int value)
-            : this()
-        {
-            this.Value = value;
-        }
+            : this() => this.Value = value;
 
         /// <summary>
         /// Allows the implicit conversion of an instance of <see cref="Int32Converter"/> to a 
@@ -72,10 +69,7 @@ namespace ImageProcessor.Imaging.MetaData
         /// <returns>
         /// An instance of <see cref="int"/>.
         /// </returns>
-        public static implicit operator int(Int32Converter value)
-        {
-            return value.Value;
-        }
+        public static implicit operator int(Int32Converter value) => value.Value;
 
         /// <summary>
         /// Allows the implicit conversion of an instance of <see cref="int"/> to a 
@@ -87,9 +81,6 @@ namespace ImageProcessor.Imaging.MetaData
         /// <returns>
         /// An instance of <see cref="Int32Converter"/>.
         /// </returns>
-        public static implicit operator Int32Converter(int value)
-        {
-            return new Int32Converter(value);
-        }
+        public static implicit operator Int32Converter(int value) => new Int32Converter(value);
     }
 }

--- a/src/ImageProcessor/Imaging/MetaData/Rational.cs
+++ b/src/ImageProcessor/Imaging/MetaData/Rational.cs
@@ -32,7 +32,7 @@ namespace ImageProcessor.Imaging.MetaData
     /// </typeparam>
     [SuppressMessage("StyleCop.CSharp.OrderingRules", "SA1202:ElementsMustBeOrderedByAccess", Justification = "Reviewed. Suppression is OK here. Better readability.")]
     [Serializable]
-    public struct Rational<T> :
+    public readonly struct Rational<T> :
         IConvertible,
         IComparable,
         IComparable<T>
@@ -42,8 +42,6 @@ namespace ImageProcessor.Imaging.MetaData
         /// Represents an empty instance of <see cref="Rational{T}"/>.
         /// </summary>
         public static readonly Rational<T> Empty = new Rational<T>();
-
-        #region Constants
 
         /// <summary>
         /// The delimiter.
@@ -55,10 +53,6 @@ namespace ImageProcessor.Imaging.MetaData
         /// </summary>
         // ReSharper disable once StaticMemberInGenericType
         private static readonly char[] DelimSet = { Delim };
-
-        #endregion Constants
-
-        #region Fields
 
         /// <summary>
         /// The parser delegate method.
@@ -85,9 +79,6 @@ namespace ImageProcessor.Imaging.MetaData
         /// The denominator.
         /// </summary>
         private readonly T denominator;
-        #endregion Fields
-
-        #region Init
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Rational{T}"/> struct. 
@@ -138,10 +129,6 @@ namespace ImageProcessor.Imaging.MetaData
         /// </returns>
         private delegate bool TryParseDelegate(string value, out T rational);
 
-        #endregion Init
-
-        #region Properties
-
         /// <summary>
         /// Gets and sets the numerator of the rational number
         /// </summary>
@@ -164,7 +151,7 @@ namespace ImageProcessor.Imaging.MetaData
         {
             get
             {
-                if (maxValue == default(decimal))
+                if (maxValue == default)
                 {
                     FieldInfo max = typeof(T).GetField("MaxValue", BindingFlags.Static | BindingFlags.Public);
                     if (max != null)
@@ -188,10 +175,6 @@ namespace ImageProcessor.Imaging.MetaData
             }
         }
 
-        #endregion Properties
-
-        #region Parse Methods
-
         /// <summary>
         /// Approximate the decimal value accurate to a precision of 0.000001m
         /// </summary>
@@ -200,10 +183,7 @@ namespace ImageProcessor.Imaging.MetaData
         /// <remarks>
         /// <see href="http://stackoverflow.com/questions/95727"/>
         /// </remarks>
-        public static Rational<T> Approximate(decimal value)
-        {
-            return Approximate(value, 0.000001m);
-        }
+        public static Rational<T> Approximate(decimal value) => Approximate(value, 0.000001m);
 
         /// <summary>
         /// Approximate the decimal value accurate to a certain precision
@@ -273,7 +253,7 @@ namespace ImageProcessor.Imaging.MetaData
 
             string[] parts = value.Split(DelimSet, 2, StringSplitOptions.RemoveEmptyEntries);
             T numerator = parser(parts[0]);
-            T denominator = parts.Length > 1 ? parser(parts[1]) : default(T);
+            T denominator = parts.Length > 1 ? parser(parts[1]) : default;
 
             return new Rational<T>(numerator, denominator);
         }
@@ -300,9 +280,9 @@ namespace ImageProcessor.Imaging.MetaData
                 tryParser = BuildTryParser();
             }
 
-            T numerator, denominator;
+            T denominator;
             string[] parts = value.Split(DelimSet, 2, StringSplitOptions.RemoveEmptyEntries);
-            if (!tryParser(parts[0], out numerator))
+            if (!tryParser(parts[0], out T numerator))
             {
                 rational = Empty;
                 return false;
@@ -318,7 +298,7 @@ namespace ImageProcessor.Imaging.MetaData
             }
             else
             {
-                denominator = default(T);
+                denominator = default;
             }
 
             rational = new Rational<T>(numerator, denominator);
@@ -416,10 +396,6 @@ namespace ImageProcessor.Imaging.MetaData
                     }
                 };
         }
-
-        #endregion Parse Methods
-
-        #region Math Methods
 
         /// <summary>
         /// Finds the greatest common divisor and reduces the fraction by this amount.
@@ -530,10 +506,6 @@ namespace ImageProcessor.Imaging.MetaData
             return a;
         }
 
-        #endregion Math Methods
-
-        #region IConvertible Members
-
         /// <summary>
         /// Converts the value of this instance to an equivalent <see cref="T:System.String"/> using the specified 
         /// culture-specific formatting information.
@@ -584,8 +556,8 @@ namespace ImageProcessor.Imaging.MetaData
                     return 0L;
                 }
 
-                return ((IConvertible)this.numerator.ToInt64(provider)).ToDecimal(provider) /
-                    ((IConvertible)d).ToDecimal(provider);
+                return ((IConvertible)this.numerator.ToInt64(provider)).ToDecimal(provider)
+                    / ((IConvertible)d).ToDecimal(provider);
             }
         }
 
@@ -644,10 +616,7 @@ namespace ImageProcessor.Imaging.MetaData
         /// An <see cref="T:System.IFormatProvider"/> interface implementation that supplies culture-specific 
         /// formatting information. 
         /// </param>
-        bool IConvertible.ToBoolean(IFormatProvider provider)
-        {
-            return ((IConvertible)this.ToDecimal(provider)).ToBoolean(provider);
-        }
+        bool IConvertible.ToBoolean(IFormatProvider provider) => ((IConvertible)this.ToDecimal(provider)).ToBoolean(provider);
 
         /// <summary>
         /// Converts the value of this instance to an equivalent 8-bit unsigned integer using the specified 
@@ -660,10 +629,7 @@ namespace ImageProcessor.Imaging.MetaData
         /// An <see cref="T:System.IFormatProvider"/> interface implementation that 
         /// supplies culture-specific formatting information. 
         /// </param>
-        byte IConvertible.ToByte(IFormatProvider provider)
-        {
-            return ((IConvertible)this.ToDecimal(provider)).ToByte(provider);
-        }
+        byte IConvertible.ToByte(IFormatProvider provider) => ((IConvertible)this.ToDecimal(provider)).ToByte(provider);
 
         /// <summary>
         /// Converts the value of this instance to an equivalent Unicode character using the specified 
@@ -676,10 +642,7 @@ namespace ImageProcessor.Imaging.MetaData
         /// An <see cref="T:System.IFormatProvider"/> interface implementation that supplies culture-specific 
         /// formatting information. 
         /// </param>
-        char IConvertible.ToChar(IFormatProvider provider)
-        {
-            return ((IConvertible)this.ToDecimal(provider)).ToChar(provider);
-        }
+        char IConvertible.ToChar(IFormatProvider provider) => ((IConvertible)this.ToDecimal(provider)).ToChar(provider);
 
         /// <summary>
         /// Converts the value of this instance to an equivalent 16-bit signed integer using the specified 
@@ -692,10 +655,7 @@ namespace ImageProcessor.Imaging.MetaData
         /// An <see cref="T:System.IFormatProvider"/> interface implementation that supplies culture-specific 
         /// formatting information. 
         /// </param>
-        short IConvertible.ToInt16(IFormatProvider provider)
-        {
-            return ((IConvertible)this.ToDecimal(provider)).ToInt16(provider);
-        }
+        short IConvertible.ToInt16(IFormatProvider provider) => ((IConvertible)this.ToDecimal(provider)).ToInt16(provider);
 
         /// <summary>
         /// Converts the value of this instance to an equivalent 32-bit signed integer using the specified 
@@ -708,10 +668,7 @@ namespace ImageProcessor.Imaging.MetaData
         /// An <see cref="T:System.IFormatProvider"/> interface implementation that supplies culture-specific 
         /// formatting information. 
         /// </param>
-        int IConvertible.ToInt32(IFormatProvider provider)
-        {
-            return ((IConvertible)this.ToDecimal(provider)).ToInt32(provider);
-        }
+        int IConvertible.ToInt32(IFormatProvider provider) => ((IConvertible)this.ToDecimal(provider)).ToInt32(provider);
 
         /// <summary>
         /// Converts the value of this instance to an equivalent 64-bit signed integer using the specified 
@@ -724,10 +681,7 @@ namespace ImageProcessor.Imaging.MetaData
         /// An <see cref="T:System.IFormatProvider"/> interface implementation that supplies culture-specific 
         /// formatting information. 
         /// </param>
-        long IConvertible.ToInt64(IFormatProvider provider)
-        {
-            return ((IConvertible)this.ToDecimal(provider)).ToInt64(provider);
-        }
+        long IConvertible.ToInt64(IFormatProvider provider) => ((IConvertible)this.ToDecimal(provider)).ToInt64(provider);
 
         /// <summary>
         /// Converts the value of this instance to an equivalent 8-bit signed integer using the specified 
@@ -740,10 +694,7 @@ namespace ImageProcessor.Imaging.MetaData
         /// An <see cref="T:System.IFormatProvider"/> interface implementation that supplies culture-specific 
         /// formatting information. 
         /// </param>
-        sbyte IConvertible.ToSByte(IFormatProvider provider)
-        {
-            return ((IConvertible)this.ToDecimal(provider)).ToSByte(provider);
-        }
+        sbyte IConvertible.ToSByte(IFormatProvider provider) => ((IConvertible)this.ToDecimal(provider)).ToSByte(provider);
 
         /// <summary>
         /// Converts the value of this instance to an equivalent 16-bit unsigned integer using the specified 
@@ -756,10 +707,7 @@ namespace ImageProcessor.Imaging.MetaData
         /// An <see cref="T:System.IFormatProvider"/> interface implementation that supplies culture-specific 
         /// formatting information. 
         /// </param>
-        ushort IConvertible.ToUInt16(IFormatProvider provider)
-        {
-            return ((IConvertible)this.ToDecimal(provider)).ToUInt16(provider);
-        }
+        ushort IConvertible.ToUInt16(IFormatProvider provider) => ((IConvertible)this.ToDecimal(provider)).ToUInt16(provider);
 
         /// <summary>
         /// Converts the value of this instance to an equivalent 32-bit unsigned integer using the specified 
@@ -772,10 +720,7 @@ namespace ImageProcessor.Imaging.MetaData
         /// An <see cref="T:System.IFormatProvider"/> interface implementation that supplies culture-specific 
         /// formatting information. 
         /// </param>
-        uint IConvertible.ToUInt32(IFormatProvider provider)
-        {
-            return ((IConvertible)this.ToDecimal(provider)).ToUInt32(provider);
-        }
+        uint IConvertible.ToUInt32(IFormatProvider provider) => ((IConvertible)this.ToDecimal(provider)).ToUInt32(provider);
 
         /// <summary>
         /// Converts the value of this instance to an equivalent 64-bit unsigned integer using the specified 
@@ -788,10 +733,7 @@ namespace ImageProcessor.Imaging.MetaData
         /// An <see cref="T:System.IFormatProvider"/> interface implementation that 
         /// supplies culture-specific formatting information. 
         /// </param>
-        ulong IConvertible.ToUInt64(IFormatProvider provider)
-        {
-            return ((IConvertible)this.ToDecimal(provider)).ToUInt64(provider);
-        }
+        ulong IConvertible.ToUInt64(IFormatProvider provider) => ((IConvertible)this.ToDecimal(provider)).ToUInt64(provider);
 
         /// <summary>
         /// Converts the value of this instance to an equivalent <see cref="T:System.DateTime"/> using the specified 
@@ -804,10 +746,7 @@ namespace ImageProcessor.Imaging.MetaData
         /// An <see cref="T:System.IFormatProvider"/> interface implementation that supplies culture-specific 
         /// formatting information. 
         /// </param>
-        DateTime IConvertible.ToDateTime(IFormatProvider provider)
-        {
-            return new DateTime(((IConvertible)this).ToInt64(provider));
-        }
+        DateTime IConvertible.ToDateTime(IFormatProvider provider) => new DateTime(((IConvertible)this).ToInt64(provider));
 
         /// <summary>
         /// Returns the <see cref="T:System.TypeCode"/> for this instance.
@@ -816,10 +755,7 @@ namespace ImageProcessor.Imaging.MetaData
         /// The enumerated constant that is the <see cref="T:System.TypeCode"/> of the class or value type that 
         /// implements this interface.
         /// </returns>
-        TypeCode IConvertible.GetTypeCode()
-        {
-            return this.numerator.GetTypeCode();
-        }
+        TypeCode IConvertible.GetTypeCode() => this.numerator.GetTypeCode();
 
         /// <summary>
         /// Converts the value of this instance to an <see cref="T:System.Object"/> of the specified 
@@ -851,8 +787,8 @@ namespace ImageProcessor.Imaging.MetaData
                 return this;
             }
 
-            if (!conversionType.IsGenericType ||
-                typeof(Rational<>) != conversionType.GetGenericTypeDefinition())
+            if (!conversionType.IsGenericType
+                || typeof(Rational<>) != conversionType.GetGenericTypeDefinition())
             {
                 // fall back to basic conversion
                 return Convert.ChangeType(this, conversionType, provider);
@@ -875,10 +811,6 @@ namespace ImageProcessor.Imaging.MetaData
             return ctor.Invoke(ctorArgs);
         }
 
-        #endregion IConvertible Members
-
-        #region IComparable Members
-
         /// <summary>
         /// Compares the current instance with another object of the same type and returns an integer that indicates 
         /// whether the current instance precedes, follows, or occurs in the same position in the sort order as the 
@@ -896,11 +828,11 @@ namespace ImageProcessor.Imaging.MetaData
         /// </exception>
         public int CompareTo(object obj)
         {
-            if (obj is Rational<T>)
+            if (obj is Rational<T> rational)
             {
                 // Differentiate between a real zero and a divide by zero
                 // work around divide by zero value to get meaningful comparisons
-                Rational<T> other = (Rational<T>)obj;
+                var other = rational;
                 if (Convert.ToDecimal(this.denominator) == 0m)
                 {
                     if (Convert.ToDecimal(other.denominator) == 0m)
@@ -925,10 +857,6 @@ namespace ImageProcessor.Imaging.MetaData
             return Convert.ToDecimal(this).CompareTo(Convert.ToDecimal(obj));
         }
 
-        #endregion IComparable Members
-
-        #region IComparable<T> Members
-
         /// <summary>
         /// Compares the current instance with another object of the same type and returns an integer that indicates 
         /// whether the current instance precedes, follows, or occurs in the same position in the sort order as the 
@@ -941,14 +869,7 @@ namespace ImageProcessor.Imaging.MetaData
         /// zero This instance follows <paramref name="other"/> in the sort order. 
         /// </returns>
         /// <param name="other">An object to compare with this instance. </param>
-        public int CompareTo(T other)
-        {
-            return decimal.Compare(Convert.ToDecimal(this), Convert.ToDecimal(other));
-        }
-
-        #endregion IComparable<T> Members
-
-        #region Operators
+        public int CompareTo(T other) => decimal.Compare(Convert.ToDecimal(this), Convert.ToDecimal(other));
 
         /// <summary>
         /// Performs a numeric negation of the operand.
@@ -959,7 +880,7 @@ namespace ImageProcessor.Imaging.MetaData
         /// </returns>
         public static Rational<T> operator -(Rational<T> rational)
         {
-            T numerator = (T)Convert.ChangeType(-Convert.ToDecimal(rational.numerator), typeof(T));
+            var numerator = (T)Convert.ChangeType(-Convert.ToDecimal(rational.numerator), typeof(T));
             return new Rational<T>(numerator, rational.denominator);
         }
 
@@ -998,10 +919,7 @@ namespace ImageProcessor.Imaging.MetaData
         /// <param name="r1">The first rational operand.</param>
         /// <param name="r2">The second rational operand.</param>
         /// <returns>The computed result.</returns>
-        public static Rational<T> operator -(Rational<T> r1, Rational<T> r2)
-        {
-            return r1 + (-r2);
-        }
+        public static Rational<T> operator -(Rational<T> r1, Rational<T> r2) => r1 + (-r2);
 
         /// <summary>
         /// Computes the product of multiplying two rational instances.
@@ -1023,10 +941,7 @@ namespace ImageProcessor.Imaging.MetaData
         /// <param name="r1">The first rational operand.</param>
         /// <param name="r2">The second rational operand.</param>
         /// <returns>The computed product.</returns>
-        public static Rational<T> operator /(Rational<T> r1, Rational<T> r2)
-        {
-            return r1 * new Rational<T>(r2.denominator, r2.numerator);
-        }
+        public static Rational<T> operator /(Rational<T> r1, Rational<T> r2) => r1 * new Rational<T>(r2.denominator, r2.numerator);
 
         /// <summary>
         /// Determines whether the first rational operand is less than the second.
@@ -1034,10 +949,7 @@ namespace ImageProcessor.Imaging.MetaData
         /// <param name="r1">The first rational operand.</param>
         /// <param name="r2">The second rational operand.</param>
         /// <returns>The computed result.</returns>
-        public static bool operator <(Rational<T> r1, Rational<T> r2)
-        {
-            return r1.CompareTo(r2) < 0;
-        }
+        public static bool operator <(Rational<T> r1, Rational<T> r2) => r1.CompareTo(r2) < 0;
 
         /// <summary>
         /// Determines whether the first rational operand is less than or equal to the second.
@@ -1045,10 +957,7 @@ namespace ImageProcessor.Imaging.MetaData
         /// <param name="r1">The first rational operand.</param>
         /// <param name="r2">The second rational operand.</param>
         /// <returns>The computed result.</returns>
-        public static bool operator <=(Rational<T> r1, Rational<T> r2)
-        {
-            return r1.CompareTo(r2) <= 0;
-        }
+        public static bool operator <=(Rational<T> r1, Rational<T> r2) => r1.CompareTo(r2) <= 0;
 
         /// <summary>
         /// Determines whether the first rational operand is greater than the second.
@@ -1056,10 +965,7 @@ namespace ImageProcessor.Imaging.MetaData
         /// <param name="r1">The first rational operand.</param>
         /// <param name="r2">The second rational operand.</param>
         /// <returns>The computed result.</returns>
-        public static bool operator >(Rational<T> r1, Rational<T> r2)
-        {
-            return r1.CompareTo(r2) > 0;
-        }
+        public static bool operator >(Rational<T> r1, Rational<T> r2) => r1.CompareTo(r2) > 0;
 
         /// <summary>
         /// Determines whether the first rational operand is greater than or equal to the second.
@@ -1067,10 +973,7 @@ namespace ImageProcessor.Imaging.MetaData
         /// <param name="r1">The first rational operand.</param>
         /// <param name="r2">The second rational operand.</param>
         /// <returns>The computed result.</returns>
-        public static bool operator >=(Rational<T> r1, Rational<T> r2)
-        {
-            return r1.CompareTo(r2) >= 0;
-        }
+        public static bool operator >=(Rational<T> r1, Rational<T> r2) => r1.CompareTo(r2) >= 0;
 
         /// <summary>
         /// Determines whether the first rational operand is equal to the second.
@@ -1078,10 +981,7 @@ namespace ImageProcessor.Imaging.MetaData
         /// <param name="r1">The first rational operand.</param>
         /// <param name="r2">The second rational operand.</param>
         /// <returns>The computed result.</returns>
-        public static bool operator ==(Rational<T> r1, Rational<T> r2)
-        {
-            return r1.CompareTo(r2) == 0;
-        }
+        public static bool operator ==(Rational<T> r1, Rational<T> r2) => r1.CompareTo(r2) == 0;
 
         /// <summary>
         /// Determines whether the first rational operand is not equal to the second.
@@ -1089,14 +989,7 @@ namespace ImageProcessor.Imaging.MetaData
         /// <param name="r1">The first rational operand.</param>
         /// <param name="r2">The second rational operand.</param>
         /// <returns>The computed result.</returns>
-        public static bool operator !=(Rational<T> r1, Rational<T> r2)
-        {
-            return r1.CompareTo(r2) != 0;
-        }
-
-        #endregion Operators
-
-        #region Object Overrides
+        public static bool operator !=(Rational<T> r1, Rational<T> r2) => r1.CompareTo(r2) != 0;
 
         /// <summary>
         /// Returns the fully qualified type name of this instance.
@@ -1104,10 +997,7 @@ namespace ImageProcessor.Imaging.MetaData
         /// <returns>
         /// A <see cref="T:System.String"/> containing a fully qualified type name.
         /// </returns>
-        public override string ToString()
-        {
-            return Convert.ToString(this, CultureInfo.InvariantCulture);
-        }
+        public override string ToString() => Convert.ToString(this, CultureInfo.InvariantCulture);
 
         /// <summary>
         /// Indicates whether this instance and a specified object are equal.
@@ -1117,10 +1007,7 @@ namespace ImageProcessor.Imaging.MetaData
         /// otherwise, false. 
         /// </returns>
         /// <param name="obj">The object to compare with the current instance. </param>
-        public override bool Equals(object obj)
-        {
-            return this.CompareTo(obj) == 0;
-        }
+        public override bool Equals(object obj) => this.CompareTo(obj) == 0;
 
         /// <summary>
         /// Returns the hash code for this instance.
@@ -1135,7 +1022,5 @@ namespace ImageProcessor.Imaging.MetaData
             num = (-1521134295 * num) + EqualityComparer<T>.Default.GetHashCode(this.numerator);
             return (-1521134295 * num) + EqualityComparer<T>.Default.GetHashCode(this.denominator);
         }
-
-        #endregion Object Overrides
     }
 }

--- a/src/ImageProcessor/Imaging/Quantizers/Quantizer.cs
+++ b/src/ImageProcessor/Imaging/Quantizers/Quantizer.cs
@@ -38,10 +38,7 @@ namespace ImageProcessor.Imaging.Quantizers
         /// only call the 'QuantizeImage' function. If two passes are required, the code will call 'InitialQuantizeImage'
         /// and then 'QuantizeImage'.
         /// </remarks>
-        protected Quantizer(bool singlePass)
-        {
-            this.singlePass = singlePass;
-        }
+        protected Quantizer(bool singlePass) => this.singlePass = singlePass;
 
         /// <summary>
         /// Quantize an image and return the resulting output bitmap.
@@ -59,18 +56,18 @@ namespace ImageProcessor.Imaging.Quantizers
             int width = source.Width;
 
             // And construct a rectangle from these dimensions
-            Rectangle bounds = new Rectangle(0, 0, width, height);
+            var bounds = new Rectangle(0, 0, width, height);
 
             // First off take a 32bpp copy of the image
-            Bitmap copy = new Bitmap(width, height, PixelFormat.Format32bppPArgb);
+            var copy = new Bitmap(width, height, PixelFormat.Format32bppPArgb);
             copy.SetResolution(source.HorizontalResolution, source.VerticalResolution);
 
             // And construct an 8bpp version
-            Bitmap output = new Bitmap(width, height, PixelFormat.Format8bppIndexed);
+            var output = new Bitmap(width, height, PixelFormat.Format8bppIndexed);
             output.SetResolution(source.HorizontalResolution, source.VerticalResolution);
 
             // Now lock the bitmap into memory
-            using (Graphics g = Graphics.FromImage(copy))
+            using (var g = Graphics.FromImage(copy))
             {
                 g.PageUnit = GraphicsUnit.Pixel;
 

--- a/src/ImageProcessor/Imaging/Quantizers/WuQuantizer/ColorMoment.cs
+++ b/src/ImageProcessor/Imaging/Quantizers/WuQuantizer/ColorMoment.cs
@@ -157,10 +157,7 @@ namespace ImageProcessor.Imaging.Quantizers.WuQuantizer
         /// <returns>
         /// The <see cref="long"/> representing the amplitude.
         /// </returns>
-        public long Amplitude()
-        {
-            return (this.Alpha * this.Alpha) + (this.Red * this.Red) + (this.Green * this.Green) + (this.Blue * this.Blue);
-        }
+        public long Amplitude() => (this.Alpha * this.Alpha) + (this.Red * this.Red) + (this.Green * this.Green) + (this.Blue * this.Blue);
 
         /// <summary>
         /// The variance.
@@ -180,9 +177,6 @@ namespace ImageProcessor.Imaging.Quantizers.WuQuantizer
         /// <returns>
         /// The <see cref="long"/>.
         /// </returns>
-        public long WeightedDistance()
-        {
-            return this.Amplitude() / this.Weight;
-        }
+        public long WeightedDistance() => this.Amplitude() / this.Weight;
     }
 }

--- a/src/ImageProcessor/Imaging/Quantizers/WuQuantizer/CubeCut.cs
+++ b/src/ImageProcessor/Imaging/Quantizers/WuQuantizer/CubeCut.cs
@@ -15,7 +15,7 @@ namespace ImageProcessor.Imaging.Quantizers.WuQuantizer
     /// Represents a cube cut.
     /// Adapted from <see href="https://github.com/drewnoakes"/>
     /// </summary>
-    internal struct CubeCut
+    internal readonly struct CubeCut
     {
         /// <summary>
         /// The position.

--- a/src/ImageProcessor/Imaging/Quantizers/WuQuantizer/Histogram.cs
+++ b/src/ImageProcessor/Imaging/Quantizers/WuQuantizer/Histogram.cs
@@ -41,9 +41,6 @@ namespace ImageProcessor.Imaging.Quantizers.WuQuantizer
         /// <summary>
         /// The clear.
         /// </summary>
-        internal void Clear()
-        {
-            Array.Clear(this.Moments, 0, SideSize * SideSize * SideSize * SideSize);
-        }
+        internal void Clear() => Array.Clear(this.Moments, 0, SideSize * SideSize * SideSize * SideSize);
     }
 }

--- a/src/ImageProcessor/Imaging/Quantizers/WuQuantizer/ImageBuffer.cs
+++ b/src/ImageProcessor/Imaging/Quantizers/WuQuantizer/ImageBuffer.cs
@@ -32,10 +32,7 @@ namespace ImageProcessor.Imaging.Quantizers.WuQuantizer
         /// <param name="image">
         /// The image to store.
         /// </param>
-        public ImageBuffer(Bitmap image)
-        {
-            this.Image = image;
-        }
+        public ImageBuffer(Bitmap image) => this.Image = image;
 
         /// <summary>
         /// Gets the image.
@@ -54,9 +51,9 @@ namespace ImageProcessor.Imaging.Quantizers.WuQuantizer
             {
                 int width = this.Image.Width;
                 int height = this.Image.Height;
-                Color32[] pixels = new Color32[width];
+                var pixels = new Color32[width];
 
-                using (FastBitmap bitmap = new FastBitmap(this.Image))
+                using (var bitmap = new FastBitmap(this.Image))
                 {
                     for (int y = 0; y < height; y++)
                     {

--- a/src/ImageProcessor/Imaging/Quantizers/WuQuantizer/PaletteColorHistory.cs
+++ b/src/ImageProcessor/Imaging/Quantizers/WuQuantizer/PaletteColorHistory.cs
@@ -52,10 +52,7 @@ namespace ImageProcessor.Imaging.Quantizers.WuQuantizer
         /// <returns>
         /// The normalized <see cref="Color"/>.
         /// </returns>
-        public Color ToNormalizedColor()
-        {
-            return (this.Sum != 0) ? Color.FromArgb((int)(this.Alpha /= this.Sum), (int)(this.Red /= this.Sum), (int)(this.Green /= this.Sum), (int)(this.Blue /= this.Sum)) : Color.Empty;
-        }
+        public Color ToNormalizedColor() => (this.Sum != 0) ? Color.FromArgb((int)(this.Alpha /= this.Sum), (int)(this.Red /= this.Sum), (int)(this.Green /= this.Sum), (int)(this.Blue /= this.Sum)) : Color.Empty;
 
         /// <summary>
         /// Adds a pixel to the color history.

--- a/src/ImageProcessor/Imaging/Quantizers/WuQuantizer/PaletteLookup.cs
+++ b/src/ImageProcessor/Imaging/Quantizers/WuQuantizer/PaletteLookup.cs
@@ -71,8 +71,7 @@ namespace ImageProcessor.Imaging.Quantizers.WuQuantizer
         public byte GetPaletteIndex(Color32 pixel)
         {
             int pixelKey = pixel.Argb & this.paletteMask;
-            LookupNode[] bucket;
-            if (!this.lookupNodes.TryGetValue(pixelKey, out bucket))
+            if (!this.lookupNodes.TryGetValue(pixelKey, out LookupNode[] bucket))
             {
                 bucket = this.Palette;
             }
@@ -188,7 +187,7 @@ namespace ImageProcessor.Imaging.Quantizers.WuQuantizer
             byte greenMask = ComputeBitMask(maxGreen, Convert.ToInt32(Math.Round(uniqueGreens / totalUniques * availableBits)));
             byte blueMask = ComputeBitMask(maxBlue, Convert.ToInt32(Math.Round(uniqueBlues / totalUniques * availableBits)));
 
-            Color32 maskedPixel = new Color32(alphaMask, redMask, greenMask, blueMask);
+            var maskedPixel = new Color32(alphaMask, redMask, greenMask, blueMask);
             return maskedPixel.Argb;
         }
 
@@ -226,13 +225,12 @@ namespace ImageProcessor.Imaging.Quantizers.WuQuantizer
         private void BuildLookup(Color32[] palette)
         {
             int mask = GetMask(palette);
-            Dictionary<int, List<LookupNode>> tempLookup = new Dictionary<int, List<LookupNode>>();
+            var tempLookup = new Dictionary<int, List<LookupNode>>();
             foreach (LookupNode lookup in this.Palette)
             {
                 int pixelKey = lookup.Color32.Argb & mask;
 
-                List<LookupNode> bucket;
-                if (!tempLookup.TryGetValue(pixelKey, out bucket))
+                if (!tempLookup.TryGetValue(pixelKey, out List<LookupNode> bucket))
                 {
                     bucket = new List<LookupNode>();
                     tempLookup[pixelKey] = bucket;

--- a/src/ImageProcessor/Imaging/Quantizers/WuQuantizer/WuQuantizer.cs
+++ b/src/ImageProcessor/Imaging/Quantizers/WuQuantizer/WuQuantizer.cs
@@ -45,10 +45,10 @@ namespace ImageProcessor.Imaging.Quantizers.WuQuantizer
         /// </returns>
         internal override Bitmap GetQuantizedImage(ImageBuffer imageBuffer, int colorCount, Color32[] lookups, int alphaThreshold)
         {
-            Bitmap result = new Bitmap(imageBuffer.Image.Width, imageBuffer.Image.Height, PixelFormat.Format8bppIndexed);
+            var result = new Bitmap(imageBuffer.Image.Width, imageBuffer.Image.Height, PixelFormat.Format8bppIndexed);
             result.SetResolution(imageBuffer.Image.HorizontalResolution, imageBuffer.Image.VerticalResolution);
-            ImageBuffer resultBuffer = new ImageBuffer(result);
-            PaletteColorHistory[] paletteHistogram = new PaletteColorHistory[colorCount + 1];
+            var resultBuffer = new ImageBuffer(result);
+            var paletteHistogram = new PaletteColorHistory[colorCount + 1];
             resultBuffer.UpdatePixelIndexes(IndexedPixels(imageBuffer, lookups, alphaThreshold, paletteHistogram));
             result.Palette = BuildPalette(result.Palette, paletteHistogram);
             return result;
@@ -98,7 +98,7 @@ namespace ImageProcessor.Imaging.Quantizers.WuQuantizer
         private static IEnumerable<byte[]> IndexedPixels(ImageBuffer image, Color32[] lookups, int alphaThreshold, PaletteColorHistory[] paletteHistogram)
         {
             byte[] lineIndexes = new byte[image.Image.Width];
-            PaletteLookup lookup = new PaletteLookup(lookups);
+            var lookup = new PaletteLookup(lookups);
 
             // Determine the correct fallback color.
             byte fallback = lookups.Length < AlphaMax ? AlphaMin : AlphaMax;

--- a/src/ImageProcessor/Imaging/Quantizers/WuQuantizer/WuQuantizerBase.cs
+++ b/src/ImageProcessor/Imaging/Quantizers/WuQuantizer/WuQuantizerBase.cs
@@ -69,46 +69,14 @@ namespace ImageProcessor.Imaging.Quantizers.WuQuantizer
         private const int MaxSideIndex = 32;
 
         /// <summary>
-        /// The transparency threshold.
-        /// </summary>
-        private byte threshold = 0;
-
-        /// <summary>
-        /// The transparency fade.
-        /// </summary>
-        private byte fade = 1;
-
-        /// <summary>
         /// Gets or sets the transparency threshold (0 - 255)
         /// </summary>
-        public byte Threshold
-        {
-            get
-            {
-                return this.threshold;
-            }
-
-            set
-            {
-                this.threshold = value;
-            }
-        }
+        public byte Threshold { get; set; } = 0;
 
         /// <summary>
         /// Gets or sets the alpha fade (0 - 255)
         /// </summary>
-        public byte Fade
-        {
-            get
-            {
-                return this.fade;
-            }
-
-            set
-            {
-                this.fade = value;
-            }
-        }
+        public byte Fade { get; set; } = 1;
 
         /// <summary>
         /// Quantize an image and return the resulting output bitmap
@@ -119,15 +87,12 @@ namespace ImageProcessor.Imaging.Quantizers.WuQuantizer
         /// <returns>
         /// A quantized version of the image.
         /// </returns>
-        public Bitmap Quantize(Image source)
-        {
-            return this.Quantize(source, this.Threshold, this.Fade);
-        }
+        public Bitmap Quantize(Image source) => this.Quantize(source, this.Threshold, this.Fade);
 
         /// <summary>
         /// Quantize an image and return the resulting output bitmap
         /// </summary>
-        /// <param name="source">
+        /// <param name="image">
         /// The 32 bit per pixel image to quantize.
         /// </param>
         /// <param name="alphaThreshold">
@@ -139,10 +104,7 @@ namespace ImageProcessor.Imaging.Quantizers.WuQuantizer
         /// <returns>
         /// A quantized version of the image.
         /// </returns>
-        public Bitmap Quantize(Image source, int alphaThreshold, int alphaFader)
-        {
-            return this.Quantize(source, alphaThreshold, alphaFader, null, 256);
-        }
+        public Bitmap Quantize(Image image, int alphaThreshold, int alphaFader) => this.Quantize(image, alphaThreshold, alphaFader, null, 256);
 
         /// <summary>
         /// Quantize an image and return the resulting output bitmap
@@ -174,10 +136,10 @@ namespace ImageProcessor.Imaging.Quantizers.WuQuantizer
                 // The image has to be a 32 bit per pixel Argb image.
                 if (Image.GetPixelFormatSize(source.PixelFormat) != 32)
                 {
-                    Bitmap clone = new Bitmap(source.Width, source.Height, PixelFormat.Format32bppPArgb);
+                    var clone = new Bitmap(source.Width, source.Height, PixelFormat.Format32bppPArgb);
                     clone.SetResolution(source.HorizontalResolution, source.VerticalResolution);
 
-                    using (Graphics graphics = Graphics.FromImage(clone))
+                    using (var graphics = Graphics.FromImage(clone))
                     {
                         graphics.PageUnit = GraphicsUnit.Pixel;
                         graphics.Clear(Color.Transparent);
@@ -292,8 +254,8 @@ namespace ImageProcessor.Imaging.Quantizers.WuQuantizer
         [SuppressMessage("StyleCop.CSharp.SpacingRules", "SA1001:CommasMustBeSpacedCorrectly", Justification = "Reviewed. Suppression is OK here.")]
         private static void CalculateMoments(ColorMoment[,,,] moments)
         {
-            ColorMoment[,] areaSquared = new ColorMoment[SideSize, SideSize];
-            ColorMoment[] area = new ColorMoment[SideSize];
+            var areaSquared = new ColorMoment[SideSize, SideSize];
+            var area = new ColorMoment[SideSize];
             for (int alphaIndex = 1; alphaIndex < SideSize; alphaIndex++)
             {
                 for (int redIndex = 1; redIndex < SideSize; redIndex++)
@@ -301,7 +263,7 @@ namespace ImageProcessor.Imaging.Quantizers.WuQuantizer
                     Array.Clear(area, 0, area.Length);
                     for (int greenIndex = 1; greenIndex < SideSize; greenIndex++)
                     {
-                        ColorMoment line = new ColorMoment();
+                        var line = new ColorMoment();
                         for (int blueIndex = 1; blueIndex < SideSize; blueIndex++)
                         {
                             line.AddFast(ref moments[alphaIndex, redIndex, greenIndex, blueIndex]);
@@ -341,44 +303,44 @@ namespace ImageProcessor.Imaging.Quantizers.WuQuantizer
             switch (direction)
             {
                 case Alpha:
-                    return (moment[position, cube.RedMaximum, cube.GreenMaximum, cube.BlueMaximum] -
-                            moment[position, cube.RedMaximum, cube.GreenMinimum, cube.BlueMaximum] -
-                            moment[position, cube.RedMinimum, cube.GreenMaximum, cube.BlueMaximum] +
-                            moment[position, cube.RedMinimum, cube.GreenMinimum, cube.BlueMaximum]) -
-                           (moment[position, cube.RedMaximum, cube.GreenMaximum, cube.BlueMinimum] -
-                            moment[position, cube.RedMaximum, cube.GreenMinimum, cube.BlueMinimum] -
-                            moment[position, cube.RedMinimum, cube.GreenMaximum, cube.BlueMinimum] +
-                            moment[position, cube.RedMinimum, cube.GreenMinimum, cube.BlueMinimum]);
+                    return (moment[position, cube.RedMaximum, cube.GreenMaximum, cube.BlueMaximum]
+                            - moment[position, cube.RedMaximum, cube.GreenMinimum, cube.BlueMaximum]
+                            - moment[position, cube.RedMinimum, cube.GreenMaximum, cube.BlueMaximum]
+                            + moment[position, cube.RedMinimum, cube.GreenMinimum, cube.BlueMaximum])
+                           - (moment[position, cube.RedMaximum, cube.GreenMaximum, cube.BlueMinimum]
+                            - moment[position, cube.RedMaximum, cube.GreenMinimum, cube.BlueMinimum]
+                            - moment[position, cube.RedMinimum, cube.GreenMaximum, cube.BlueMinimum]
+                            + moment[position, cube.RedMinimum, cube.GreenMinimum, cube.BlueMinimum]);
 
                 case Red:
-                    return (moment[cube.AlphaMaximum, position, cube.GreenMaximum, cube.BlueMaximum] -
-                            moment[cube.AlphaMaximum, position, cube.GreenMinimum, cube.BlueMaximum] -
-                            moment[cube.AlphaMinimum, position, cube.GreenMaximum, cube.BlueMaximum] +
-                            moment[cube.AlphaMinimum, position, cube.GreenMinimum, cube.BlueMaximum]) -
-                           (moment[cube.AlphaMaximum, position, cube.GreenMaximum, cube.BlueMinimum] -
-                            moment[cube.AlphaMaximum, position, cube.GreenMinimum, cube.BlueMinimum] -
-                            moment[cube.AlphaMinimum, position, cube.GreenMaximum, cube.BlueMinimum] +
-                            moment[cube.AlphaMinimum, position, cube.GreenMinimum, cube.BlueMinimum]);
+                    return (moment[cube.AlphaMaximum, position, cube.GreenMaximum, cube.BlueMaximum]
+                            - moment[cube.AlphaMaximum, position, cube.GreenMinimum, cube.BlueMaximum]
+                            - moment[cube.AlphaMinimum, position, cube.GreenMaximum, cube.BlueMaximum]
+                            + moment[cube.AlphaMinimum, position, cube.GreenMinimum, cube.BlueMaximum])
+                           - (moment[cube.AlphaMaximum, position, cube.GreenMaximum, cube.BlueMinimum]
+                            - moment[cube.AlphaMaximum, position, cube.GreenMinimum, cube.BlueMinimum]
+                            - moment[cube.AlphaMinimum, position, cube.GreenMaximum, cube.BlueMinimum]
+                            + moment[cube.AlphaMinimum, position, cube.GreenMinimum, cube.BlueMinimum]);
 
                 case Green:
-                    return (moment[cube.AlphaMaximum, cube.RedMaximum, position, cube.BlueMaximum] -
-                            moment[cube.AlphaMaximum, cube.RedMinimum, position, cube.BlueMaximum] -
-                            moment[cube.AlphaMinimum, cube.RedMaximum, position, cube.BlueMaximum] +
-                            moment[cube.AlphaMinimum, cube.RedMinimum, position, cube.BlueMaximum]) -
-                           (moment[cube.AlphaMaximum, cube.RedMaximum, position, cube.BlueMinimum] -
-                            moment[cube.AlphaMaximum, cube.RedMinimum, position, cube.BlueMinimum] -
-                            moment[cube.AlphaMinimum, cube.RedMaximum, position, cube.BlueMinimum] +
-                            moment[cube.AlphaMinimum, cube.RedMinimum, position, cube.BlueMinimum]);
+                    return (moment[cube.AlphaMaximum, cube.RedMaximum, position, cube.BlueMaximum]
+                            - moment[cube.AlphaMaximum, cube.RedMinimum, position, cube.BlueMaximum]
+                            - moment[cube.AlphaMinimum, cube.RedMaximum, position, cube.BlueMaximum]
+                            + moment[cube.AlphaMinimum, cube.RedMinimum, position, cube.BlueMaximum])
+                           - (moment[cube.AlphaMaximum, cube.RedMaximum, position, cube.BlueMinimum]
+                            - moment[cube.AlphaMaximum, cube.RedMinimum, position, cube.BlueMinimum]
+                            - moment[cube.AlphaMinimum, cube.RedMaximum, position, cube.BlueMinimum]
+                            + moment[cube.AlphaMinimum, cube.RedMinimum, position, cube.BlueMinimum]);
 
                 case Blue:
-                    return (moment[cube.AlphaMaximum, cube.RedMaximum, cube.GreenMaximum, position] -
-                            moment[cube.AlphaMaximum, cube.RedMaximum, cube.GreenMinimum, position] -
-                            moment[cube.AlphaMaximum, cube.RedMinimum, cube.GreenMaximum, position] +
-                            moment[cube.AlphaMaximum, cube.RedMinimum, cube.GreenMinimum, position]) -
-                           (moment[cube.AlphaMinimum, cube.RedMaximum, cube.GreenMaximum, position] -
-                            moment[cube.AlphaMinimum, cube.RedMaximum, cube.GreenMinimum, position] -
-                            moment[cube.AlphaMinimum, cube.RedMinimum, cube.GreenMaximum, position] +
-                            moment[cube.AlphaMinimum, cube.RedMinimum, cube.GreenMinimum, position]);
+                    return (moment[cube.AlphaMaximum, cube.RedMaximum, cube.GreenMaximum, position]
+                            - moment[cube.AlphaMaximum, cube.RedMaximum, cube.GreenMinimum, position]
+                            - moment[cube.AlphaMaximum, cube.RedMinimum, cube.GreenMaximum, position]
+                            + moment[cube.AlphaMaximum, cube.RedMinimum, cube.GreenMinimum, position])
+                           - (moment[cube.AlphaMinimum, cube.RedMaximum, cube.GreenMaximum, position]
+                            - moment[cube.AlphaMinimum, cube.RedMaximum, cube.GreenMinimum, position]
+                            - moment[cube.AlphaMinimum, cube.RedMinimum, cube.GreenMaximum, position]
+                            + moment[cube.AlphaMinimum, cube.RedMinimum, cube.GreenMinimum, position]);
 
                 default:
                     return new ColorMoment();
@@ -406,44 +368,44 @@ namespace ImageProcessor.Imaging.Quantizers.WuQuantizer
             switch (direction)
             {
                 case Alpha:
-                    return (-moment[cube.AlphaMinimum, cube.RedMaximum, cube.GreenMaximum, cube.BlueMaximum] +
-                            moment[cube.AlphaMinimum, cube.RedMaximum, cube.GreenMinimum, cube.BlueMaximum] +
-                            moment[cube.AlphaMinimum, cube.RedMinimum, cube.GreenMaximum, cube.BlueMaximum] -
-                            moment[cube.AlphaMinimum, cube.RedMinimum, cube.GreenMinimum, cube.BlueMaximum]) -
-                           (-moment[cube.AlphaMinimum, cube.RedMaximum, cube.GreenMaximum, cube.BlueMinimum] +
-                            moment[cube.AlphaMinimum, cube.RedMaximum, cube.GreenMinimum, cube.BlueMinimum] +
-                            moment[cube.AlphaMinimum, cube.RedMinimum, cube.GreenMaximum, cube.BlueMinimum] -
-                            moment[cube.AlphaMinimum, cube.RedMinimum, cube.GreenMinimum, cube.BlueMinimum]);
+                    return -moment[cube.AlphaMinimum, cube.RedMaximum, cube.GreenMaximum, cube.BlueMaximum]
+                            + moment[cube.AlphaMinimum, cube.RedMaximum, cube.GreenMinimum, cube.BlueMaximum]
+                            + moment[cube.AlphaMinimum, cube.RedMinimum, cube.GreenMaximum, cube.BlueMaximum]
+                            - moment[cube.AlphaMinimum, cube.RedMinimum, cube.GreenMinimum, cube.BlueMaximum]
+                           - (-moment[cube.AlphaMinimum, cube.RedMaximum, cube.GreenMaximum, cube.BlueMinimum]
+                            + moment[cube.AlphaMinimum, cube.RedMaximum, cube.GreenMinimum, cube.BlueMinimum]
+                            + moment[cube.AlphaMinimum, cube.RedMinimum, cube.GreenMaximum, cube.BlueMinimum]
+                            - moment[cube.AlphaMinimum, cube.RedMinimum, cube.GreenMinimum, cube.BlueMinimum]);
 
                 case Red:
-                    return (-moment[cube.AlphaMaximum, cube.RedMinimum, cube.GreenMaximum, cube.BlueMaximum] +
-                            moment[cube.AlphaMaximum, cube.RedMinimum, cube.GreenMinimum, cube.BlueMaximum] +
-                            moment[cube.AlphaMinimum, cube.RedMinimum, cube.GreenMaximum, cube.BlueMaximum] -
-                            moment[cube.AlphaMinimum, cube.RedMinimum, cube.GreenMinimum, cube.BlueMaximum]) -
-                           (-moment[cube.AlphaMaximum, cube.RedMinimum, cube.GreenMaximum, cube.BlueMinimum] +
-                            moment[cube.AlphaMaximum, cube.RedMinimum, cube.GreenMinimum, cube.BlueMinimum] +
-                            moment[cube.AlphaMinimum, cube.RedMinimum, cube.GreenMaximum, cube.BlueMinimum] -
-                            moment[cube.AlphaMinimum, cube.RedMinimum, cube.GreenMinimum, cube.BlueMinimum]);
+                    return -moment[cube.AlphaMaximum, cube.RedMinimum, cube.GreenMaximum, cube.BlueMaximum]
+                            + moment[cube.AlphaMaximum, cube.RedMinimum, cube.GreenMinimum, cube.BlueMaximum]
+                            + moment[cube.AlphaMinimum, cube.RedMinimum, cube.GreenMaximum, cube.BlueMaximum]
+                            - moment[cube.AlphaMinimum, cube.RedMinimum, cube.GreenMinimum, cube.BlueMaximum]
+                           - (-moment[cube.AlphaMaximum, cube.RedMinimum, cube.GreenMaximum, cube.BlueMinimum]
+                            + moment[cube.AlphaMaximum, cube.RedMinimum, cube.GreenMinimum, cube.BlueMinimum]
+                            + moment[cube.AlphaMinimum, cube.RedMinimum, cube.GreenMaximum, cube.BlueMinimum]
+                            - moment[cube.AlphaMinimum, cube.RedMinimum, cube.GreenMinimum, cube.BlueMinimum]);
 
                 case Green:
-                    return (-moment[cube.AlphaMaximum, cube.RedMaximum, cube.GreenMinimum, cube.BlueMaximum] +
-                            moment[cube.AlphaMaximum, cube.RedMinimum, cube.GreenMinimum, cube.BlueMaximum] +
-                            moment[cube.AlphaMinimum, cube.RedMaximum, cube.GreenMinimum, cube.BlueMaximum] -
-                            moment[cube.AlphaMinimum, cube.RedMinimum, cube.GreenMinimum, cube.BlueMaximum]) -
-                           (-moment[cube.AlphaMaximum, cube.RedMaximum, cube.GreenMinimum, cube.BlueMinimum] +
-                            moment[cube.AlphaMaximum, cube.RedMinimum, cube.GreenMinimum, cube.BlueMinimum] +
-                            moment[cube.AlphaMinimum, cube.RedMaximum, cube.GreenMinimum, cube.BlueMinimum] -
-                            moment[cube.AlphaMinimum, cube.RedMinimum, cube.GreenMinimum, cube.BlueMinimum]);
+                    return -moment[cube.AlphaMaximum, cube.RedMaximum, cube.GreenMinimum, cube.BlueMaximum]
+                            + moment[cube.AlphaMaximum, cube.RedMinimum, cube.GreenMinimum, cube.BlueMaximum]
+                            + moment[cube.AlphaMinimum, cube.RedMaximum, cube.GreenMinimum, cube.BlueMaximum]
+                            - moment[cube.AlphaMinimum, cube.RedMinimum, cube.GreenMinimum, cube.BlueMaximum]
+                           - (-moment[cube.AlphaMaximum, cube.RedMaximum, cube.GreenMinimum, cube.BlueMinimum]
+                            + moment[cube.AlphaMaximum, cube.RedMinimum, cube.GreenMinimum, cube.BlueMinimum]
+                            + moment[cube.AlphaMinimum, cube.RedMaximum, cube.GreenMinimum, cube.BlueMinimum]
+                            - moment[cube.AlphaMinimum, cube.RedMinimum, cube.GreenMinimum, cube.BlueMinimum]);
 
                 case Blue:
-                    return (-moment[cube.AlphaMaximum, cube.RedMaximum, cube.GreenMaximum, cube.BlueMinimum] +
-                            moment[cube.AlphaMaximum, cube.RedMaximum, cube.GreenMinimum, cube.BlueMinimum] +
-                            moment[cube.AlphaMaximum, cube.RedMinimum, cube.GreenMaximum, cube.BlueMinimum] -
-                            moment[cube.AlphaMaximum, cube.RedMinimum, cube.GreenMinimum, cube.BlueMinimum]) -
-                           (-moment[cube.AlphaMinimum, cube.RedMaximum, cube.GreenMaximum, cube.BlueMinimum] +
-                            moment[cube.AlphaMinimum, cube.RedMaximum, cube.GreenMinimum, cube.BlueMinimum] +
-                            moment[cube.AlphaMinimum, cube.RedMinimum, cube.GreenMaximum, cube.BlueMinimum] -
-                            moment[cube.AlphaMinimum, cube.RedMinimum, cube.GreenMinimum, cube.BlueMinimum]);
+                    return -moment[cube.AlphaMaximum, cube.RedMaximum, cube.GreenMaximum, cube.BlueMinimum]
+                            + moment[cube.AlphaMaximum, cube.RedMaximum, cube.GreenMinimum, cube.BlueMinimum]
+                            + moment[cube.AlphaMaximum, cube.RedMinimum, cube.GreenMaximum, cube.BlueMinimum]
+                            - moment[cube.AlphaMaximum, cube.RedMinimum, cube.GreenMinimum, cube.BlueMinimum]
+                           - (-moment[cube.AlphaMinimum, cube.RedMaximum, cube.GreenMaximum, cube.BlueMinimum]
+                            + moment[cube.AlphaMinimum, cube.RedMaximum, cube.GreenMinimum, cube.BlueMinimum]
+                            + moment[cube.AlphaMinimum, cube.RedMinimum, cube.GreenMaximum, cube.BlueMinimum]
+                            - moment[cube.AlphaMinimum, cube.RedMinimum, cube.GreenMinimum, cube.BlueMinimum]);
 
                 default:
                     return new ColorMoment();
@@ -654,23 +616,23 @@ namespace ImageProcessor.Imaging.Quantizers.WuQuantizer
         [SuppressMessage("StyleCop.CSharp.SpacingRules", "SA1001:CommasMustBeSpacedCorrectly", Justification = "Reviewed. Suppression is OK here.")]
         private static ColorMoment Volume(ColorMoment[,,,] moments, Box cube)
         {
-            return (moments[cube.AlphaMaximum, cube.RedMaximum, cube.GreenMaximum, cube.BlueMaximum] -
-                    moments[cube.AlphaMaximum, cube.RedMaximum, cube.GreenMinimum, cube.BlueMaximum] -
-                    moments[cube.AlphaMaximum, cube.RedMinimum, cube.GreenMaximum, cube.BlueMaximum] +
-                    moments[cube.AlphaMaximum, cube.RedMinimum, cube.GreenMinimum, cube.BlueMaximum] -
-                    moments[cube.AlphaMinimum, cube.RedMaximum, cube.GreenMaximum, cube.BlueMaximum] +
-                    moments[cube.AlphaMinimum, cube.RedMaximum, cube.GreenMinimum, cube.BlueMaximum] +
-                    moments[cube.AlphaMinimum, cube.RedMinimum, cube.GreenMaximum, cube.BlueMaximum] -
-                    moments[cube.AlphaMinimum, cube.RedMinimum, cube.GreenMinimum, cube.BlueMaximum]) -
+            return moments[cube.AlphaMaximum, cube.RedMaximum, cube.GreenMaximum, cube.BlueMaximum]
+                    - moments[cube.AlphaMaximum, cube.RedMaximum, cube.GreenMinimum, cube.BlueMaximum]
+                    - moments[cube.AlphaMaximum, cube.RedMinimum, cube.GreenMaximum, cube.BlueMaximum]
+                    + moments[cube.AlphaMaximum, cube.RedMinimum, cube.GreenMinimum, cube.BlueMaximum]
+                    - moments[cube.AlphaMinimum, cube.RedMaximum, cube.GreenMaximum, cube.BlueMaximum]
+                    + moments[cube.AlphaMinimum, cube.RedMaximum, cube.GreenMinimum, cube.BlueMaximum]
+                    + moments[cube.AlphaMinimum, cube.RedMinimum, cube.GreenMaximum, cube.BlueMaximum]
+                    - moments[cube.AlphaMinimum, cube.RedMinimum, cube.GreenMinimum, cube.BlueMaximum]
 
-                   (moments[cube.AlphaMaximum, cube.RedMaximum, cube.GreenMaximum, cube.BlueMinimum] -
-                    moments[cube.AlphaMinimum, cube.RedMaximum, cube.GreenMaximum, cube.BlueMinimum] -
-                    moments[cube.AlphaMaximum, cube.RedMaximum, cube.GreenMinimum, cube.BlueMinimum] +
-                    moments[cube.AlphaMinimum, cube.RedMaximum, cube.GreenMinimum, cube.BlueMinimum] -
-                    moments[cube.AlphaMaximum, cube.RedMinimum, cube.GreenMaximum, cube.BlueMinimum] +
-                    moments[cube.AlphaMinimum, cube.RedMinimum, cube.GreenMaximum, cube.BlueMinimum] +
-                    moments[cube.AlphaMaximum, cube.RedMinimum, cube.GreenMinimum, cube.BlueMinimum] -
-                    moments[cube.AlphaMinimum, cube.RedMinimum, cube.GreenMinimum, cube.BlueMinimum]);
+                   - (moments[cube.AlphaMaximum, cube.RedMaximum, cube.GreenMaximum, cube.BlueMinimum]
+                    - moments[cube.AlphaMinimum, cube.RedMaximum, cube.GreenMaximum, cube.BlueMinimum]
+                    - moments[cube.AlphaMaximum, cube.RedMaximum, cube.GreenMinimum, cube.BlueMinimum]
+                    + moments[cube.AlphaMinimum, cube.RedMaximum, cube.GreenMinimum, cube.BlueMinimum]
+                    - moments[cube.AlphaMaximum, cube.RedMinimum, cube.GreenMaximum, cube.BlueMinimum]
+                    + moments[cube.AlphaMinimum, cube.RedMinimum, cube.GreenMaximum, cube.BlueMinimum]
+                    + moments[cube.AlphaMaximum, cube.RedMinimum, cube.GreenMinimum, cube.BlueMinimum]
+                    - moments[cube.AlphaMinimum, cube.RedMinimum, cube.GreenMinimum, cube.BlueMinimum]);
         }
 
         /// <summary>
@@ -691,7 +653,7 @@ namespace ImageProcessor.Imaging.Quantizers.WuQuantizer
             --colorCount;
             int next = 0;
             float[] volumeVariance = new float[colorCount];
-            Box[] cubes = new Box[colorCount];
+            var cubes = new Box[colorCount];
             cubes[0].AlphaMaximum = MaxSideIndex;
             cubes[0].RedMaximum = MaxSideIndex;
             cubes[0].GreenMaximum = MaxSideIndex;
@@ -750,7 +712,7 @@ namespace ImageProcessor.Imaging.Quantizers.WuQuantizer
         [SuppressMessage("StyleCop.CSharp.SpacingRules", "SA1001:CommasMustBeSpacedCorrectly", Justification = "Reviewed. Suppression is OK here.")]
         private static Color32[] BuildLookups(Box[] cubes, ColorMoment[,,,] moments)
         {
-            Color32[] lookups = new Color32[cubes.Length];
+            var lookups = new Color32[cubes.Length];
 
             for (int cubeIndex = 0; cubeIndex < cubes.Length; cubeIndex++)
             {
@@ -761,15 +723,13 @@ namespace ImageProcessor.Imaging.Quantizers.WuQuantizer
                     continue;
                 }
 
-                Color32 lookup = new Color32
+                lookups[cubeIndex] = new Color32
                 {
                     A = (byte)(volume.Alpha / volume.Weight),
                     R = (byte)(volume.Red / volume.Weight),
                     G = (byte)(volume.Green / volume.Weight),
                     B = (byte)(volume.Blue / volume.Weight)
                 };
-
-                lookups[cubeIndex] = lookup;
             }
 
             return lookups;

--- a/src/ImageProcessor/Imaging/ResizeLayer.cs
+++ b/src/ImageProcessor/Imaging/ResizeLayer.cs
@@ -10,13 +10,9 @@
 
 namespace ImageProcessor.Imaging
 {
-    #region Using
-
     using System.Collections.Generic;
     using System.Drawing;
     using System.Linq;
-
-    #endregion
 
     /// <summary>
     /// Encapsulates the properties required to resize an image.
@@ -127,9 +123,7 @@ namespace ImageProcessor.Imaging
         /// </returns>
         public override bool Equals(object obj)
         {
-            ResizeLayer resizeLayer = obj as ResizeLayer;
-
-            if (resizeLayer == null)
+            if (!(obj is ResizeLayer resizeLayer))
             {
                 return false;
             }
@@ -167,8 +161,7 @@ namespace ImageProcessor.Imaging
                 hashCode = (hashCode * 397) ^ (int)this.AnchorPosition;
                 hashCode = (hashCode * 397) ^ this.Upscale.GetHashCode();
                 hashCode = (hashCode * 397) ^ (this.CenterCoordinates?.GetHashCode() ?? 0);
-                hashCode = (hashCode * 397) ^ this.AnchorPoint.GetHashCode();
-                return hashCode;
+                return (hashCode * 397) ^ this.AnchorPoint.GetHashCode();
             }
         }
     }

--- a/src/ImageProcessor/Imaging/Resizer.cs
+++ b/src/ImageProcessor/Imaging/Resizer.cs
@@ -15,7 +15,6 @@ namespace ImageProcessor.Imaging
     using System.Drawing;
     using System.Drawing.Drawing2D;
     using System.Drawing.Imaging;
-    using System.Linq;
 
     using ImageProcessor.Common.Exceptions;
     using ImageProcessor.Common.Extensions;
@@ -33,10 +32,7 @@ namespace ImageProcessor.Imaging
         /// <param name="size">
         /// The <see cref="Size"/> to resize the image to.
         /// </param>
-        public Resizer(Size size)
-        {
-            this.ResizeLayer = new ResizeLayer(size);
-        }
+        public Resizer(Size size) => this.ResizeLayer = new ResizeLayer(size);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Resizer"/> class.
@@ -44,10 +40,7 @@ namespace ImageProcessor.Imaging
         /// <param name="resizeLayer">
         /// The <see cref="ResizeLayer"/>.
         /// </param>
-        public Resizer(ResizeLayer resizeLayer)
-        {
-            this.ResizeLayer = resizeLayer;
-        }
+        public Resizer(ResizeLayer resizeLayer) => this.ResizeLayer = resizeLayer;
 
         /// <summary>
         /// Gets or sets the <see cref="ResizeLayer"/>.
@@ -100,13 +93,13 @@ namespace ImageProcessor.Imaging
         /// </returns>
         protected virtual Bitmap ResizeComposite(Image source, int width, int height, Rectangle destination)
         {
-            Bitmap resized = new Bitmap(width, height, PixelFormat.Format32bppPArgb);
+            var resized = new Bitmap(width, height, PixelFormat.Format32bppPArgb);
             resized.SetResolution(source.HorizontalResolution, source.VerticalResolution);
 
-            using (Graphics graphics = Graphics.FromImage(resized))
+            using (var graphics = Graphics.FromImage(resized))
             {
                 GraphicsHelper.SetGraphicsOptions(graphics);
-                using (ImageAttributes attributes = new ImageAttributes())
+                using (var attributes = new ImageAttributes())
                 {
                     attributes.SetWrapMode(WrapMode.TileFlipXY);
                     graphics.DrawImage(source, destination, 0, 0, source.Width, source.Height, GraphicsUnit.Pixel, attributes);
@@ -126,10 +119,7 @@ namespace ImageProcessor.Imaging
         /// <returns>
         /// The <see cref="Bitmap"/>.
         /// </returns>
-        protected virtual Bitmap ResizeLinear(Image source, int width, int height, Rectangle destination)
-        {
-            return this.ResizeLinear(source, width, height, destination, this.AnimationProcessMode);
-        }
+        protected virtual Bitmap ResizeLinear(Image source, int width, int height, Rectangle destination) => this.ResizeLinear(source, width, height, destination, this.AnimationProcessMode);
 
         /// <summary>
         /// Gets an image resized using the linear color space with gamma correction adjustments.
@@ -147,13 +137,13 @@ namespace ImageProcessor.Imaging
             // Adjust the gamma value so that the image is in the linear color space.
             Bitmap linear = Adjustments.ToLinear(source.Copy(animationProcessMode));
 
-            Bitmap resized = new Bitmap(width, height, PixelFormat.Format32bppPArgb);
+            var resized = new Bitmap(width, height, PixelFormat.Format32bppPArgb);
             resized.SetResolution(source.HorizontalResolution, source.VerticalResolution);
 
-            using (Graphics graphics = Graphics.FromImage(resized))
+            using (var graphics = Graphics.FromImage(resized))
             {
                 GraphicsHelper.SetGraphicsOptions(graphics);
-                using (ImageAttributes attributes = new ImageAttributes())
+                using (var attributes = new ImageAttributes())
                 {
                     attributes.SetWrapMode(WrapMode.TileFlipXY);
                     graphics.DrawImage(linear, destination, 0, 0, source.Width, source.Height, GraphicsUnit.Pixel, attributes);
@@ -379,7 +369,7 @@ namespace ImageProcessor.Imaging
                     {
                         ratio = percentWidth;
 
-                        if (centerCoordinates != null && centerCoordinates.Any())
+                        if (centerCoordinates?.Length > 0)
                         {
                             double center = -(ratio * sourceHeight) * centerCoordinates[0];
                             destinationY = (int)center + (height / 2);
@@ -420,7 +410,7 @@ namespace ImageProcessor.Imaging
                     {
                         ratio = percentHeight;
 
-                        if (centerCoordinates != null && centerCoordinates.Any())
+                        if (centerCoordinates?.Length > 0)
                         {
                             double center = -(ratio * sourceWidth) * centerCoordinates[1];
                             destinationX = (int)center + (width / 2);
@@ -543,7 +533,7 @@ namespace ImageProcessor.Imaging
                 }
 
                 // Restrict sizes
-                if (restrictedSizes != null && restrictedSizes.Any())
+                if (restrictedSizes?.Count > 0)
                 {
                     bool reject = true;
                     foreach (Size restrictedSize in restrictedSizes)
@@ -570,13 +560,13 @@ namespace ImageProcessor.Imaging
                 if (width > 0 && height > 0 && width <= maxWidth && height <= maxHeight)
                 {
                     // Exit if upscaling is not allowed.
-                    if ((width > sourceWidth || height > sourceHeight) && upscale == false && resizeMode != ResizeMode.Stretch)
+                    if ((width > sourceWidth || height > sourceHeight) && !upscale && resizeMode != ResizeMode.Stretch)
                     {
                         return (Bitmap)source;
                     }
 
                     // Do the resize.
-                    Rectangle destination = new Rectangle(destinationX, destinationY, destinationWidth, destinationHeight);
+                    var destination = new Rectangle(destinationX, destinationY, destinationWidth, destinationHeight);
 
                     newImage = linear ? this.ResizeLinear(source, width, height, destination, this.AnimationProcessMode) : this.ResizeComposite(source, width, height, destination);
 

--- a/src/ImageProcessor/Imaging/RoundedCornerLayer.cs
+++ b/src/ImageProcessor/Imaging/RoundedCornerLayer.cs
@@ -42,7 +42,6 @@ namespace ImageProcessor.Imaging
             this.BottomRight = bottomRight;
         }
 
-        #region Properties
         /// <summary>
         /// Gets or sets the radius of the corners.
         /// </summary>
@@ -67,7 +66,6 @@ namespace ImageProcessor.Imaging
         /// Gets or sets a value indicating whether bottom right corners are to be added.
         /// </summary>
         public bool BottomRight { get; set; }
-        #endregion
 
         /// <summary>
         /// Returns a value that indicates whether the specified object is an 
@@ -83,9 +81,7 @@ namespace ImageProcessor.Imaging
         /// </returns>
         public override bool Equals(object obj)
         {
-            RoundedCornerLayer rounded = obj as RoundedCornerLayer;
-
-            if (rounded == null)
+            if (!(obj is RoundedCornerLayer rounded))
             {
                 return false;
             }
@@ -109,8 +105,7 @@ namespace ImageProcessor.Imaging
                 hashCode = (hashCode * 397) ^ this.TopLeft.GetHashCode();
                 hashCode = (hashCode * 397) ^ this.TopRight.GetHashCode();
                 hashCode = (hashCode * 397) ^ this.BottomLeft.GetHashCode();
-                hashCode = (hashCode * 397) ^ this.BottomRight.GetHashCode();
-                return hashCode;
+                return (hashCode * 397) ^ this.BottomRight.GetHashCode();
             }
         }
     }

--- a/src/ImageProcessor/Imaging/TextLayer.cs
+++ b/src/ImageProcessor/Imaging/TextLayer.cs
@@ -109,9 +109,7 @@ namespace ImageProcessor.Imaging
         /// </returns>
         public override bool Equals(object obj)
         {
-            TextLayer textLayer = obj as TextLayer;
-
-            if (textLayer == null)
+            if (!(obj is TextLayer textLayer))
             {
                 return false;
             }
@@ -147,18 +145,14 @@ namespace ImageProcessor.Imaging
                 hashCode = (hashCode * 397) ^ this.FontSize;
                 hashCode = (hashCode * 397) ^ this.Position.GetHashCode();
                 hashCode = (hashCode * 397) ^ this.Vertical.GetHashCode();
-                hashCode = (hashCode * 397) ^ this.RightToLeft.GetHashCode();
-                return hashCode;
+                return (hashCode * 397) ^ this.RightToLeft.GetHashCode();
             }
         }
 
         /// <summary>
         /// Disposes the object and frees resources for the Garbage Collector.
         /// </summary>
-        public void Dispose()
-        {
-            this.Dispose(true);
-        }
+        public void Dispose() => this.Dispose(true);
 
         /// <summary>
         /// Disposes the object and frees resources for the Garbage Collector.

--- a/src/ImageProcessor/Processors/Alpha.cs
+++ b/src/ImageProcessor/Processors/Alpha.cs
@@ -25,10 +25,7 @@ namespace ImageProcessor.Processors
         /// <summary>
         /// Initializes a new instance of the <see cref="Alpha"/> class.
         /// </summary>
-        public Alpha()
-        {
-            this.Settings = new Dictionary<string, string>();
-        }
+        public Alpha() => this.Settings = new Dictionary<string, string>();
 
         /// <summary>
         /// Gets or sets the dynamic parameter.

--- a/src/ImageProcessor/Processors/AutoRotate.cs
+++ b/src/ImageProcessor/Processors/AutoRotate.cs
@@ -33,10 +33,7 @@ namespace ImageProcessor.Processors
         /// <summary>
         /// Initializes a new instance of the <see cref="AutoRotate"/> class.
         /// </summary>
-        public AutoRotate()
-        {
-            this.Settings = new Dictionary<string, string>();
-        }
+        public AutoRotate() => this.Settings = new Dictionary<string, string>();
 
         /// <summary>
         /// Gets or sets DynamicParameter.

--- a/src/ImageProcessor/Processors/Background.cs
+++ b/src/ImageProcessor/Processors/Background.cs
@@ -28,10 +28,7 @@ namespace ImageProcessor.Processors
         /// <summary>
         /// Initializes a new instance of the <see cref="Background"/> class.
         /// </summary>
-        public Background()
-        {
-            this.Settings = new Dictionary<string, string>();
-        }
+        public Background() => this.Settings = new Dictionary<string, string>();
 
         /// <summary>
         /// Gets or sets the dynamic parameter.
@@ -87,16 +84,16 @@ namespace ImageProcessor.Processors
                 if (image.Size != background.Size || image.Size != new Size(backgroundWidth, backgroundHeight))
                 {
                     // Find the maximum possible dimensions and resize the image.
-                    ResizeLayer layer = new ResizeLayer(new Size(backgroundWidth, backgroundHeight), ResizeMode.Max);
-                    Resizer resizer = new Resizer(layer) { AnimationProcessMode = factory.AnimationProcessMode };
+                    var layer = new ResizeLayer(new Size(backgroundWidth, backgroundHeight), ResizeMode.Max);
+                    var resizer = new Resizer(layer) { AnimationProcessMode = factory.AnimationProcessMode };
                     background = resizer.ResizeImage(background, factory.FixGamma);
                     backgroundWidth = background.Width;
                     backgroundHeight = background.Height;
                 }
 
                 // Figure out bounds.
-                Rectangle parent = new Rectangle(0, 0, width, height);
-                Rectangle child = new Rectangle(0, 0, backgroundWidth, backgroundHeight);
+                var parent = new Rectangle(0, 0, width, height);
+                var child = new Rectangle(0, 0, backgroundWidth, backgroundHeight);
 
                 // Apply opacity.
                 if (opacity < 100)
@@ -107,7 +104,7 @@ namespace ImageProcessor.Processors
                 newImage = new Bitmap(width, height, PixelFormat.Format32bppPArgb);
                 newImage.SetResolution(image.HorizontalResolution, image.VerticalResolution);
 
-                using (Graphics graphics = Graphics.FromImage(newImage))
+                using (var graphics = Graphics.FromImage(newImage))
                 {
                     GraphicsHelper.SetGraphicsOptions(graphics, true);
 

--- a/src/ImageProcessor/Processors/BackgroundColor.cs
+++ b/src/ImageProcessor/Processors/BackgroundColor.cs
@@ -26,10 +26,7 @@ namespace ImageProcessor.Processors
         /// <summary>
         /// Initializes a new instance of the <see cref="BackgroundColor"/> class.
         /// </summary>
-        public BackgroundColor()
-        {
-            this.Settings = new Dictionary<string, string>();
-        }
+        public BackgroundColor() => this.Settings = new Dictionary<string, string>();
 
         /// <summary>
         /// Gets or sets the DynamicParameter.
@@ -65,7 +62,7 @@ namespace ImageProcessor.Processors
                 newImage.SetResolution(image.HorizontalResolution, image.VerticalResolution);
 
                 // Make a graphics object from the empty bitmap.
-                using (Graphics graphics = Graphics.FromImage(newImage))
+                using (var graphics = Graphics.FromImage(newImage))
                 {
                     GraphicsHelper.SetGraphicsOptions(graphics, true);
 

--- a/src/ImageProcessor/Processors/Brightness.cs
+++ b/src/ImageProcessor/Processors/Brightness.cs
@@ -25,10 +25,7 @@ namespace ImageProcessor.Processors
         /// <summary>
         /// Initializes a new instance of the <see cref="Brightness"/> class.
         /// </summary>
-        public Brightness()
-        {
-            this.Settings = new Dictionary<string, string>();
-        }
+        public Brightness() => this.Settings = new Dictionary<string, string>();
 
         /// <summary>
         /// Gets or sets DynamicParameter.

--- a/src/ImageProcessor/Processors/Contrast.cs
+++ b/src/ImageProcessor/Processors/Contrast.cs
@@ -25,10 +25,7 @@ namespace ImageProcessor.Processors
         /// <summary>
         /// Initializes a new instance of the <see cref="Contrast"/> class.
         /// </summary>
-        public Contrast()
-        {
-            this.Settings = new Dictionary<string, string>();
-        }
+        public Contrast() => this.Settings = new Dictionary<string, string>();
 
         /// <summary>
         /// Gets or sets DynamicParameter.

--- a/src/ImageProcessor/Processors/Crop.cs
+++ b/src/ImageProcessor/Processors/Crop.cs
@@ -15,7 +15,6 @@ namespace ImageProcessor.Processors
     using System.Drawing;
     using System.Drawing.Drawing2D;
     using System.Drawing.Imaging;
-    using System.Linq;
 
     using ImageProcessor.Common.Exceptions;
     using ImageProcessor.Imaging;
@@ -30,10 +29,7 @@ namespace ImageProcessor.Processors
         /// <summary>
         /// Initializes a new instance of the <see cref="Crop"/> class.
         /// </summary>
-        public Crop()
-        {
-            this.Settings = new Dictionary<string, string>();
-        }
+        public Crop() => this.Settings = new Dictionary<string, string>();
 
         /// <summary>
         /// Gets or sets DynamicParameter.
@@ -95,7 +91,7 @@ namespace ImageProcessor.Processors
                     rectangleF = new RectangleF(cropLayer.Left, cropLayer.Top, cropLayer.Right, cropLayer.Bottom);
                 }
 
-                Rectangle rectangle = Rectangle.Round(rectangleF);
+                var rectangle = Rectangle.Round(rectangleF);
 
                 if (rectangle.X < sourceWidth && rectangle.Y < sourceHeight)
                 {
@@ -121,7 +117,7 @@ namespace ImageProcessor.Processors
                         this.ForwardRotateFlip(rotationValue, ref image);
                     }
 
-                    using (Graphics graphics = Graphics.FromImage(newImage))
+                    using (var graphics = Graphics.FromImage(newImage))
                     {
                         GraphicsHelper.SetGraphicsOptions(graphics);
 
@@ -129,7 +125,7 @@ namespace ImageProcessor.Processors
                         // as the algorithm appears to be pulling averaging detail from surrounding pixels beyond the edge 
                         // of the image. Using the ImageAttributes class to specify that the pixels beyond are simply mirror 
                         // images of the pixels within solves this problem.
-                        using (ImageAttributes wrapMode = new ImageAttributes())
+                        using (var wrapMode = new ImageAttributes())
                         {
                             wrapMode.SetWrapMode(WrapMode.TileFlipXY);
 
@@ -154,7 +150,7 @@ namespace ImageProcessor.Processors
                         this.ReverseRotateFlip(rotationValue, ref image);
                     }
 
-                    if (factory.PreserveExifData && factory.ExifPropertyItems.Any())
+                    if (factory.PreserveExifData && factory.ExifPropertyItems.Count > 0)
                     {
                         // Set the width EXIF data.
                         factory.SetPropertyItem(ExifPropertyTag.ImageWidth, (ushort)image.Width);

--- a/src/ImageProcessor/Processors/DetectEdges.cs
+++ b/src/ImageProcessor/Processors/DetectEdges.cs
@@ -25,10 +25,7 @@ namespace ImageProcessor.Processors
         /// <summary>
         /// Initializes a new instance of the <see cref="DetectEdges"/> class.
         /// </summary>
-        public DetectEdges()
-        {
-            this.Settings = new Dictionary<string, string>();
-        }
+        public DetectEdges() => this.Settings = new Dictionary<string, string>();
 
         /// <summary>
         /// Gets or sets the dynamic parameter.
@@ -67,7 +64,7 @@ namespace ImageProcessor.Processors
 
             try
             {
-                ConvolutionFilter convolutionFilter = new ConvolutionFilter(filter, greyscale);
+                var convolutionFilter = new ConvolutionFilter(filter, greyscale);
 
                 // Check and assign the correct method. Don't use reflection for speed.
                 return filter is I2DEdgeFilter

--- a/src/ImageProcessor/Processors/EntropyCrop.cs
+++ b/src/ImageProcessor/Processors/EntropyCrop.cs
@@ -11,7 +11,6 @@ namespace ImageProcessor.Processors
     using System.Collections.Generic;
     using System.Drawing;
     using System.Drawing.Imaging;
-    using System.Linq;
 
     using ImageProcessor.Common.Exceptions;
     using ImageProcessor.Imaging.Filters.Binarization;
@@ -27,10 +26,7 @@ namespace ImageProcessor.Processors
         /// <summary>
         /// Initializes a new instance of the <see cref="EntropyCrop"/> class.
         /// </summary>
-        public EntropyCrop()
-        {
-            this.Settings = new Dictionary<string, string>();
-        }
+        public EntropyCrop() => this.Settings = new Dictionary<string, string>();
 
         /// <summary>
         /// Gets or sets the dynamic parameter.
@@ -71,7 +67,7 @@ namespace ImageProcessor.Processors
 
                 newImage = new Bitmap(rectangle.Width, rectangle.Height, PixelFormat.Format32bppPArgb);
                 newImage.SetResolution(image.HorizontalResolution, image.VerticalResolution);
-                using (Graphics graphics = Graphics.FromImage(newImage))
+                using (var graphics = Graphics.FromImage(newImage))
                 {
                     graphics.DrawImage(
                                      image,
@@ -87,7 +83,7 @@ namespace ImageProcessor.Processors
                 image.Dispose();
                 image = newImage;
 
-                if (factory.PreserveExifData && factory.ExifPropertyItems.Any())
+                if (factory.PreserveExifData && factory.ExifPropertyItems.Count > 0)
                 {
                     // Set the width EXIF data.
                     factory.SetPropertyItem(ExifPropertyTag.ImageWidth, (ushort)image.Width);

--- a/src/ImageProcessor/Processors/Filter.cs
+++ b/src/ImageProcessor/Processors/Filter.cs
@@ -26,10 +26,7 @@ namespace ImageProcessor.Processors
         /// <summary>
         /// Initializes a new instance of the <see cref="Filter"/> class.
         /// </summary>
-        public Filter()
-        {
-            this.Settings = new Dictionary<string, string>();
-        }
+        public Filter() => this.Settings = new Dictionary<string, string>();
 
         /// <summary>
         /// Gets or sets DynamicParameter.
@@ -71,7 +68,7 @@ namespace ImageProcessor.Processors
                 newImage.SetResolution(image.HorizontalResolution, image.VerticalResolution);
                 IMatrixFilter matrix = this.DynamicParameter;
                 newImage = matrix.TransformImage(image, newImage);
-                
+
                 image.Dispose();
                 image = newImage;
             }

--- a/src/ImageProcessor/Processors/Flip.cs
+++ b/src/ImageProcessor/Processors/Flip.cs
@@ -13,7 +13,6 @@ namespace ImageProcessor.Processors
     using System;
     using System.Collections.Generic;
     using System.Drawing;
-    using System.Linq;
 
     using ImageProcessor.Common.Exceptions;
     using ImageProcessor.Imaging.MetaData;
@@ -26,10 +25,7 @@ namespace ImageProcessor.Processors
         /// <summary>
         /// Initializes a new instance of the <see cref="Flip"/> class.
         /// </summary>
-        public Flip()
-        {
-            this.Settings = new Dictionary<string, string>();
-        }
+        public Flip() => this.Settings = new Dictionary<string, string>();
 
         /// <summary>
         /// Gets or sets DynamicParameter.
@@ -70,7 +66,7 @@ namespace ImageProcessor.Processors
                 // Flip
                 image.RotateFlip(rotateFlipType);
 
-                if (factory.PreserveExifData && factory.ExifPropertyItems.Any())
+                if (factory.PreserveExifData && factory.ExifPropertyItems.Count > 0)
                 {
                     // Set the width EXIF data.
                     factory.SetPropertyItem(ExifPropertyTag.ImageWidth, (ushort)image.Width);

--- a/src/ImageProcessor/Processors/Format.cs
+++ b/src/ImageProcessor/Processors/Format.cs
@@ -25,10 +25,7 @@ namespace ImageProcessor.Processors
         /// <summary>
         /// Initializes a new instance of the <see cref="Format"/> class.
         /// </summary>
-        public Format()
-        {
-            this.Settings = new Dictionary<string, string>();
-        }
+        public Format() => this.Settings = new Dictionary<string, string>();
 
         /// <summary>
         /// Gets or sets DynamicParameter.

--- a/src/ImageProcessor/Processors/Gamma.cs
+++ b/src/ImageProcessor/Processors/Gamma.cs
@@ -25,10 +25,7 @@ namespace ImageProcessor.Processors
         /// <summary>
         /// Initializes a new instance of the <see cref="Gamma"/> class.
         /// </summary>
-        public Gamma()
-        {
-            this.Settings = new Dictionary<string, string>();
-        }
+        public Gamma() => this.Settings = new Dictionary<string, string>();
 
         /// <summary>
         /// Gets or sets the dynamic parameter.

--- a/src/ImageProcessor/Processors/GaussianBlur.cs
+++ b/src/ImageProcessor/Processors/GaussianBlur.cs
@@ -25,10 +25,7 @@ namespace ImageProcessor.Processors
         /// <summary>
         /// Initializes a new instance of the <see cref="GaussianBlur"/> class.
         /// </summary>
-        public GaussianBlur()
-        {
-            this.Settings = new Dictionary<string, string>();
-        }
+        public GaussianBlur() => this.Settings = new Dictionary<string, string>();
 
         /// <summary>
         /// Gets or sets the DynamicParameter.
@@ -50,12 +47,12 @@ namespace ImageProcessor.Processors
         /// </returns>
         public Image ProcessImage(ImageFactory factory)
         {
-            Bitmap image = (Bitmap)factory.Image;
+            var image = (Bitmap)factory.Image;
 
             try
             {
                 GaussianLayer gaussianLayer = this.DynamicParameter;
-                Convolution convolution = new Convolution(gaussianLayer.Sigma) { Threshold = gaussianLayer.Threshold };
+                var convolution = new Convolution(gaussianLayer.Sigma) { Threshold = gaussianLayer.Threshold };
                 double[,] kernel = convolution.CreateGuassianBlurFilter(gaussianLayer.Size);
 
                 return convolution.ProcessKernel(image, kernel, factory.FixGamma);

--- a/src/ImageProcessor/Processors/GaussianSharpen.cs
+++ b/src/ImageProcessor/Processors/GaussianSharpen.cs
@@ -25,10 +25,7 @@ namespace ImageProcessor.Processors
         /// <summary>
         /// Initializes a new instance of the <see cref="GaussianSharpen"/> class.
         /// </summary>
-        public GaussianSharpen()
-        {
-            this.Settings = new Dictionary<string, string>();
-        }
+        public GaussianSharpen() => this.Settings = new Dictionary<string, string>();
 
         /// <summary>
         /// Gets or sets the DynamicParameter.
@@ -50,12 +47,12 @@ namespace ImageProcessor.Processors
         /// </returns>
         public Image ProcessImage(ImageFactory factory)
         {
-            Bitmap image = (Bitmap)factory.Image;
+            var image = (Bitmap)factory.Image;
 
             try
             {
                 GaussianLayer gaussianLayer = this.DynamicParameter;
-                Convolution convolution = new Convolution(gaussianLayer.Sigma) { Threshold = gaussianLayer.Threshold };
+                var convolution = new Convolution(gaussianLayer.Sigma) { Threshold = gaussianLayer.Threshold };
                 double[,] kernel = convolution.CreateGuassianSharpenFilter(gaussianLayer.Size);
 
                 return convolution.ProcessKernel(image, kernel, factory.FixGamma);

--- a/src/ImageProcessor/Processors/Halftone.cs
+++ b/src/ImageProcessor/Processors/Halftone.cs
@@ -27,10 +27,7 @@ namespace ImageProcessor.Processors
         /// <summary>
         /// Initializes a new instance of the <see cref="Halftone"/> class.
         /// </summary>
-        public Halftone()
-        {
-            this.Settings = new Dictionary<string, string>();
-        }
+        public Halftone() => this.Settings = new Dictionary<string, string>();
 
         /// <summary>
         /// Gets or sets the dynamic parameter.
@@ -69,7 +66,7 @@ namespace ImageProcessor.Processors
             Bitmap edgeBitmap = null;
             try
             {
-                HalftoneFilter filter = new HalftoneFilter(5);
+                var filter = new HalftoneFilter(5);
                 newImage = new Bitmap(image);
                 newImage.SetResolution(image.HorizontalResolution, image.VerticalResolution);
                 newImage = filter.ApplyFilter(newImage);
@@ -82,14 +79,14 @@ namespace ImageProcessor.Processors
                     edgeBitmap.SetResolution(image.HorizontalResolution, image.VerticalResolution);
                     edgeBitmap = Effects.Trace(image, edgeBitmap, 120);
 
-                    using (Graphics graphics = Graphics.FromImage(newImage))
+                    using (var graphics = Graphics.FromImage(newImage))
                     {
                         // Overlay the image.
                         graphics.DrawImage(edgeBitmap, 0, 0);
-                        Rectangle rectangle = new Rectangle(0, 0, width, height);
+                        var rectangle = new Rectangle(0, 0, width, height);
 
                         // Draw an edge around the image.
-                        using (Pen blackPen = new Pen(Color.Black))
+                        using (var blackPen = new Pen(Color.Black))
                         {
                             blackPen.Width = 4;
                             graphics.DrawRectangle(blackPen, rectangle);

--- a/src/ImageProcessor/Processors/Hue.cs
+++ b/src/ImageProcessor/Processors/Hue.cs
@@ -25,10 +25,7 @@ namespace ImageProcessor.Processors
         /// <summary>
         /// Initializes a new instance of the <see cref="Hue"/> class.
         /// </summary>
-        public Hue()
-        {
-            this.Settings = new Dictionary<string, string>();
-        }
+        public Hue() => this.Settings = new Dictionary<string, string>();
 
         /// <summary>
         /// Gets or sets the dynamic parameter.
@@ -67,7 +64,7 @@ namespace ImageProcessor.Processors
 
                 int width = image.Width;
                 int height = image.Height;
-                using (FastBitmap fastBitmap = new FastBitmap(image))
+                using (var fastBitmap = new FastBitmap(image))
                 {
                     if (!rotate)
                     {
@@ -75,8 +72,8 @@ namespace ImageProcessor.Processors
                         {
                             for (int x = 0; x < width; x++)
                             {
-                                HslaColor original = HslaColor.FromColor(fastBitmap.GetPixel(x, y));
-                                HslaColor altered = HslaColor.FromHslaColor(degrees / 360f, original.S, original.L, original.A);
+                                var original = HslaColor.FromColor(fastBitmap.GetPixel(x, y));
+                                var altered = HslaColor.FromHslaColor(degrees / 360f, original.S, original.L, original.A);
                                 fastBitmap.SetPixel(x, y, altered);
                             }
                         }
@@ -87,8 +84,8 @@ namespace ImageProcessor.Processors
                         {
                             for (int x = 0; x < width; x++)
                             {
-                                HslaColor original = HslaColor.FromColor(fastBitmap.GetPixel(x, y));
-                                HslaColor altered = HslaColor.FromHslaColor((original.H + (degrees / 360f)) % 1, original.S, original.L, original.A);
+                                var original = HslaColor.FromColor(fastBitmap.GetPixel(x, y));
+                                var altered = HslaColor.FromHslaColor((original.H + (degrees / 360f)) % 1, original.S, original.L, original.A);
                                 fastBitmap.SetPixel(x, y, altered);
                             }
                         }

--- a/src/ImageProcessor/Processors/Mask.cs
+++ b/src/ImageProcessor/Processors/Mask.cs
@@ -29,10 +29,7 @@ namespace ImageProcessor.Processors
         /// <summary>
         /// Initializes a new instance of the <see cref="Mask"/> class.
         /// </summary>
-        public Mask()
-        {
-            this.Settings = new Dictionary<string, string>();
-        }
+        public Mask() => this.Settings = new Dictionary<string, string>();
 
         /// <summary>
         /// Gets or sets the dynamic parameter.
@@ -81,13 +78,13 @@ namespace ImageProcessor.Processors
 
                 if (mask.Size != image.Size)
                 {
-                    Rectangle parent = new Rectangle(0, 0, width, height);
+                    var parent = new Rectangle(0, 0, width, height);
                     Rectangle child = ImageMaths.GetFilteredBoundingRectangle(mask, 0, RgbaComponent.A);
                     maskCropped = new Bitmap(child.Width, child.Height, PixelFormat.Format32bppPArgb);
                     maskCropped.SetResolution(image.HorizontalResolution, image.VerticalResolution);
 
                     // First crop any bounding transparency.
-                    using (Graphics graphics = Graphics.FromImage(maskCropped))
+                    using (var graphics = Graphics.FromImage(maskCropped))
                     {
                         GraphicsHelper.SetGraphicsOptions(graphics);
 
@@ -105,7 +102,7 @@ namespace ImageProcessor.Processors
                     // Now position the mask in an image of the same dimensions as the original.
                     maskPositioned = new Bitmap(width, height, PixelFormat.Format32bppPArgb);
                     maskPositioned.SetResolution(image.HorizontalResolution, image.VerticalResolution);
-                    using (Graphics graphics = Graphics.FromImage(maskPositioned))
+                    using (var graphics = Graphics.FromImage(maskPositioned))
                     {
                         GraphicsHelper.SetGraphicsOptions(graphics, true);
                         graphics.Clear(Color.Transparent);

--- a/src/ImageProcessor/Processors/Meta.cs
+++ b/src/ImageProcessor/Processors/Meta.cs
@@ -24,10 +24,7 @@ namespace ImageProcessor.Processors
         /// <summary>
         /// Initializes a new instance of the <see cref="Meta"/> class.
         /// </summary>
-        public Meta()
-        {
-            this.Settings = new Dictionary<string, string>();
-        }
+        public Meta() => this.Settings = new Dictionary<string, string>();
 
         /// <summary>
         /// Gets or sets DynamicParameter.

--- a/src/ImageProcessor/Processors/Overlay.cs
+++ b/src/ImageProcessor/Processors/Overlay.cs
@@ -27,10 +27,7 @@ namespace ImageProcessor.Processors
         /// <summary>
         /// Initializes a new instance of the <see cref="Overlay"/> class.
         /// </summary>
-        public Overlay()
-        {
-            this.Settings = new Dictionary<string, string>();
-        }
+        public Overlay() => this.Settings = new Dictionary<string, string>();
 
         /// <summary>
         /// Gets or sets the dynamic parameter.
@@ -85,16 +82,16 @@ namespace ImageProcessor.Processors
                 if (image.Size != overlay.Size || image.Size != new Size(overlayWidth, overlayHeight))
                 {
                     // Find the maximum possible dimensions and resize the image.
-                    ResizeLayer layer = new ResizeLayer(new Size(overlayWidth, overlayHeight), ResizeMode.Max);
-                    Resizer resizer = new Resizer(layer) { AnimationProcessMode = factory.AnimationProcessMode };
+                    var layer = new ResizeLayer(new Size(overlayWidth, overlayHeight), ResizeMode.Max);
+                    var resizer = new Resizer(layer) { AnimationProcessMode = factory.AnimationProcessMode };
                     overlay = resizer.ResizeImage(overlay, factory.FixGamma);
                     overlayWidth = overlay.Width;
                     overlayHeight = overlay.Height;
                 }
 
                 // Figure out bounds.
-                Rectangle parent = new Rectangle(0, 0, width, height);
-                Rectangle child = new Rectangle(0, 0, overlayWidth, overlayHeight);
+                var parent = new Rectangle(0, 0, width, height);
+                var child = new Rectangle(0, 0, overlayWidth, overlayHeight);
 
                 // Apply opacity.
                 if (opacity < 100)
@@ -102,7 +99,7 @@ namespace ImageProcessor.Processors
                     overlay = Adjustments.Alpha(overlay, opacity);
                 }
 
-                using (Graphics graphics = Graphics.FromImage(image))
+                using (var graphics = Graphics.FromImage(image))
                 {
                     GraphicsHelper.SetGraphicsOptions(graphics, true);
 

--- a/src/ImageProcessor/Processors/Pixelate.cs
+++ b/src/ImageProcessor/Processors/Pixelate.cs
@@ -27,10 +27,7 @@ namespace ImageProcessor.Processors
         /// <summary>
         /// Initializes a new instance of the <see cref="Pixelate"/> class.
         /// </summary>
-        public Pixelate()
-        {
-            this.Settings = new Dictionary<string, string>();
-        }
+        public Pixelate() => this.Settings = new Dictionary<string, string>();
 
         /// <summary>
         /// Gets or sets the dynamic parameter.
@@ -81,10 +78,12 @@ namespace ImageProcessor.Processors
                 newImage = new Bitmap(image);
                 newImage.SetResolution(image.HorizontalResolution, image.VerticalResolution);
 
-                using (FastBitmap fastBitmap = new FastBitmap(newImage))
+                using (var fastBitmap = new FastBitmap(newImage))
                 {
                     // Get the range on the y-plane to choose from.
+#pragma warning disable RCS1196 // Call extension method as instance method.
                     IEnumerable<int> range = EnumerableExtensions.SteppedRange(y, i => i < y + height && i < maxHeight, size);
+#pragma warning restore RCS1196 // Call extension method as instance method.
 
                     Parallel.ForEach(
                         range,

--- a/src/ImageProcessor/Processors/Quality.cs
+++ b/src/ImageProcessor/Processors/Quality.cs
@@ -24,10 +24,7 @@ namespace ImageProcessor.Processors
         /// <summary>
         /// Initializes a new instance of the <see cref="Quality"/> class.
         /// </summary>
-        public Quality()
-        {
-            this.Settings = new Dictionary<string, string>();
-        }
+        public Quality() => this.Settings = new Dictionary<string, string>();
 
         /// <summary>
         /// Gets or sets DynamicParameter.

--- a/src/ImageProcessor/Processors/ReplaceColor.cs
+++ b/src/ImageProcessor/Processors/ReplaceColor.cs
@@ -28,10 +28,7 @@ namespace ImageProcessor.Processors
         /// <summary>
         /// Initializes a new instance of the <see cref="ReplaceColor"/> class.
         /// </summary>
-        public ReplaceColor()
-        {
-            this.Settings = new Dictionary<string, string>();
-        }
+        public ReplaceColor() => this.Settings = new Dictionary<string, string>();
 
         /// <summary>
         /// Gets or sets the dynamic parameter.
@@ -97,7 +94,7 @@ namespace ImageProcessor.Processors
                 int width = image.Width;
                 int height = image.Height;
 
-                using (FastBitmap fastBitmap = new FastBitmap(newImage))
+                using (var fastBitmap = new FastBitmap(newImage))
                 {
                     Parallel.For(
                         0,

--- a/src/ImageProcessor/Processors/Resize.cs
+++ b/src/ImageProcessor/Processors/Resize.cs
@@ -14,7 +14,6 @@ namespace ImageProcessor.Processors
     using System.Collections.Generic;
     using System.Drawing;
     using System.Globalization;
-    using System.Linq;
 
     using ImageProcessor.Common.Exceptions;
     using ImageProcessor.Imaging;
@@ -78,18 +77,15 @@ namespace ImageProcessor.Processors
 
                 // Augment the layer with the extra information.
                 resizeLayer.RestrictedSizes = this.RestrictedSizes;
-                Size maxSize = new Size();
-
-                int maxWidth;
-                int maxHeight;
-                int.TryParse(this.Settings["MaxWidth"], NumberStyles.Any, CultureInfo.InvariantCulture, out maxWidth);
-                int.TryParse(this.Settings["MaxHeight"], NumberStyles.Any, CultureInfo.InvariantCulture, out maxHeight);
+                var maxSize = new Size();
+                int.TryParse(this.Settings["MaxWidth"], NumberStyles.Any, CultureInfo.InvariantCulture, out int maxWidth);
+                int.TryParse(this.Settings["MaxHeight"], NumberStyles.Any, CultureInfo.InvariantCulture, out int maxHeight);
 
                 maxSize.Width = maxWidth;
                 maxSize.Height = maxHeight;
 
                 resizeLayer.MaxSize = maxSize;
-                Resizer resizer = new Resizer(resizeLayer) { ImageFormat = factory.CurrentImageFormat, AnimationProcessMode = factory.AnimationProcessMode };
+                var resizer = new Resizer(resizeLayer) { ImageFormat = factory.CurrentImageFormat, AnimationProcessMode = factory.AnimationProcessMode };
                 newImage = resizer.ResizeImage(image, factory.FixGamma);
 
                 // Check that the original image has not been returned.
@@ -99,7 +95,7 @@ namespace ImageProcessor.Processors
                     image.Dispose();
                     image = newImage;
 
-                    if (factory.PreserveExifData && factory.ExifPropertyItems.Any())
+                    if (factory.PreserveExifData && factory.ExifPropertyItems.Count > 0)
                     {
                         // Set the width EXIF data.
                         factory.SetPropertyItem(ExifPropertyTag.ImageWidth, (ushort)image.Width);

--- a/src/ImageProcessor/Processors/Resolution.cs
+++ b/src/ImageProcessor/Processors/Resolution.cs
@@ -13,7 +13,6 @@ namespace ImageProcessor.Processors
     using System;
     using System.Collections.Generic;
     using System.Drawing;
-    using System.Linq;
 
     using ImageProcessor.Common.Exceptions;
     using ImageProcessor.Imaging.MetaData;
@@ -26,10 +25,7 @@ namespace ImageProcessor.Processors
         /// <summary>
         /// Initializes a new instance of the <see cref="Resolution"/> class.
         /// </summary>
-        public Resolution()
-        {
-            this.Settings = new Dictionary<string, string>();
-        }
+        public Resolution() => this.Settings = new Dictionary<string, string>();
 
         /// <summary>
         /// Gets or sets the dynamic parameter.
@@ -82,14 +78,14 @@ namespace ImageProcessor.Processors
                     ((Bitmap)image).SetResolution(resolution.Item1, resolution.Item2);
                 }
 
-                if (factory.PreserveExifData && factory.ExifPropertyItems.Any())
+                if (factory.PreserveExifData && factory.ExifPropertyItems.Count > 0)
                 {
                     // Set the horizontal EXIF data.
-                    Rational<uint> horizontalRational = new Rational<uint>((uint)resolution.Item1, 1);
+                    var horizontalRational = new Rational<uint>((uint)resolution.Item1, 1);
                     factory.SetPropertyItem(ExifPropertyTag.XResolution, horizontalRational);
 
                     // Set the vertical EXIF data.
-                    Rational<uint> verticalRational = new Rational<uint>((uint)resolution.Item2, 1);
+                    var verticalRational = new Rational<uint>((uint)resolution.Item2, 1);
                     factory.SetPropertyItem(ExifPropertyTag.YResolution, verticalRational);
 
                     // Set the unit EXIF data

--- a/src/ImageProcessor/Processors/Rotate.cs
+++ b/src/ImageProcessor/Processors/Rotate.cs
@@ -14,7 +14,6 @@ namespace ImageProcessor.Processors
     using System.Collections.Generic;
     using System.Drawing;
     using System.Drawing.Imaging;
-    using System.Linq;
 
     using ImageProcessor.Common.Exceptions;
     using ImageProcessor.Imaging.Helpers;
@@ -28,10 +27,7 @@ namespace ImageProcessor.Processors
         /// <summary>
         /// Initializes a new instance of the <see cref="Rotate"/> class.
         /// </summary>
-        public Rotate()
-        {
-            this.Settings = new Dictionary<string, string>();
-        }
+        public Rotate() => this.Settings = new Dictionary<string, string>();
 
         /// <summary>
         /// Gets or sets DynamicParameter.
@@ -76,7 +72,7 @@ namespace ImageProcessor.Processors
                 // Create a rotated image.
                 image = this.RotateImage(image, rotateAtX, rotateAtY, angle);
 
-                if (factory.PreserveExifData && factory.ExifPropertyItems.Any())
+                if (factory.PreserveExifData && factory.ExifPropertyItems.Count > 0)
                 {
                     // Set the width EXIF data.
                     factory.SetPropertyItem(ExifPropertyTag.ImageWidth, (ushort)image.Width);
@@ -112,11 +108,11 @@ namespace ImageProcessor.Processors
             int y = (newSize.Height - image.Height) / 2;
 
             // Create a new empty bitmap to hold rotated image
-            Bitmap newImage = new Bitmap(newSize.Width, newSize.Height, PixelFormat.Format32bppPArgb);
+            var newImage = new Bitmap(newSize.Width, newSize.Height, PixelFormat.Format32bppPArgb);
             newImage.SetResolution(image.HorizontalResolution, image.VerticalResolution);
 
             // Make a graphics object from the empty bitmap
-            using (Graphics graphics = Graphics.FromImage(newImage))
+            using (var graphics = Graphics.FromImage(newImage))
             {
                 // Reduce the jagged edge.
                 GraphicsHelper.SetGraphicsOptions(graphics);

--- a/src/ImageProcessor/Processors/RotateBounded.cs
+++ b/src/ImageProcessor/Processors/RotateBounded.cs
@@ -14,7 +14,6 @@ namespace ImageProcessor.Processors
     using System.Collections.Generic;
     using System.Drawing;
     using System.Drawing.Imaging;
-    using System.Linq;
 
     using ImageProcessor.Common.Exceptions;
     using ImageProcessor.Imaging.Helpers;
@@ -57,7 +56,7 @@ namespace ImageProcessor.Processors
                 // Create a rotated image.
                 image = this.RotateImage(image, rotateParams.Item1, rotateParams.Item2);
 
-                if (factory.PreserveExifData && factory.ExifPropertyItems.Any())
+                if (factory.PreserveExifData && factory.ExifPropertyItems.Count > 0)
                 {
                     // Set the width EXIF data.
                     factory.SetPropertyItem(ExifPropertyTag.ImageWidth, (ushort)image.Width);
@@ -100,7 +99,7 @@ namespace ImageProcessor.Processors
         /// </returns>
         private Bitmap RotateImage(Image image, float angleInDegrees, bool keepSize)
         {
-            Size newSize = new Size(image.Width, image.Height);
+            var newSize = new Size(image.Width, image.Height);
 
             float zoom = ImageMaths.ZoomAfterRotation(image.Width, image.Height, angleInDegrees);
 
@@ -116,11 +115,11 @@ namespace ImageProcessor.Processors
             float rotateAtY = Math.Abs(image.Height / 2);
 
             // Create a new empty bitmap to hold rotated image
-            Bitmap newImage = new Bitmap(newSize.Width, newSize.Height, PixelFormat.Format32bppPArgb);
+            var newImage = new Bitmap(newSize.Width, newSize.Height, PixelFormat.Format32bppPArgb);
             newImage.SetResolution(image.HorizontalResolution, image.VerticalResolution);
 
             // Make a graphics object from the empty bitmap
-            using (Graphics graphics = Graphics.FromImage(newImage))
+            using (var graphics = Graphics.FromImage(newImage))
             {
                 GraphicsHelper.SetGraphicsOptions(graphics);
 

--- a/src/ImageProcessor/Processors/RoundedCorners.cs
+++ b/src/ImageProcessor/Processors/RoundedCorners.cs
@@ -28,10 +28,7 @@ namespace ImageProcessor.Processors
         /// <summary>
         /// Initializes a new instance of the <see cref="RoundedCorners"/> class.
         /// </summary>
-        public RoundedCorners()
-        {
-            this.Settings = new Dictionary<string, string>();
-        }
+        public RoundedCorners() => this.Settings = new Dictionary<string, string>();
 
         /// <summary>
         /// Gets or sets DynamicParameter.
@@ -75,9 +72,7 @@ namespace ImageProcessor.Processors
                 bool bottomRight = roundedCornerLayer.BottomRight;
 
                 // Create a rounded image.
-                image = this.RoundCornerImage(image, radius, topLeft, topRight, bottomLeft, bottomRight);
-
-                return image;
+                return this.RoundCornerImage(image, radius, topLeft, topRight, bottomLeft, bottomRight);
             }
             catch (Exception ex)
             {
@@ -102,16 +97,16 @@ namespace ImageProcessor.Processors
             int cornerDiameter = cornerRadius * 2;
 
             // Create a new empty bitmap to hold rotated image
-            Bitmap newImage = new Bitmap(image.Width, image.Height, PixelFormat.Format32bppPArgb);
+            var newImage = new Bitmap(image.Width, image.Height, PixelFormat.Format32bppPArgb);
             newImage.SetResolution(image.HorizontalResolution, image.VerticalResolution);
 
             // Make a graphics object from the empty bitmap
-            using (Graphics graphics = Graphics.FromImage(newImage))
+            using (var graphics = Graphics.FromImage(newImage))
             {
                 GraphicsHelper.SetGraphicsOptions(graphics, true, true);
 
                 // Add rounded corners
-                using (GraphicsPath path = new GraphicsPath())
+                using (var path = new GraphicsPath())
                 {
                     // Determined if the top left has a rounded corner
                     if (topLeft)

--- a/src/ImageProcessor/Processors/Saturation.cs
+++ b/src/ImageProcessor/Processors/Saturation.cs
@@ -28,10 +28,7 @@ namespace ImageProcessor.Processors
         /// <summary>
         /// Initializes a new instance of the <see cref="Saturation"/> class.
         /// </summary>
-        public Saturation()
-        {
-            this.Settings = new Dictionary<string, string>();
-        }
+        public Saturation() => this.Settings = new Dictionary<string, string>();
 
         /// <summary>
         /// Gets or sets DynamicParameter.
@@ -84,7 +81,7 @@ namespace ImageProcessor.Processors
                 newImage = new Bitmap(image.Width, image.Height, PixelFormat.Format32bppPArgb);
                 newImage.SetResolution(image.HorizontalResolution, image.VerticalResolution);
 
-                ColorMatrix colorMatrix =
+                var colorMatrix =
                     new ColorMatrix(
                         new[]
                             {
@@ -107,9 +104,9 @@ namespace ImageProcessor.Processors
                                 new float[] { 0, 0, 0, 0, 1 }
                             });
 
-                using (Graphics graphics = Graphics.FromImage(newImage))
+                using (var graphics = Graphics.FromImage(newImage))
                 {
-                    using (ImageAttributes imageAttributes = new ImageAttributes())
+                    using (var imageAttributes = new ImageAttributes())
                     {
                         imageAttributes.SetColorMatrix(colorMatrix);
 

--- a/src/ImageProcessor/Processors/Tint.cs
+++ b/src/ImageProcessor/Processors/Tint.cs
@@ -26,10 +26,7 @@ namespace ImageProcessor.Processors
         /// <summary>
         /// Initializes a new instance of the <see cref="Tint"/> class.
         /// </summary>
-        public Tint()
-        {
-            this.Settings = new Dictionary<string, string>();
-        }
+        public Tint() => this.Settings = new Dictionary<string, string>();
 
         /// <summary>
         /// Gets or sets DynamicParameter.
@@ -68,15 +65,15 @@ namespace ImageProcessor.Processors
                         new float[] { 0, 0, 0, 0, 1 }
                     };
 
-                ColorMatrix colorMatrix = new ColorMatrix(colorMatrixElements);
+                var colorMatrix = new ColorMatrix(colorMatrixElements);
                 newImage = new Bitmap(image.Width, image.Height, PixelFormat.Format32bppPArgb);
                 newImage.SetResolution(image.HorizontalResolution, image.VerticalResolution);
 
-                using (Graphics graphics = Graphics.FromImage(newImage))
+                using (var graphics = Graphics.FromImage(newImage))
                 {
                     GraphicsHelper.SetGraphicsOptions(graphics);
 
-                    using (ImageAttributes attributes = new ImageAttributes())
+                    using (var attributes = new ImageAttributes())
                     {
                         attributes.SetColorMatrix(colorMatrix, ColorMatrixFlag.Default, ColorAdjustType.Bitmap);
                         graphics.DrawImage(image, new Rectangle(0, 0, image.Width, image.Height), 0, 0, image.Width, image.Height, GraphicsUnit.Pixel, attributes);

--- a/src/ImageProcessor/Processors/Vignette.cs
+++ b/src/ImageProcessor/Processors/Vignette.cs
@@ -65,7 +65,7 @@ namespace ImageProcessor.Processors
 
             try
             {
-                Color baseColor = (Color)this.DynamicParameter;
+                var baseColor = (Color)this.DynamicParameter;
                 return Effects.Vignette(image, baseColor);
             }
             catch (Exception ex)

--- a/src/ImageProcessor/Processors/Watermark.cs
+++ b/src/ImageProcessor/Processors/Watermark.cs
@@ -27,10 +27,7 @@ namespace ImageProcessor.Processors
         /// <summary>
         /// Initializes a new instance of the <see cref="Watermark"/> class.
         /// </summary>
-        public Watermark()
-        {
-            this.Settings = new Dictionary<string, string>();
-        }
+        public Watermark() => this.Settings = new Dictionary<string, string>();
 
         /// <summary>
         /// Gets or sets DynamicParameter.
@@ -81,11 +78,11 @@ namespace ImageProcessor.Processors
                     image.RotateFlip(flipType.Value);
                 }
 
-                using (Graphics graphics = Graphics.FromImage(image))
+                using (var graphics = Graphics.FromImage(image))
                 {
                     using (Font font = this.GetFont(textLayer.FontFamily, fontSize, fontStyle))
                     {
-                        using (StringFormat drawFormat = new StringFormat(StringFormat.GenericTypographic))
+                        using (var drawFormat = new StringFormat(StringFormat.GenericTypographic))
                         {
                             StringFormatFlags? formatFlags = this.GetFlags(textLayer);
                             if (formatFlags != null)
@@ -128,7 +125,7 @@ namespace ImageProcessor.Processors
                                         // Scale the shadow position to match the font size.
                                         // Magic number but it's based on artistic preference.
                                         int shadowDiff = (int)Math.Ceiling(fontSize / 24f);
-                                        Point shadowPoint = new Point(origin.Value.X + shadowDiff, origin.Value.Y + shadowDiff);
+                                        var shadowPoint = new Point(origin.Value.X + shadowDiff, origin.Value.Y + shadowDiff);
 
                                         // Set the bounds so any overlapping text will wrap.
                                         if (textLayer.RightToLeft && fallbackUsed)
@@ -208,7 +205,7 @@ namespace ImageProcessor.Processors
             {
                 // Clone the font family and use it. Disposing of the family in the TextLayer is 
                 // the responsibility of the user. 
-                using (FontFamily clone = new FontFamily(fontFamily.Name))
+                using (var clone = new FontFamily(fontFamily.Name))
                 {
                     return new Font(clone, fontSize, fontStyle, GraphicsUnit.Pixel);
                 }

--- a/tests/ImageProcessor.UnitTests/Extensions/EnumerableExtensionsUnitTests.cs
+++ b/tests/ImageProcessor.UnitTests/Extensions/EnumerableExtensionsUnitTests.cs
@@ -20,7 +20,7 @@ namespace ImageProcessor.UnitTests.Extensions
     /// <summary>
     /// The enumerable extensions unit tests.
     /// </summary>
-    public class EnumerableExtensionsUnitTests
+    public static class EnumerableExtensionsUnitTests
     {
         /// <summary>
         /// The when stepped range.
@@ -35,7 +35,7 @@ namespace ImageProcessor.UnitTests.Extensions
             public void ThenShouldReturn1Through9NumbersGiven1Then10Then1()
             {
                 // Arrange // Act
-                var enumerable = EnumerableExtensions.SteppedRange(1, 10, 1);
+                IEnumerable<int> enumerable = EnumerableExtensions.SteppedRange(1, 10, 1);
 
                 // Assert
                 Assert.That(enumerable, Is.EquivalentTo(new List<int> { 1, 2, 3, 4, 5, 6, 7, 8, 9 }));
@@ -48,7 +48,7 @@ namespace ImageProcessor.UnitTests.Extensions
             public void ThenShouldReturnNegative10Through0GivenBetweenRangeNegative10Then1Then1()
             {
                 // Arrange // Act
-                var enumerable = EnumerableExtensions.SteppedRange(-10, 1, 1);
+                IEnumerable<int> enumerable = EnumerableExtensions.SteppedRange(-10, 1, 1);
 
                 // Assert
                 Assert.That(enumerable, Is.EquivalentTo(new List<int> { 0, -1, -2, -3, -4, -5, -6, -7, -8, -9, -10 }));
@@ -61,7 +61,7 @@ namespace ImageProcessor.UnitTests.Extensions
             public void ThenShouldReturn1Then3Then5Then7Then9GivenBetweenRange1Then10Then2()
             {
                 // Arrange // Act
-                var enumerable = EnumerableExtensions.SteppedRange(1, 10, 2);
+                IEnumerable<int> enumerable = EnumerableExtensions.SteppedRange(1, 10, 2);
 
                 // Assert
                 Assert.That(enumerable, Is.EquivalentTo(new List<int> { 1, 3, 5, 7, 9 }));
@@ -91,7 +91,7 @@ namespace ImageProcessor.UnitTests.Extensions
             public void ThenReturn0To9GivenFunction0ThenILessThan10Then1()
             {
                 // Arrange // Act
-                var enumerable = EnumerableExtensions.SteppedRange(0, i => i < 10, 1);
+                IEnumerable<int> enumerable = EnumerableExtensions.SteppedRange(0, i => i < 10, 1);
 
                 // Assert
                 Assert.That(enumerable, Is.EquivalentTo(new List<int> { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 }));

--- a/tests/ImageProcessor.Web.UnitTests/Extensions/DirectoryInfoExtensionsUnitTests.cs
+++ b/tests/ImageProcessor.Web.UnitTests/Extensions/DirectoryInfoExtensionsUnitTests.cs
@@ -19,7 +19,7 @@ namespace ImageProcessor.Web.UnitTests.Extensions
     /// <summary>
     /// The directory info extensions unit tests.
     /// </summary>
-    public class DirectoryInfoExtensionsUnitTests
+    public static class DirectoryInfoExtensionsUnitTests
     {
         /// <summary>
         /// The when safe enumerable directories.
@@ -79,6 +79,7 @@ namespace ImageProcessor.Web.UnitTests.Extensions
                 // Assert
                 Assert.That(directories, Is.EquivalentTo(directoryList.Select(s => new DirectoryInfo(s))));
             }
+
             /// <summary>
             /// The then should return empty enumerable directories given path with invalid directory
             /// </summary>
@@ -93,83 +94,6 @@ namespace ImageProcessor.Web.UnitTests.Extensions
 
                 // Assert
                 Assert.That(directories, Is.EquivalentTo(Enumerable.Empty<DirectoryInfo>()));
-            }
-        }
-
-        /// <summary>
-        /// The when safe enumerable directories async.
-        /// </summary>
-        [TestFixture]
-        public class WhenSafeEnumerableDirectoriesAsync
-        {
-            /// <summary>
-            /// The test directory root.
-            /// </summary>
-            private static readonly string TestDirectoryRoot = TestContext.CurrentContext.TestDirectory + @"\DirectoryInfoExtensionsTests";
-
-            /// <summary>
-            /// The directory count.
-            /// </summary>
-            private const int DirectoryCount = 6;
-
-            /// <summary>
-            /// The directory list.
-            /// </summary>
-            private IEnumerable<string> directoryList;
-
-            /// <summary>
-            /// The setup directories.
-            /// </summary>
-            [SetUp]
-            public void SetupDirectories()
-            {
-                directoryList = Enumerable.Range(1, DirectoryCount).Select(i => string.Format("{0}/TestDirectory{1}", TestDirectoryRoot, i));
-                foreach (var directory in directoryList)
-                {
-                    Directory.CreateDirectory(directory);
-                }
-            }
-
-            /// <summary>
-            /// The remove directories.
-            /// </summary>
-            [TearDown]
-            public void RemoveDirectories()
-            {
-                Directory.Delete(TestDirectoryRoot, true);
-            }
-            /// <summary>
-            /// Then should return enumerable directories asynchronously given path with subdirectories
-            /// </summary>
-            [Test]
-            public async Task ThenShouldReturnEnumerableDirectoriesAsyncGivenPathWithSubDirectories()
-            {
-                // Arrange
-                var info = new DirectoryInfo(TestDirectoryRoot);
-                var asyncResult = info.SafeEnumerateDirectoriesAsync();
-
-                // Act
-                var directories = await asyncResult;
-
-                // Assert
-                Assert.That(directories, Is.EquivalentTo(directoryList.Select(s => new DirectoryInfo(s))));
-            }
-
-            /// <summary>
-            /// Then return empty enumerable directories asynchronously given invalid directory
-            /// </summary>
-            [Test]
-            public async Task ThenReturnEmptyEnumerableGivenInvalidDirectory()
-            {
-                // Arrange
-                var info = new DirectoryInfo(string.Format("{0}Bad", TestDirectoryRoot));
-                var asyncResult = info.SafeEnumerateDirectoriesAsync();
-
-                // Act
-                var directories = await asyncResult;
-
-                // Assert
-                Assert.That(directories, Is.EqualTo(Enumerable.Empty<DirectoryInfo>()));
             }
         }
     }


### PR DESCRIPTION
Adjustments.Opacity now respects passed rectangle.

### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/JimBobSquarePants/ImageProcessor/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practise as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
- Cleanup code.
- Make structs readonly where appropriate
- `Adjustments.Opacity` now respects passed rectangle. 

<!-- Thanks for contributing to ImageProcessor! -->
