### PR TITLE
Add missing attribute "memoryMaxMinutes" to config sample

### DIFF
--- a/imageprocessor-web/plugins/azure-blob-cache.md
+++ b/imageprocessor-web/plugins/azure-blob-cache.md
@@ -57,9 +57,10 @@ configuration files.
 
       folderDepth (Optional - Added v1.3.0) sets the maximum number folder levels to nest the cached images. Defaults to 6.
       trimCache (Optional - Added v1.3.0) whether to perform a cleanup of the cache when a new file is created. Defaults to true.
+      memoryMaxMinutes="1" (Optional - Added v1.4.2) how long to store a cached file reference in-memory to reduce IO. Defaults to 1 minute.
   -->
     <cache name="AzureBlobCache" type="ImageProcessor.Web.Plugins.AzureBlobCache.AzureBlobCache, ImageProcessor.Web.Plugins.AzureBlobCache" 
-           maxDays="365" browserMaxDays="7" folderDepth="6" trimCache="true">
+           maxDays="365" browserMaxDays="7" folderDepth="6" trimCache="true" memoryMaxMinutes="1">
       <settings>
         <!-- The Account, Container and CDN details -->
         <setting key="CachedStorageAccount" value="DefaultEndpointsProtocol=https;AccountName=[CacheAccountName];AccountKey=[CacheAccountKey]"/>

--- a/imageprocessor-web/plugins/azure-blob-cache.md
+++ b/imageprocessor-web/plugins/azure-blob-cache.md
@@ -57,7 +57,7 @@ configuration files.
 
       folderDepth (Optional - Added v1.3.0) sets the maximum number folder levels to nest the cached images. Defaults to 6.
       trimCache (Optional - Added v1.3.0) whether to perform a cleanup of the cache when a new file is created. Defaults to true.
-      memoryMaxMinutes="1" (Optional - Added v1.4.2) how long to store a cached file reference in-memory to reduce IO. Defaults to 1 minute.
+      memoryMaxMinutes (Optional - Added v1.4.2) how long to store a cached file reference in-memory to reduce IO. Defaults to 1 minute.
   -->
     <cache name="AzureBlobCache" type="ImageProcessor.Web.Plugins.AzureBlobCache.AzureBlobCache, ImageProcessor.Web.Plugins.AzureBlobCache" 
            maxDays="365" browserMaxDays="7" folderDepth="6" trimCache="true" memoryMaxMinutes="1">


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/JimBobSquarePants/ImageProcessor/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practise as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [ ] I have provided test coverage for my change (where applicable)

### Description
I added the attribute to the config sample and an explanation of what it does.