### PR TITLE
fix for container name path issue & additional request parameter for explicit redirect 

### DIFF
--- a/src/ImageProcessor.Web.Plugins.AzureBlobCache/AzureBlobCache.cs
+++ b/src/ImageProcessor.Web.Plugins.AzureBlobCache/AzureBlobCache.cs
@@ -324,7 +324,8 @@ namespace ImageProcessor.Web.Plugins.AzureBlobCache
         /// </param>
         public override void RewritePath(HttpContext context)
         {
-            if (streamCachedImage)
+            bool requestRequiresRedirect = context.Request.Url.Query.ToLower().Contains("&redirect=true");
+            if (streamCachedImage && !requestRequiresRedirect)
             {
                 string blobPath = this.CachedPath.Substring(cloudCachedBlobContainer.Uri.ToString().Length + 1);
                 CloudBlockBlob blockBlob = cloudCachedBlobContainer.GetBlockBlobReference(blobPath);


### PR DESCRIPTION
### Prerequisites

- [x ] I have written a descriptive pull-request title
- [ x] I have verified that there are no overlapping [pull-requests](https://github.com/JimBobSquarePants/ImageProcessor/pulls) open
- [x ] I have verified that I am following matches the existing coding patterns and practise as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [ ] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Some configuration settings lead to a wrong request path. 
The additional explicit request query parameter in AzureBlobCache.cs should give the possibility to handle private blob protection in the frontend. For back office stream is sufficient(?). Actually private blobs make no sense when you stream them without further protection!
<!-- Thanks for contributing to ImageProcessor! -->
