### PR TITLE
Added overlay color processor

### DIFF
--- a/ImageProcessor.sln
+++ b/ImageProcessor.sln
@@ -47,6 +47,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Nuspecs", "Nuspecs", "{E0B8
 		build\NuSpecs\ImageProcessor.Plugins.WebP.nuspec = build\NuSpecs\ImageProcessor.Plugins.WebP.nuspec
 		build\NuSpecs\ImageProcessor.Web.Config.nuspec = build\NuSpecs\ImageProcessor.Web.Config.nuspec
 		build\NuSpecs\ImageProcessor.Web.nuspec = build\NuSpecs\ImageProcessor.Web.nuspec
+		build\NuSpecs\ImageProcessor.Web.Plugins.AmazonS3Cache.nuspec = build\NuSpecs\ImageProcessor.Web.Plugins.AmazonS3Cache.nuspec
 		build\NuSpecs\ImageProcessor.Web.Plugins.AzureBlobCache.nuspec = build\NuSpecs\ImageProcessor.Web.Plugins.AzureBlobCache.nuspec
 		build\NuSpecs\ImageProcessor.Web.PostProcessor.nuspec = build\NuSpecs\ImageProcessor.Web.PostProcessor.nuspec
 	EndProjectSection

--- a/build/NuSpecs/ImageProcessor.Web.Plugins.AmazonS3Cache.nuspec
+++ b/build/NuSpecs/ImageProcessor.Web.Plugins.AmazonS3Cache.nuspec
@@ -1,0 +1,38 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
+  <metadata>
+    <id>ImageProcessor.Web.Plugins.AmazonS3Cache</id>
+    <version>$version$</version>
+    <title>ImageProcessor.Web.Plugins.AmazonS3Cache</title>
+    <authors>James Jackson-South</authors>
+    <owners>James Jackson-South</owners>
+    <projectUrl>http://imageprocessor.org</projectUrl>
+    <iconUrl>https://raw.githubusercontent.com/JimBobSquarePants/ImageProcessor/develop/build/icons/imageprocessor-logo-128.png</iconUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>
+      Adds a self cleaning cache to ImageProcessor.Web that uses Amazon S3 Buckets to store processed images.
+
+      If you use ImageProcessor.Web please get in touch via my twitter @james_m_south
+
+      Feedback is always welcome
+    </description>
+    <summary>ImageProcessor.Web AmazonS3Cache for ASP.NET websites.</summary>
+    <releaseNotes />
+    <copyright>James Jackson-South</copyright>
+    <language>en-GB</language>
+    <tags>Image Resize Crop Rotate Quality Watermark Gif Jpg Jpeg Bitmap Png Tiff Amazon S3 Cache Asp</tags>
+    <dependencies>
+      <group targetFramework=".NETFramework4.5.2">
+        <dependency id="ImageProcessor.Web" version="4.9.4.0" />
+        <dependency id="ImageProcessor.Web.Config" version="2.4.1.0" />
+        <dependency id="AWSSDK.Core" version="3.3.23.1" />
+        <dependency id="AWSSDK.S3" version="3.3.18.3" />
+      </group>
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="..\content\ImageProcessor.Web.Plugins.AmazonS3Cache\config\imageprocessor\cache.config.transform" target="content\config\imageprocessor\cache.config.transform" />
+    <file src="..\_BuildOutput\ImageProcessor.Web.Plugins.AmazonS3Cache\lib\net452\ImageProcessor.Web.Plugins.AmazonS3Cache.dll" target="lib\net452" />
+    <file src="..\_BuildOutput\ImageProcessor.Web.Plugins.AmazonS3Cache\lib\net452\ImageProcessor.Web.Plugins.AmazonS3Cache.xml" target="lib\net452" />
+  </files>
+</package>

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -49,11 +49,20 @@ $imageprocessorWebConfig = @{
 
 $imageProcessorWebPluginsAzureBlobCache = @{
     name    = "ImageProcessor.Web.Plugins.AzureBlobCache"
-    version = "1.4.2.${buildNumber}"
+    version = "1.4.3.${buildNumber}"
     folder  = Join-Path $buildPath "src\ImageProcessor.Web.Plugins.AzureBlobCache"
     output  = Join-Path $binPath "ImageProcessor.Web.Plugins.AzureBlobCache\lib\net452"
     csproj  = "ImageProcessor.Web.Plugins.AzureBlobCache.csproj"
     nuspec  = Join-Path $nuspecsPath "ImageProcessor.Web.Plugins.AzureBlobCache.nuspec"
+};
+
+$imageProcessorWebPluginsAmazonS3Cache = @{
+    name    = "ImageProcessor.Web.Plugins.AzureBlobCache"
+    version = "1.0.0.${buildNumber}"
+    folder  = Join-Path $buildPath "src\ImageProcessor.Web.Plugins.AmazonS3Cache"
+    output  = Join-Path $binPath "ImageProcessor.Web.Plugins.AmazonS3Cache\lib\net452"
+    csproj  = "ImageProcessor.Web.Plugins.AmazonS3Cache.csproj"
+    nuspec  = Join-Path $nuspecsPath "ImageProcessor.Web.Plugins.AmazonS3Cache.nuspec"
 };
 
 $imageProcessorWebPluginsPostProcessor = @{
@@ -72,6 +81,7 @@ $projects = @(
     $imageprocessorWeb,
     $imageprocessorWebConfig,
     $imageProcessorWebPluginsAzureBlobCache,
+    $imageProcessorWebPluginsAmazonS3Cache,
     $imageProcessorWebPluginsPostProcessor
 );
 

--- a/build/content/ImageProcessor.Web.Plugins.AmazonS3Cache/config/imageprocessor/cache.config.transform
+++ b/build/content/ImageProcessor.Web.Plugins.AmazonS3Cache/config/imageprocessor/cache.config.transform
@@ -4,9 +4,14 @@
       <settings>
         <setting key="AwsAccessKey" value="" />
         <setting key="AwsSecretKey" value="" />
-        <setting key="AwsBucketName" value="" />
-        <setting key="CachedCDNRoot" value="" />
-        <setting key="RegionEndpoint" value="EUWest1" />
+        <setting key="AwsBucketName" value="[BucketName]"/>
+        <setting key="AwsCacheKeyPrefix" value="cache" />
+        <setting key="RegionEndpoint" value="[RegionEndPoint]" />
+        <setting key="SourceRegionEndpoint" value="" />
+        <setting key="CachedCDNRoot" value="[CdnRootUrl]" />
+        <setting key="CloudSourceURI" value="https://s3.[SourceRegionEndPoint].amazonaws.com/[BucketName]/" />
+        <setting key="CachedCDNTimeout" value="2000" />
+        <setting key="StreamCachedImage" value="false" />
       </settings>
     </cache>
   </caches>

--- a/src/ImageProcessor.Web/Configuration/Resources/processing.config.transform
+++ b/src/ImageProcessor.Web/Configuration/Resources/processing.config.transform
@@ -46,6 +46,7 @@
         <setting key="VirtualPath" value="~/images/imageprocessor/overlay/"/>
       </settings>
     </plugin>
+    <plugin name="OverlayColor" type="ImageProcessor.Web.Processors.OverlayColor, ImageProcessor.Web"/>
     <plugin name="Pixelate" type="ImageProcessor.Web.Processors.Pixelate, ImageProcessor.Web"/>
     <plugin name="Quality" type="ImageProcessor.Web.Processors.Quality, ImageProcessor.Web" enabled="true"/>
     <plugin name="ReplaceColor" type="ImageProcessor.Web.Processors.ReplaceColor, ImageProcessor.Web"/>

--- a/src/ImageProcessor.Web/HttpModules/ImageProcessingModule.cs
+++ b/src/ImageProcessor.Web/HttpModules/ImageProcessingModule.cs
@@ -136,17 +136,6 @@ namespace ImageProcessor.Web.HttpModules
         }
 
         /// <summary>
-        /// The process querystring event handler. DO NOT USE!
-        /// </summary>
-        /// <param name="sender">The sender.</param>
-        /// <param name="e">The <see cref="ProcessQueryStringEventArgs"/>.
-        /// </param>
-        /// <returns>Returns the processed querystring.</returns>
-        [Obsolete("Use ValidatingRequest instead")]
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public delegate string ProcessQuerystringEventHandler(object sender, ProcessQueryStringEventArgs e);
-
-        /// <summary>
         /// Event to use to validate the request or manipulate the request parameters
         /// </summary>
         /// <remarks>

--- a/src/ImageProcessor.Web/ImageProcessor.Web.csproj
+++ b/src/ImageProcessor.Web/ImageProcessor.Web.csproj
@@ -90,6 +90,7 @@
     <Compile Include="Processors\Mask.cs" />
     <Compile Include="Processors\Background.cs" />
     <Compile Include="Processors\Overlay.cs" />
+    <Compile Include="Processors\OverlayColor.cs" />
     <Compile Include="Processors\Pixelate.cs" />
     <Compile Include="Processors\ReplaceColor.cs" />
     <Compile Include="Processors\RotateBounded.cs" />

--- a/src/ImageProcessor.Web/Processors/OverlayColor.cs
+++ b/src/ImageProcessor.Web/Processors/OverlayColor.cs
@@ -1,0 +1,73 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="OverlayColor.cs" company="James Jackson-South">
+//   Copyright (c) James Jackson-South.
+//   Licensed under the Apache License, Version 2.0.
+// </copyright>
+// <summary>
+//   Adds a color overlay to the current image.
+// </summary>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace ImageProcessor.Web.Processors
+{
+	using System.Collections.Specialized;
+	using System.Drawing;
+	using System.Text.RegularExpressions;
+	using System.Web;
+
+	using ImageProcessor.Processors;
+	using ImageProcessor.Web.Helpers;
+
+	/// <summary>
+	/// Adds a color overlay to the current image.
+	/// </summary>
+	public class OverlayColor : IWebGraphicsProcessor
+	{
+		/// <summary>
+		/// The regular expression to search strings for.
+		/// </summary>
+		private static readonly Regex QueryRegex = new Regex("color=[^&]", RegexOptions.Compiled);
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="OverlayColor"/> class.
+		/// </summary>
+		public OverlayColor() => this.Processor = new ImageProcessor.Processors.OverlayColor();
+
+		/// <summary>
+		/// Gets the regular expression to search strings for.
+		/// </summary>
+		public Regex RegexPattern => QueryRegex;
+
+		/// <summary>
+		/// Gets the order in which this processor is to be used in a chain.
+		/// </summary>
+		public int SortOrder { get; private set; }
+
+		/// <summary>
+		/// Gets the associated graphics processor.
+		/// </summary>
+		public IGraphicsProcessor Processor { get; }
+
+		/// <summary>
+		/// The position in the original string where the first character of the captured substring was found.
+		/// </summary>
+		/// <param name="queryString">The query string to search.</param>
+		/// <returns>
+		/// The zero-based starting position in the original string where the captured substring was found.
+		/// </returns>
+		public int MatchRegexIndex(string queryString)
+		{
+			this.SortOrder = int.MaxValue;
+			Match match = this.RegexPattern.Match(queryString);
+
+			if (match.Success)
+			{
+				this.SortOrder = match.Index;
+				NameValueCollection queryCollection = HttpUtility.ParseQueryString(queryString);
+				this.Processor.DynamicParameter = (Color)QueryParamParser.Instance.ParseValue<Color>(queryCollection["color"]);
+			}
+
+			return this.SortOrder;
+		}
+	}
+}

--- a/src/ImageProcessor/ImageProcessor.csproj
+++ b/src/ImageProcessor/ImageProcessor.csproj
@@ -166,6 +166,7 @@
     <Compile Include="Imaging\TextLayer.cs" />
     <Compile Include="MetaDataMode.cs" />
     <Compile Include="Processors\Background.cs" />
+    <Compile Include="Processors\OverlayColor.cs" />
     <Compile Include="Processors\Resolution.cs" />
     <Compile Include="Processors\Gamma.cs" />
     <Compile Include="Processors\Alpha.cs" />

--- a/src/ImageProcessor/Processors/OverlayColor.cs
+++ b/src/ImageProcessor/Processors/OverlayColor.cs
@@ -1,0 +1,78 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="OverlayColor.cs" company="James Jackson-South">
+//   Copyright (c) James Jackson-South.
+//   Licensed under the Apache License, Version 2.0.
+// </copyright>
+// <summary>
+//   Adds a color overlay to the current image.
+// </summary>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace ImageProcessor.Processors
+{
+	using System;
+	using System.Collections.Generic;
+	using System.Drawing;
+
+	using ImageProcessor.Common.Exceptions;
+	using ImageProcessor.Imaging.Helpers;
+
+	/// <summary>
+	/// Adds a color overlay to the current image.
+	/// </summary>
+	public class OverlayColor : IGraphicsProcessor
+	{
+		/// <summary>
+		/// Initializes a new instance of the <see cref="OverlayColor"/> class.
+		/// </summary>
+		public OverlayColor() => this.Settings = new Dictionary<string, string>();
+
+		/// <summary>
+		/// Gets or sets the DynamicParameter.
+		/// </summary>
+		public dynamic DynamicParameter { get; set; }
+
+		/// <summary>
+		/// Gets or sets any additional settings required by the processor.
+		/// </summary>
+		public Dictionary<string, string> Settings { get; set; }
+
+		/// <summary>
+		/// Processes the image.
+		/// </summary>
+		/// <param name="factory">The current instance of the 
+		/// <see cref="T:ImageProcessor.ImageFactory" /> class containing
+		/// the image to process.</param>
+		/// <returns>
+		/// The processed image from the current instance of the <see cref="T:ImageProcessor.ImageFactory" /> class.
+		/// </returns>
+		public Image ProcessImage(ImageFactory factory)
+		{
+			Image image = factory.Image;
+
+			try
+			{
+				Color overlayColor = this.DynamicParameter;
+				if (overlayColor.A > 0)
+				{
+					using (var graphics = Graphics.FromImage(image))
+					{
+						GraphicsHelper.SetGraphicsOptions(graphics, true);
+
+						// Fill with overlay color
+						using (SolidBrush brush = new SolidBrush(overlayColor))
+						{
+							graphics.FillRectangle(brush, 0, 0, image.Width, image.Height);
+						}
+					}
+				}
+			}
+			catch (Exception ex)
+			{
+				throw new ImageProcessingException("Error processing image with " + this.GetType().Name, ex);
+			}
+
+			return image;
+		}
+	}
+}


### PR DESCRIPTION
Along the same lines as PR #628, I've added an `OverlayColor` processor, so you can overlay a (semi-transparent) color to the whole image.

I know you can just add an overlay in the HTML of a page, but because images with less colors are a _lot_ smaller (~50%), you'd be downloading unnessecary color data... We used this method (HTML overlay) on the 2nd and 3rd frontpage slide on https://www.tomatoworld.nl/en (so you have an idea of what the result will be).

I first tried to combine the background color and alpha processors, but that didn't work (the alpha processor only created a washed out image). Adding an overlay image (PNG filled with the semi-transparent color) with the exact same dimensions works, but adds a lot of extra work to add new dimensions and/or colors.

To get the solution to build, I merged the `Feature/AmazonS3Cache` branch, so you may want to do this yourself and cherry pick commit 7d4c364.