### PR TITLE
Fix PNG processing not working unless output is redirected on process

### DIFF
--- a/src/ImageProcessor.Web.Plugins.PostProcessor/PostProcessor.cs
+++ b/src/ImageProcessor.Web.Plugins.PostProcessor/PostProcessor.cs
@@ -125,7 +125,9 @@ namespace ImageProcessor.Web.Plugins.PostProcessor
                 WorkingDirectory = PostProcessorBootstrapper.Instance.WorkingPath,
                 Arguments = arguments,
                 UseShellExecute = false,
-                CreateNoWindow = true
+                CreateNoWindow = true,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true
             };
 
             Process process = null;


### PR DESCRIPTION
Fixes #713 

I've removed more and more of the output implementation I did to see what happened. Turns out it still works when you just set the output to be redirected. I've tested it with a release build with and without the redirection. It consistently doesn't work without, and consistently work with.


[edit] darnit, I thought I was at dev branch. will test again.