### PR TITLE
Processors not matched when query string casing is different

### DIFF
--- a/src/ImageProcessor.Web.Plugins.AmazonS3Cache/AmazonS3Cache.cs
+++ b/src/ImageProcessor.Web.Plugins.AmazonS3Cache/AmazonS3Cache.cs
@@ -40,7 +40,7 @@ namespace ImageProcessor.Web.Plugins.AmazonS3Cache
         /// <summary>
         /// The regular expression for parsing a remote uri.
         /// </summary>
-        private static readonly Regex RemoteRegex = new Regex("^http(s)?://", RegexOptions.Compiled);
+        private static readonly Regex RemoteRegex = new Regex("^http(s)?://", RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture | RegexOptions.IgnoreCase);
 
         /// <summary>
         /// The assembly version.

--- a/src/ImageProcessor.Web.Plugins.AzureBlobCache/AzureBlobCache.cs
+++ b/src/ImageProcessor.Web.Plugins.AzureBlobCache/AzureBlobCache.cs
@@ -38,7 +38,7 @@ namespace ImageProcessor.Web.Plugins.AzureBlobCache
         /// <summary>
         /// The regular expression for parsing a remote uri.
         /// </summary>
-        private static readonly Regex RemoteRegex = new Regex("^http(s)?://", RegexOptions.Compiled);
+        private static readonly Regex RemoteRegex = new Regex("^http(s)?://", RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture | RegexOptions.IgnoreCase);
 
         /// <summary>
         /// The assembly version.

--- a/src/ImageProcessor.Web/Extensions/StringExtensions.cs
+++ b/src/ImageProcessor.Web/Extensions/StringExtensions.cs
@@ -48,8 +48,8 @@ namespace ImageProcessor.Web.Extensions
                 // Concatenate the hash bytes into one long String.
                 return hash.Aggregate(
                     new StringBuilder(32),
-                    (sb, b) => sb.Append(b.ToString("X2", CultureInfo.InvariantCulture)))
-                    .ToString().ToLowerInvariant();
+                    (sb, b) => sb.Append(b.ToString("x2", CultureInfo.InvariantCulture)))
+                    .ToString();
             }
         }
 
@@ -69,8 +69,8 @@ namespace ImageProcessor.Web.Extensions
                 // Concatenate the hash bytes into one long String.
                 return hash.Aggregate(
                     new StringBuilder(40),
-                    (sb, b) => sb.Append(b.ToString("X2", CultureInfo.InvariantCulture)))
-                    .ToString().ToLowerInvariant();
+                    (sb, b) => sb.Append(b.ToString("x2", CultureInfo.InvariantCulture)))
+                    .ToString();
             }
         }
 

--- a/src/ImageProcessor.Web/Extensions/StringExtensions.cs
+++ b/src/ImageProcessor.Web/Extensions/StringExtensions.cs
@@ -23,6 +23,16 @@ namespace ImageProcessor.Web.Extensions
     public static class StringExtensions
     {
         /// <summary>
+        /// The regular expression to search strings for an array of positive floats.
+        /// </summary>
+        private static readonly Regex PositiveFloatArrayRegex = new Regex(@"[\d+\.]+(?=[,-])|[\d+\.]+(?![,-])", RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture);
+
+        /// <summary>
+        /// The regular expression to search strings for an array of positive integers.
+        /// </summary>
+        private static readonly Regex PositiveIntegerArrayRegex = new Regex(@"[\d+]+(?=[,-])|[\d+]+(?![,-])", RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture);
+
+        /// <summary>
         /// Creates an MD5 fingerprint of the String.
         /// </summary>
         /// <param name="expression">The <see cref="T:System.String">String</see> instance that this method extends.</param>
@@ -76,9 +86,7 @@ namespace ImageProcessor.Web.Extensions
                 throw new ArgumentNullException(nameof(expression));
             }
 
-            var regex = new Regex(@"[\d+]+(?=[,-])|[\d+]+(?![,-])", RegexOptions.Compiled);
-
-            MatchCollection matchCollection = regex.Matches(expression);
+            var matchCollection = PositiveIntegerArrayRegex.Matches(expression);
 
             // Get the collections.
             int count = matchCollection.Count;
@@ -105,9 +113,7 @@ namespace ImageProcessor.Web.Extensions
                 throw new ArgumentNullException(nameof(expression));
             }
 
-            var regex = new Regex(@"[\d+\.]+(?=[,-])|[\d+\.]+(?![,-])", RegexOptions.Compiled);
-
-            MatchCollection matchCollection = regex.Matches(expression);
+            var matchCollection = PositiveFloatArrayRegex.Matches(expression);
 
             // Get the collections.
             int count = matchCollection.Count;

--- a/src/ImageProcessor.Web/Helpers/CommonParameterParserUtility.cs
+++ b/src/ImageProcessor.Web/Helpers/CommonParameterParserUtility.cs
@@ -24,7 +24,7 @@ namespace ImageProcessor.Web.Helpers
         /// <summary>
         /// The collection of known colors.
         /// </summary>
-        private static readonly Dictionary<string, KnownColor> KnownColors = new Dictionary<string, KnownColor>();
+        private static readonly Dictionary<string, KnownColor> KnownColors = new Dictionary<string, KnownColor>(StringComparer.OrdinalIgnoreCase);
 
         /// <summary>
         /// The regular expression to search strings for colors.
@@ -52,15 +52,16 @@ namespace ImageProcessor.Web.Helpers
         /// </returns>
         public static float ParseAngle(string input)
         {
-            foreach (Match match in AngleRegex.Matches(input))
+            if (AngleRegex.Match(input) is var match && match.Success)
             {
                 // Split on angle
-                string value = match.Value;
-                value = match.Value.IndexOf("ANGLE", StringComparison.InvariantCultureIgnoreCase) >= 0
-                    ? value.Substring(value.IndexOf("-", StringComparison.Ordinal) + 1)
+                var value = match.Value;
+                value = match.Value.IndexOf("angle", StringComparison.OrdinalIgnoreCase) >= 0
+                    ? value.Substring(value.IndexOf('-') + 1)
                     : match.Value.Split('=')[1];
 
-                float.TryParse(value, NumberStyles.Any, CultureInfo.InvariantCulture, out float angle);
+                float.TryParse(value, NumberStyles.Any, CultureInfo.InvariantCulture, out var angle);
+
                 return angle;
             }
 
@@ -79,22 +80,22 @@ namespace ImageProcessor.Web.Helpers
         /// </returns>
         public static Color ParseColor(string input)
         {
-            foreach (Match match in ColorRegex.Matches(input))
+            if (ColorRegex.Match(input) is var match && match.Success)
             {
-                string value = match.Value;
+                var value = match.Value;
 
-                if (KnownColors.ContainsKey(value))
+                if (KnownColors.TryGetValue(value, out var knownColor))
                 {
-                    return Color.FromKnownColor(KnownColors[value]);
+                    return Color.FromKnownColor(knownColor);
                 }
 
                 if (value.Contains(","))
                 {
-                    int[] split = value.ToPositiveIntegerArray();
-                    byte red = split[0].ToByte();
-                    byte green = split[1].ToByte();
-                    byte blue = split[2].ToByte();
-                    byte alpha = split[3].ToByte();
+                    var split = value.ToPositiveIntegerArray();
+                    var red = split[0].ToByte();
+                    var green = split[1].ToByte();
+                    var blue = split[2].ToByte();
+                    var alpha = split[3].ToByte();
 
                     return Color.FromArgb(alpha, red, green, blue);
                 }
@@ -117,7 +118,7 @@ namespace ImageProcessor.Web.Helpers
         /// </returns>
         public static int ParseIn100Range(string input)
         {
-            int value = 0;
+            var value = 0;
             foreach (Match match in In100RangeRegex.Matches(input))
             {
                 value = int.Parse(match.Value, CultureInfo.InvariantCulture);

--- a/src/ImageProcessor.Web/Helpers/CommonParameterParserUtility.cs
+++ b/src/ImageProcessor.Web/Helpers/CommonParameterParserUtility.cs
@@ -34,12 +34,12 @@ namespace ImageProcessor.Web.Helpers
         /// <summary>
         /// The regular expression to search strings for angles.
         /// </summary>
-        private static readonly Regex AngleRegex = new Regex("(^(rotate(bounded)?|angle)|[^.](&,)?rotate(bounded)?|angle)(=|-)[^&|,]+", RegexOptions.Compiled);
+        private static readonly Regex AngleRegex = new Regex("(^(rotate(bounded)?|angle)|[^.](&,)?rotate(bounded)?|angle)(=|-)[^&|,]+", RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture | RegexOptions.IgnoreCase);
 
         /// <summary>
         /// The regular expression to search strings for values between 1 and 100.
         /// </summary>
-        private static readonly Regex In100RangeRegex = new Regex("(-?0*(?:100|[1-9][0-9]?))", RegexOptions.Compiled);
+        private static readonly Regex In100RangeRegex = new Regex("(-?0*(?:100|[1-9][0-9]?))", RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture);
 
         /// <summary>
         /// Returns the correct <see cref="T:System.Int32"/> containing the angle for the given string.
@@ -135,23 +135,27 @@ namespace ImageProcessor.Web.Helpers
         private static Regex BuildColorRegex()
         {
             var stringBuilder = new StringBuilder();
-            stringBuilder.Append(@"(\d+,\d+,\d+,\d+|([0-9a-fA-F]{3}){1,2}|(");
+            stringBuilder.Append(@"(\d+,\d+,\d+,\d+|([0-9a-f]{3}){1,2}|(");
 
             var knownColors = (KnownColor[])Enum.GetValues(typeof(KnownColor));
-
-            for (int i = 0; i < knownColors.Length; i++)
+            for (var i = 0; i < knownColors.Length; i++)
             {
-                KnownColor knownColor = knownColors[i];
-                string name = knownColor.ToString().ToLowerInvariant();
+                var knownColor = knownColors[i];
+                var name = knownColor.ToString();
 
                 KnownColors.Add(name, knownColor);
 
-                stringBuilder.Append(i > 0 ? "|" + name : name);
+                if (i > 0)
+                {
+                    stringBuilder.Append('|');
+                }
+
+                stringBuilder.Append(Regex.Escape(name));
             }
 
             stringBuilder.Append("))");
 
-            return new Regex(stringBuilder.ToString(), RegexOptions.IgnoreCase);
+            return new Regex(stringBuilder.ToString(), RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture | RegexOptions.IgnoreCase);
         }
     }
 }

--- a/src/ImageProcessor.Web/Helpers/ImageHelpers.cs
+++ b/src/ImageProcessor.Web/Helpers/ImageHelpers.cs
@@ -66,12 +66,12 @@ namespace ImageProcessor.Web.Helpers
         /// <summary>
         /// The image format regex.
         /// </summary>
-        private static readonly Regex FormatRegex = new Regex(@"(\.?)(png8|" + ExtensionRegexPattern + ")", RegexOptions.IgnoreCase | RegexOptions.RightToLeft);
+        private static readonly Regex FormatRegex = new Regex(@"(\.?)(png8|" + ExtensionRegexPattern + ")", RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture | RegexOptions.IgnoreCase | RegexOptions.RightToLeft);
 
         /// <summary>
         /// The image format regex for matching the file format at the end of a string.
         /// </summary>
-        private static readonly Regex EndFormatRegex = new Regex(@"(\.)" + ExtensionRegexPattern + "$", RegexOptions.IgnoreCase | RegexOptions.RightToLeft);
+        private static readonly Regex EndFormatRegex = new Regex(@"(\.)" + ExtensionRegexPattern + "$", RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture | RegexOptions.IgnoreCase | RegexOptions.RightToLeft);
 
         /// <summary>
         /// Checks a given string to check whether the value contains a valid image extension.
@@ -180,26 +180,10 @@ namespace ImageProcessor.Web.Helpers
         private static string BuildExtensionRegexPattern()
         {
             var stringBuilder = new StringBuilder();
-            stringBuilder.Append("(");
-            int counter = 0;
-            foreach (ISupportedImageFormat imageFormat in ImageProcessorBootstrapper.Instance.SupportedImageFormats)
-            {
-                foreach (string fileExtension in imageFormat.FileExtensions)
-                {
-                    if (counter == 0)
-                    {
-                        stringBuilder.Append(fileExtension.ToLowerInvariant());
-                    }
-                    else
-                    {
-                        stringBuilder.AppendFormat("|{0}", fileExtension.ToLowerInvariant());
-                    }
-                }
+            stringBuilder.Append('(');
+            stringBuilder.Append(string.Join("|", ImageProcessorBootstrapper.Instance.SupportedImageFormats.SelectMany(f => f.FileExtensions).Select(Regex.Escape)));
+            stringBuilder.Append(')');
 
-                counter++;
-            }
-
-            stringBuilder.Append(")");
             return stringBuilder.ToString();
         }
     }

--- a/src/ImageProcessor.Web/Helpers/ImageHelpers.cs
+++ b/src/ImageProcessor.Web/Helpers/ImageHelpers.cs
@@ -132,7 +132,7 @@ namespace ImageProcessor.Web.Helpers
                 }
 
                 // Ah the enigma that is the png file.
-                if (value.EndsWith("png8", StringComparison.InvariantCultureIgnoreCase))
+                if (value.EndsWith("png8", StringComparison.OrdinalIgnoreCase))
                 {
                     return "png";
                 }

--- a/src/ImageProcessor.Web/Helpers/QuerystringParser/Converters/ColorTypeConverter.cs
+++ b/src/ImageProcessor.Web/Helpers/QuerystringParser/Converters/ColorTypeConverter.cs
@@ -26,12 +26,12 @@ namespace ImageProcessor.Web.Helpers
         /// <summary>
         /// The web color regex.
         /// </summary>
-        private static readonly Regex HexColorRegex = new Regex("([0-9a-fA-F]{3}){1,2}", RegexOptions.Compiled);
+        private static readonly Regex HexColorRegex = new Regex("([0-9a-fA-F]{3}){1,2}", RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture);
 
         /// <summary>
         /// The number color regex.
         /// </summary>
-        private static readonly Regex NumberRegex = new Regex(@"\d+", RegexOptions.Compiled);
+        private static readonly Regex NumberRegex = new Regex(@"\d+", RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture);
 
         /// <summary>
         /// The system color table map.

--- a/src/ImageProcessor.Web/Helpers/QuerystringParser/Converters/ColorTypeConverter.cs
+++ b/src/ImageProcessor.Web/Helpers/QuerystringParser/Converters/ColorTypeConverter.cs
@@ -230,34 +230,31 @@ namespace ImageProcessor.Web.Helpers
                 throw new ArgumentNullException(nameof(destinationType));
             }
 
-            if (destinationType == typeof(string))
+            if (destinationType == typeof(string) && value != null)
             {
-                if (value != null)
+                var color = (Color)value;
+
+                if (color == Color.Empty)
                 {
-                    var color = (Color)value;
-
-                    if (color == Color.Empty)
-                    {
-                        return string.Empty;
-                    }
-
-                    if (color.IsKnownColor)
-                    {
-                        return color.Name;
-                    }
-
-                    if (color.IsNamedColor)
-                    {
-                        return "'" + color.Name + "'";
-                    }
-
-                    // In the Web scenario, colors should be formatted in #RRGGBB notation 
-                    var sb = new StringBuilder("#", 7);
-                    sb.Append(color.R.ToString("X2", CultureInfo.InvariantCulture));
-                    sb.Append(color.G.ToString("X2", CultureInfo.InvariantCulture));
-                    sb.Append(color.B.ToString("X2", CultureInfo.InvariantCulture));
-                    return sb.ToString();
+                    return string.Empty;
                 }
+
+                if (color.IsKnownColor)
+                {
+                    return color.Name;
+                }
+
+                if (color.IsNamedColor)
+                {
+                    return "'" + color.Name + "'";
+                }
+
+                // In the Web scenario, colors should be formatted in #RRGGBB notation 
+                var sb = new StringBuilder("#", 7);
+                sb.Append(color.R.ToString("X2", CultureInfo.InvariantCulture));
+                sb.Append(color.G.ToString("X2", CultureInfo.InvariantCulture));
+                sb.Append(color.B.ToString("X2", CultureInfo.InvariantCulture));
+                return sb.ToString();
             }
 
             return base.ConvertTo(culture, value, destinationType);

--- a/src/ImageProcessor.Web/Helpers/UrlParser.cs
+++ b/src/ImageProcessor.Web/Helpers/UrlParser.cs
@@ -35,7 +35,7 @@ namespace ImageProcessor.Web.Helpers
             if (!string.IsNullOrWhiteSpace(servicePrefix))
             {
                 // Handle when prefix is contained in filename.
-                string[] split = Regex.Split(url, Regex.Escape(servicePrefix), RegexOptions.IgnoreCase);
+                string[] split = Regex.Split(url, Regex.Escape(servicePrefix), RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture | RegexOptions.IgnoreCase);
                 if (split.Length > 1)
                 {
                     url = string.Join(servicePrefix, split.Skip(1).ToArray()).TrimStart("?");

--- a/src/ImageProcessor.Web/HttpModules/ImageProcessingModule.cs
+++ b/src/ImageProcessor.Web/HttpModules/ImageProcessingModule.cs
@@ -251,8 +251,6 @@ namespace ImageProcessor.Web.HttpModules
                 return;
             }
 
-            string upper = url.Host.ToUpperInvariant();
-
             // Check for root or sub domain.
             bool validUrl = false;
             foreach (ImageSecuritySection.SafeUrl safeUrl in origins.WhiteList)
@@ -268,11 +266,11 @@ namespace ImageProcessor.Web.HttpModules
                 if (!uri.IsAbsoluteUri)
                 {
                     var rebaseUri = new Uri($"http://{uri.ToString().TrimStart('.', '/')}");
-                    validUrl = upper.StartsWith(rebaseUri.Host.ToUpperInvariant()) || upper.EndsWith(rebaseUri.Host.ToUpperInvariant());
+                    validUrl = url.Host.StartsWith(rebaseUri.Host, StringComparison.OrdinalIgnoreCase) || url.Host.EndsWith(rebaseUri.Host, StringComparison.OrdinalIgnoreCase);
                 }
                 else
                 {
-                    validUrl = upper.StartsWith(uri.Host.ToUpperInvariant()) || upper.EndsWith(uri.Host.ToUpperInvariant());
+                    validUrl = url.Host.StartsWith(uri.Host, StringComparison.OrdinalIgnoreCase) || url.Host.EndsWith(uri.Host, StringComparison.OrdinalIgnoreCase);
                 }
 
                 if (validUrl)
@@ -447,7 +445,7 @@ namespace ImageProcessor.Web.HttpModules
             string rawUrl = this.GetRequestUrl(request);
 
             // Should we ignore this request?
-            if (string.IsNullOrWhiteSpace(rawUrl) || rawUrl.IndexOf("IPIGNORE=TRUE", StringComparison.InvariantCultureIgnoreCase) >= 0)
+            if (string.IsNullOrWhiteSpace(rawUrl) || rawUrl.IndexOf("ipignore=true", StringComparison.OrdinalIgnoreCase) >= 0)
             {
                 return;
             }
@@ -490,9 +488,10 @@ namespace ImageProcessor.Web.HttpModules
             queryString = validatingArgs.QueryString;
             if (string.IsNullOrWhiteSpace(originalQueryString) && !string.IsNullOrWhiteSpace(queryString))
             {
+                // Add new query string to URL
                 url = url + "?" + queryString;
             }
-            else if (!string.IsNullOrWhiteSpace(queryString))
+            else if (!string.IsNullOrWhiteSpace(queryString) && !string.Equals(originalQueryString, queryString))
             {
                 url = Regex.Replace(url, Regex.Escape(originalQueryString), queryString, RegexOptions.IgnoreCase);
             }
@@ -510,10 +509,10 @@ namespace ImageProcessor.Web.HttpModules
             }
 
             // Parse any protocol values from settings if no protocol is present.
-            if (currentService.Settings.ContainsKey("Protocol") && (ProtocolRegex.Matches(requestPath).Count == 0 || ProtocolRegex.Matches(requestPath)[0].Index > 0))
+            if (currentService.Settings.TryGetValue("Protocol", out var protocol) && (ProtocolRegex.Matches(requestPath) is var matches && (matches.Count == 0 || matches[0].Index > 0)))
             {
                 // ReSharper disable once PossibleNullReferenceException
-                requestPath = currentService.Settings["Protocol"] + "://" + requestPath.TrimStart('/');
+                requestPath = protocol + "://" + requestPath.TrimStart('/');
             }
 
             // Break out if we don't meet critera.
@@ -741,8 +740,8 @@ namespace ImageProcessor.Web.HttpModules
         private static bool ParseCacheBuster(NameValueCollection queryString)
         {
             return allowCacheBuster != null && allowCacheBuster.Value
-                && (queryString.AllKeys.Contains("v", StringComparer.InvariantCultureIgnoreCase)
-                || queryString.AllKeys.Contains("rnd", StringComparer.InvariantCultureIgnoreCase));
+                && (queryString.AllKeys.Contains("v", StringComparer.OrdinalIgnoreCase)
+                || queryString.AllKeys.Contains("rnd", StringComparer.OrdinalIgnoreCase));
         }
 
         /// <summary>
@@ -764,9 +763,9 @@ namespace ImageProcessor.Web.HttpModules
             NameValueCollection queryCollection = HttpUtility.ParseQueryString(decoded);
             process = false;
 
-            if (queryCollection.AllKeys.Contains("animationprocessmode", StringComparer.InvariantCultureIgnoreCase))
+            if (queryCollection["animationprocessmode"] is string animationProcessMode)
             {
-                mode = QueryParamParser.Instance.ParseValue<AnimationProcessMode>(queryCollection["animationprocessmode"]);
+                mode = QueryParamParser.Instance.ParseValue<AnimationProcessMode>(animationProcessMode);
 
                 // Common sense would dictate that requesting AnimationProcessMode.All is a pointless request
                 // since that is the default behaviour and shouldn't be requested on its own.
@@ -824,8 +823,8 @@ namespace ImageProcessor.Web.HttpModules
             string path = url.Split('?')[0].TrimStart(applicationPath).TrimStart('/');
             foreach (IImageService service in services)
             {
-                string key = service.Prefix;
-                if (!string.IsNullOrWhiteSpace(key) && path.StartsWith(key, StringComparison.InvariantCultureIgnoreCase))
+                var key = service.Prefix;
+                if (!string.IsNullOrWhiteSpace(key) && path.StartsWith(key, StringComparison.OrdinalIgnoreCase))
                 {
                     return service;
                 }

--- a/src/ImageProcessor.Web/HttpModules/ImageProcessingModule.cs
+++ b/src/ImageProcessor.Web/HttpModules/ImageProcessingModule.cs
@@ -50,12 +50,12 @@ namespace ImageProcessor.Web.HttpModules
         /// <summary>
         /// The regular expression to search strings for presets with.
         /// </summary>
-        private static readonly Regex PresetRegex = new Regex("preset=[^&]+", RegexOptions.Compiled);
+        private static readonly Regex PresetRegex = new Regex("preset=[^&]+", RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture | RegexOptions.IgnoreCase);
 
         /// <summary>
         /// The regular expression to search strings for protocols with.
         /// </summary>
-        private static readonly Regex ProtocolRegex = new Regex("http(s)?://", RegexOptions.Compiled);
+        private static readonly Regex ProtocolRegex = new Regex("http(s)?://", RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture | RegexOptions.IgnoreCase);
 
         /// <summary>
         /// The base assembly version.
@@ -789,7 +789,7 @@ namespace ImageProcessor.Web.HttpModules
         {
             if (!string.IsNullOrWhiteSpace(queryString))
             {
-                queryString = PresetRegex.Replace(queryString, (match) =>
+                queryString = PresetRegex.Replace(queryString, match =>
                 {
                     string preset = match.Value.Split('=')[1];
 

--- a/src/ImageProcessor.Web/Processors/Alpha.cs
+++ b/src/ImageProcessor.Web/Processors/Alpha.cs
@@ -26,7 +26,7 @@ namespace ImageProcessor.Web.Processors
         /// <summary>
         /// The regular expression to search strings for.
         /// </summary>
-        private static readonly Regex QueryRegex = new Regex(@"alpha=\d+", RegexOptions.Compiled);
+        private static readonly Regex QueryRegex = new Regex(@"alpha=\d+", RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture | RegexOptions.IgnoreCase);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Alpha"/> class.
@@ -58,8 +58,8 @@ namespace ImageProcessor.Web.Processors
         public int MatchRegexIndex(string queryString)
         {
             this.SortOrder = int.MaxValue;
-            Match match = this.RegexPattern.Match(queryString);
 
+            Match match = this.RegexPattern.Match(queryString);
             if (match.Success)
             {
                 this.SortOrder = match.Index;

--- a/src/ImageProcessor.Web/Processors/AutoRotate.cs
+++ b/src/ImageProcessor.Web/Processors/AutoRotate.cs
@@ -23,7 +23,7 @@ namespace ImageProcessor.Web.Processors
         /// <summary>
         /// The regular expression to search strings for.
         /// </summary>
-        private static readonly Regex QueryRegex = new Regex("autorotate=true", RegexOptions.Compiled);
+        private static readonly Regex QueryRegex = new Regex("autorotate=true", RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture | RegexOptions.IgnoreCase);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AutoRotate"/> class.
@@ -38,11 +38,7 @@ namespace ImageProcessor.Web.Processors
         /// <summary>
         /// Gets the order in which this processor is to be used in a chain.
         /// </summary>
-        public int SortOrder
-        {
-            get;
-            private set;
-        }
+        public int SortOrder { get; private set; }
 
         /// <summary>
         /// Gets the associated graphics processor.
@@ -61,8 +57,8 @@ namespace ImageProcessor.Web.Processors
         public int MatchRegexIndex(string queryString)
         {
             this.SortOrder = int.MaxValue;
-            Match match = this.RegexPattern.Match(queryString);
 
+            Match match = this.RegexPattern.Match(queryString);
             if (match.Success)
             {
                 this.SortOrder = match.Index;

--- a/src/ImageProcessor.Web/Processors/Background.cs
+++ b/src/ImageProcessor.Web/Processors/Background.cs
@@ -32,7 +32,7 @@ namespace ImageProcessor.Web.Processors
         /// <summary>
         /// The regular expression to search strings for.
         /// </summary>
-        private static readonly Regex QueryRegex = new Regex(@"background=[\w+-]+." + ImageHelpers.ExtensionRegexPattern);
+        private static readonly Regex QueryRegex = new Regex(@"background=[\w+-]+." + ImageHelpers.ExtensionRegexPattern, RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture | RegexOptions.IgnoreCase);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Background"/> class.
@@ -64,8 +64,8 @@ namespace ImageProcessor.Web.Processors
         public int MatchRegexIndex(string queryString)
         {
             this.SortOrder = int.MaxValue;
-            Match match = this.RegexPattern.Match(queryString);
 
+            Match match = this.RegexPattern.Match(queryString);
             if (match.Success)
             {
                 this.SortOrder = match.Index;

--- a/src/ImageProcessor.Web/Processors/BackgroundColor.cs
+++ b/src/ImageProcessor.Web/Processors/BackgroundColor.cs
@@ -26,7 +26,7 @@ namespace ImageProcessor.Web.Processors
         /// <summary>
         /// The regular expression to search strings for.
         /// </summary>
-        private static readonly Regex QueryRegex = new Regex("bgcolor=[^&]", RegexOptions.Compiled);
+        private static readonly Regex QueryRegex = new Regex("bgcolor=[^&]", RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture | RegexOptions.IgnoreCase);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="BackgroundColor"/> class.
@@ -58,13 +58,13 @@ namespace ImageProcessor.Web.Processors
         public int MatchRegexIndex(string queryString)
         {
             this.SortOrder = int.MaxValue;
-            Match match = this.RegexPattern.Match(queryString);
 
+            Match match = this.RegexPattern.Match(queryString);
             if (match.Success)
             {
                 this.SortOrder = match.Index;
                 NameValueCollection queryCollection = HttpUtility.ParseQueryString(queryString);
-                this.Processor.DynamicParameter = (Color)QueryParamParser.Instance.ParseValue<Color>(queryCollection["bgcolor"]);
+                this.Processor.DynamicParameter = QueryParamParser.Instance.ParseValue<Color>(queryCollection["bgcolor"]);
             }
 
             return this.SortOrder;

--- a/src/ImageProcessor.Web/Processors/Brightness.cs
+++ b/src/ImageProcessor.Web/Processors/Brightness.cs
@@ -26,7 +26,7 @@ namespace ImageProcessor.Web.Processors
         /// <summary>
         /// The regular expression to search strings for.
         /// </summary>
-        private static readonly Regex QueryRegex = new Regex(@"brightness=(-)?\d+", RegexOptions.Compiled);
+        private static readonly Regex QueryRegex = new Regex(@"brightness=(-)?\d+", RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture | RegexOptions.IgnoreCase);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Brightness"/> class.
@@ -58,8 +58,8 @@ namespace ImageProcessor.Web.Processors
         public int MatchRegexIndex(string queryString)
         {
             this.SortOrder = int.MaxValue;
-            Match match = this.RegexPattern.Match(queryString);
 
+            Match match = this.RegexPattern.Match(queryString);
             if (match.Success)
             {
                 this.SortOrder = match.Index;

--- a/src/ImageProcessor.Web/Processors/Contrast.cs
+++ b/src/ImageProcessor.Web/Processors/Contrast.cs
@@ -26,7 +26,7 @@ namespace ImageProcessor.Web.Processors
         /// <summary>
         /// The regular expression to search strings for.
         /// </summary>
-        private static readonly Regex QueryRegex = new Regex(@"contrast=(-)?\d+", RegexOptions.Compiled);
+        private static readonly Regex QueryRegex = new Regex(@"contrast=(-)?\d+", RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture | RegexOptions.IgnoreCase);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Contrast"/> class.
@@ -58,8 +58,8 @@ namespace ImageProcessor.Web.Processors
         public int MatchRegexIndex(string queryString)
         {
             this.SortOrder = int.MaxValue;
-            Match match = this.RegexPattern.Match(queryString);
 
+            Match match = this.RegexPattern.Match(queryString);
             if (match.Success)
             {
                 this.SortOrder = match.Index;

--- a/src/ImageProcessor.Web/Processors/Crop.cs
+++ b/src/ImageProcessor.Web/Processors/Crop.cs
@@ -25,7 +25,7 @@ namespace ImageProcessor.Web.Processors
         /// <summary>
         /// The regular expression to search strings for.
         /// </summary>
-        private static readonly Regex QueryRegex = new Regex(@"\b(?!\W+)crop\b[=]", RegexOptions.Compiled);
+        private static readonly Regex QueryRegex = new Regex(@"\b(?!\W+)crop\b[=]", RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture | RegexOptions.IgnoreCase);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Crop"/> class.
@@ -59,8 +59,8 @@ namespace ImageProcessor.Web.Processors
         public int MatchRegexIndex(string queryString)
         {
             this.SortOrder = int.MaxValue;
-            var match = this.RegexPattern.Match(queryString);
 
+            var match = this.RegexPattern.Match(queryString);
             if (match.Success)
             {
                 var queryCollection = HttpUtility.ParseQueryString(queryString);
@@ -71,7 +71,7 @@ namespace ImageProcessor.Web.Processors
 
                     // Default CropMode.Pixels will be returned.
                     var cropMode = QueryParamParser.Instance.ParseValue<CropMode>(queryCollection["cropmode"]);
-                    this.Processor.DynamicParameter = (CropLayer)new CropLayer(coordinates[0], coordinates[1], coordinates[2], coordinates[3], cropMode);
+                    this.Processor.DynamicParameter = new CropLayer(coordinates[0], coordinates[1], coordinates[2], coordinates[3], cropMode);
                 }
             }
 

--- a/src/ImageProcessor.Web/Processors/EntropyCrop.cs
+++ b/src/ImageProcessor.Web/Processors/EntropyCrop.cs
@@ -25,7 +25,7 @@ namespace ImageProcessor.Web.Processors
         /// <summary>
         /// The regular expression to search strings for.
         /// </summary>
-        private static readonly Regex QueryRegex = new Regex("entropycrop(=)?[^&]*", RegexOptions.Compiled);
+        private static readonly Regex QueryRegex = new Regex("entropycrop(=)?[^&]*", RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture | RegexOptions.IgnoreCase);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="EntropyCrop"/> class.
@@ -58,8 +58,8 @@ namespace ImageProcessor.Web.Processors
         {
             // Set the sort order to max to allow filtering.
             this.SortOrder = int.MaxValue;
-            Match match = this.RegexPattern.Match(queryString);
 
+            Match match = this.RegexPattern.Match(queryString);
             if (match.Success)
             {
                 this.SortOrder = match.Index;

--- a/src/ImageProcessor.Web/Processors/Filter.cs
+++ b/src/ImageProcessor.Web/Processors/Filter.cs
@@ -124,7 +124,7 @@ namespace ImageProcessor.Web.Processors
                     PropertyInfo filter =
                         type.GetProperties(Flags)
                             .Where(p => p.PropertyType.IsAssignableFrom(typeof(IMatrixFilter)))
-                            .First(p => p.Name.Equals(f, StringComparison.InvariantCultureIgnoreCase));
+                            .First(p => p.Name.Equals(f, StringComparison.OrdinalIgnoreCase));
 
                     return filter.GetValue(null, null) as IMatrixFilter;
                 });

--- a/src/ImageProcessor.Web/Processors/Filter.cs
+++ b/src/ImageProcessor.Web/Processors/Filter.cs
@@ -93,30 +93,15 @@ namespace ImageProcessor.Web.Processors
             const BindingFlags Flags = BindingFlags.Public | BindingFlags.Static;
             Type type = typeof(MatrixFilters);
             IEnumerable<PropertyInfo> filters = type.GetProperties(Flags)
-                              .Where(p => p.PropertyType.IsAssignableFrom(typeof(IMatrixFilter)))
-                              .ToList();
+                .Where(p => p.PropertyType.IsAssignableFrom(typeof(IMatrixFilter)))
+                .ToList();
 
             var stringBuilder = new StringBuilder();
             stringBuilder.Append("filter=(");
-            int counter = 0;
+            stringBuilder.Append(string.Join("|", filters.Select(f => Regex.Escape(f.Name))));
+            stringBuilder.Append(')');
 
-            foreach (PropertyInfo filter in filters)
-            {
-                if (counter == 0)
-                {
-                    stringBuilder.Append(filter.Name.ToLowerInvariant());
-                }
-                else
-                {
-                    stringBuilder.AppendFormat("|{0}", filter.Name.ToLowerInvariant());
-                }
-
-                counter++;
-            }
-
-            stringBuilder.Append(")");
-
-            return new Regex(stringBuilder.ToString(), RegexOptions.IgnoreCase);
+            return new Regex(stringBuilder.ToString(), RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture | RegexOptions.IgnoreCase);
         }
 
         /// <summary>

--- a/src/ImageProcessor.Web/Processors/Flip.cs
+++ b/src/ImageProcessor.Web/Processors/Flip.cs
@@ -22,7 +22,7 @@ namespace ImageProcessor.Web.Processors
         /// <summary>
         /// The regular expression to search strings for.
         /// </summary>
-        private static readonly Regex QueryRegex = new Regex("flip=(horizontal|vertical|both)", RegexOptions.Compiled);
+        private static readonly Regex QueryRegex = new Regex("flip=(horizontal|vertical|both)", RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture | RegexOptions.IgnoreCase);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Flip"/> class.
@@ -56,8 +56,8 @@ namespace ImageProcessor.Web.Processors
         public int MatchRegexIndex(string queryString)
         {
             this.SortOrder = int.MaxValue;
-            Match match = this.RegexPattern.Match(queryString);
 
+            Match match = this.RegexPattern.Match(queryString);
             if (match.Success)
             {
                 this.SortOrder = match.Index;

--- a/src/ImageProcessor.Web/Processors/Format.cs
+++ b/src/ImageProcessor.Web/Processors/Format.cs
@@ -92,7 +92,7 @@ namespace ImageProcessor.Web.Processors
             string finalIdentifier = identifier.Equals("png8") ? "png" : identifier;
             ISupportedImageFormat newFormat = null;
             var formats = ImageProcessorBootstrapper.Instance.SupportedImageFormats.ToList();
-            ISupportedImageFormat format = formats.Find(f => f.FileExtensions.Any(e => e.Equals(finalIdentifier, StringComparison.InvariantCultureIgnoreCase)));
+            ISupportedImageFormat format = formats.Find(f => f.FileExtensions.Any(e => e.Equals(finalIdentifier, StringComparison.OrdinalIgnoreCase)));
 
             if (format != null)
             {

--- a/src/ImageProcessor.Web/Processors/Format.cs
+++ b/src/ImageProcessor.Web/Processors/Format.cs
@@ -18,6 +18,7 @@ namespace ImageProcessor.Web.Processors
     using ImageProcessor.Configuration;
     using ImageProcessor.Imaging.Formats;
     using ImageProcessor.Processors;
+    using ImageProcessor.Web.Helpers;
 
     /// <summary>
     /// Sets the output of the image to a specific format.
@@ -27,7 +28,7 @@ namespace ImageProcessor.Web.Processors
         /// <summary>
         /// The regular expression to search strings for.
         /// </summary>
-        private static readonly Regex QueryRegex = BuildRegex();
+        private static readonly Regex QueryRegex = new Regex("format=(png8|" + ImageHelpers.ExtensionRegexPattern + ")", RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture | RegexOptions.IgnoreCase);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Format"/> class.
@@ -61,8 +62,8 @@ namespace ImageProcessor.Web.Processors
         public int MatchRegexIndex(string queryString)
         {
             this.SortOrder = int.MaxValue;
-            Match match = this.RegexPattern.Match(queryString);
 
+            Match match = this.RegexPattern.Match(queryString);
             if (match.Success)
             {
                 ISupportedImageFormat format = this.ParseFormat(match.Value.Split('=')[1]);
@@ -74,31 +75,6 @@ namespace ImageProcessor.Web.Processors
             }
 
             return this.SortOrder;
-        }
-
-        /// <summary>
-        /// Builds a regular expression from the <see cref="T:ImageProcessor.Imaging.Formats.ISupportedImageFormat"/> type, this allows extensibility.
-        /// </summary>
-        /// <returns>
-        /// The <see cref="Regex"/> to match matrix filters.
-        /// </returns>
-        private static Regex BuildRegex()
-        {
-            var stringBuilder = new StringBuilder();
-
-            // png8 is a special case for determining indexed png's.
-            stringBuilder.Append("format=(png8");
-            foreach (ISupportedImageFormat imageFormat in ImageProcessorBootstrapper.Instance.SupportedImageFormats)
-            {
-                foreach (string fileExtension in imageFormat.FileExtensions)
-                {
-                    stringBuilder.AppendFormat("|{0}", fileExtension.ToLowerInvariant());
-                }
-            }
-
-            stringBuilder.Append(")");
-
-            return new Regex(stringBuilder.ToString(), RegexOptions.IgnoreCase);
         }
 
         /// <summary>

--- a/src/ImageProcessor.Web/Processors/Gamma.cs
+++ b/src/ImageProcessor.Web/Processors/Gamma.cs
@@ -25,7 +25,7 @@ namespace ImageProcessor.Web.Processors
         /// <summary>
         /// The regular expression to search strings for.
         /// </summary>
-        private static readonly Regex QueryRegex = new Regex("gamma=[^&]", RegexOptions.Compiled);
+        private static readonly Regex QueryRegex = new Regex("gamma=[^&]", RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture | RegexOptions.IgnoreCase);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Gamma"/> class.
@@ -40,11 +40,7 @@ namespace ImageProcessor.Web.Processors
         /// <summary>
         /// Gets the order in which this processor is to be used in a chain.
         /// </summary>
-        public int SortOrder
-        {
-            get;
-            private set;
-        }
+        public int SortOrder { get; private set; }
 
         /// <summary>
         /// Gets the associated graphics processor.
@@ -63,8 +59,8 @@ namespace ImageProcessor.Web.Processors
         public int MatchRegexIndex(string queryString)
         {
             this.SortOrder = int.MaxValue;
-            Match match = this.RegexPattern.Match(queryString);
 
+            Match match = this.RegexPattern.Match(queryString);
             if (match.Success)
             {
                 this.SortOrder = match.Index;

--- a/src/ImageProcessor.Web/Processors/GaussianBlur.cs
+++ b/src/ImageProcessor.Web/Processors/GaussianBlur.cs
@@ -28,7 +28,7 @@ namespace ImageProcessor.Web.Processors
         /// <summary>
         /// The regular expression to search strings for.
         /// </summary>
-        private static readonly Regex QueryRegex = new Regex(@"\b(?!\W+)blur\b[=]", RegexOptions.Compiled);
+        private static readonly Regex QueryRegex = new Regex(@"\b(?!\W+)blur\b[=]", RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture | RegexOptions.IgnoreCase);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="GaussianBlur"/> class.
@@ -62,6 +62,7 @@ namespace ImageProcessor.Web.Processors
         public int MatchRegexIndex(string queryString)
         {
             this.SortOrder = int.MaxValue;
+
             Match match = this.RegexPattern.Match(queryString);
             if (match.Success)
             {

--- a/src/ImageProcessor.Web/Processors/GaussianSharpen.cs
+++ b/src/ImageProcessor.Web/Processors/GaussianSharpen.cs
@@ -28,7 +28,7 @@ namespace ImageProcessor.Web.Processors
         /// <summary>
         /// The regular expression to search strings for.
         /// </summary>
-        private static readonly Regex QueryRegex = new Regex(@"\b(?!\W+)sharpen\b[=]", RegexOptions.Compiled);
+        private static readonly Regex QueryRegex = new Regex(@"\b(?!\W+)sharpen\b[=]", RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture | RegexOptions.IgnoreCase);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="GaussianSharpen"/> class.
@@ -62,6 +62,7 @@ namespace ImageProcessor.Web.Processors
         public int MatchRegexIndex(string queryString)
         {
             this.SortOrder = int.MaxValue;
+
             Match match = this.RegexPattern.Match(queryString);
             if (match.Success)
             {

--- a/src/ImageProcessor.Web/Processors/Halftone.cs
+++ b/src/ImageProcessor.Web/Processors/Halftone.cs
@@ -22,7 +22,7 @@ namespace ImageProcessor.Web.Processors
         /// <summary>
         /// The regular expression to search strings for.
         /// </summary>
-        private static readonly Regex QueryRegex = new Regex("halftone(=comic)?", RegexOptions.Compiled);
+        private static readonly Regex QueryRegex = new Regex("halftone(=comic)?", RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture | RegexOptions.IgnoreCase);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Halftone"/> class.
@@ -54,12 +54,12 @@ namespace ImageProcessor.Web.Processors
         public int MatchRegexIndex(string queryString)
         {
             this.SortOrder = int.MaxValue;
-            Match match = this.RegexPattern.Match(queryString);
 
+            Match match = this.RegexPattern.Match(queryString);
             if (match.Success)
             {
                 this.SortOrder = match.Index;
-                this.Processor.DynamicParameter = (bool)match.Value.Contains("comic");
+                this.Processor.DynamicParameter = match.Value.Contains("comic");
             }
 
             return this.SortOrder;

--- a/src/ImageProcessor.Web/Processors/Hue.cs
+++ b/src/ImageProcessor.Web/Processors/Hue.cs
@@ -27,7 +27,7 @@ namespace ImageProcessor.Web.Processors
         /// <summary>
         /// The regular expression to search strings for.
         /// </summary>
-        private static readonly Regex QueryRegex = new Regex(@"hue=\d+", RegexOptions.Compiled);
+        private static readonly Regex QueryRegex = new Regex(@"hue=\d+", RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture | RegexOptions.IgnoreCase);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Hue"/> class.
@@ -59,13 +59,13 @@ namespace ImageProcessor.Web.Processors
         public int MatchRegexIndex(string queryString)
         {
             this.SortOrder = int.MaxValue;
-            Match match = this.RegexPattern.Match(queryString);
 
+            Match match = this.RegexPattern.Match(queryString);
             if (match.Success)
             {
                 this.SortOrder = match.Index;
-                NameValueCollection queryCollection = HttpUtility.ParseQueryString(queryString);
 
+                NameValueCollection queryCollection = HttpUtility.ParseQueryString(queryString);
                 int degrees = QueryParamParser.Instance.ParseValue<int>(queryCollection["hue"]);
                 bool rotate = QueryParamParser.Instance.ParseValue<bool>(queryCollection["hue.rotate"]);
                 degrees = ImageMaths.Clamp(degrees, 0, 360);

--- a/src/ImageProcessor.Web/Processors/Mask.cs
+++ b/src/ImageProcessor.Web/Processors/Mask.cs
@@ -32,7 +32,7 @@ namespace ImageProcessor.Web.Processors
         /// <summary>
         /// The regular expression to search strings for.
         /// </summary>
-        private static readonly Regex QueryRegex = new Regex(@"mask=[\w+-]+." + ImageHelpers.ExtensionRegexPattern);
+        private static readonly Regex QueryRegex = new Regex(@"mask=[\w+-]+." + ImageHelpers.ExtensionRegexPattern, RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture | RegexOptions.IgnoreCase);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Mask"/> class.
@@ -64,8 +64,8 @@ namespace ImageProcessor.Web.Processors
         public int MatchRegexIndex(string queryString)
         {
             this.SortOrder = int.MaxValue;
-            Match match = this.RegexPattern.Match(queryString);
 
+            Match match = this.RegexPattern.Match(queryString);
             if (match.Success)
             {
                 this.SortOrder = match.Index;

--- a/src/ImageProcessor.Web/Processors/Meta.cs
+++ b/src/ImageProcessor.Web/Processors/Meta.cs
@@ -21,7 +21,7 @@ namespace ImageProcessor.Web.Processors
         /// <summary>
         /// The regular expression to search strings for.
         /// </summary>
-        private static readonly Regex QueryRegex = new Regex("meta=(true|false)", RegexOptions.Compiled);
+        private static readonly Regex QueryRegex = new Regex("meta=(true|false)", RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture | RegexOptions.IgnoreCase);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Meta"/> class.
@@ -55,11 +55,12 @@ namespace ImageProcessor.Web.Processors
         public int MatchRegexIndex(string queryString)
         {
             this.SortOrder = int.MaxValue;
+
             Match match = this.RegexPattern.Match(queryString);
             if (match.Success)
             {
                 this.SortOrder = match.Index;
-                this.Processor.DynamicParameter = (bool)bool.Parse(match.Value.Split('=')[1]);
+                this.Processor.DynamicParameter = bool.Parse(match.Value.Split('=')[1]);
             }
 
             return this.SortOrder;

--- a/src/ImageProcessor.Web/Processors/Overlay.cs
+++ b/src/ImageProcessor.Web/Processors/Overlay.cs
@@ -32,7 +32,7 @@ namespace ImageProcessor.Web.Processors
         /// <summary>
         /// The regular expression to search strings for.
         /// </summary>
-        private static readonly Regex QueryRegex = new Regex(@"overlay=[\w+-]+." + ImageHelpers.ExtensionRegexPattern);
+        private static readonly Regex QueryRegex = new Regex(@"overlay=[\w+-]+." + ImageHelpers.ExtensionRegexPattern, RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture | RegexOptions.IgnoreCase);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Overlay"/> class.
@@ -64,8 +64,8 @@ namespace ImageProcessor.Web.Processors
         public int MatchRegexIndex(string queryString)
         {
             this.SortOrder = int.MaxValue;
-            Match match = this.RegexPattern.Match(queryString);
 
+            Match match = this.RegexPattern.Match(queryString);
             if (match.Success)
             {
                 this.SortOrder = match.Index;

--- a/src/ImageProcessor.Web/Processors/Pixelate.cs
+++ b/src/ImageProcessor.Web/Processors/Pixelate.cs
@@ -27,7 +27,7 @@ namespace ImageProcessor.Web.Processors
         /// <summary>
         /// The regular expression to search strings for.
         /// </summary>
-        private static readonly Regex QueryRegex = new Regex("pixelate=[^&]", RegexOptions.Compiled);
+        private static readonly Regex QueryRegex = new Regex("pixelate=[^&]", RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture | RegexOptions.IgnoreCase);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Pixelate"/> class.
@@ -59,8 +59,8 @@ namespace ImageProcessor.Web.Processors
         public int MatchRegexIndex(string queryString)
         {
             this.SortOrder = int.MaxValue;
-            Match match = this.RegexPattern.Match(queryString);
 
+            Match match = this.RegexPattern.Match(queryString);
             if (match.Success)
             {
                 this.SortOrder = match.Index;

--- a/src/ImageProcessor.Web/Processors/Quality.cs
+++ b/src/ImageProcessor.Web/Processors/Quality.cs
@@ -26,7 +26,7 @@ namespace ImageProcessor.Web.Processors
         /// <summary>
         /// The regular expression to search strings for.
         /// </summary>
-        private static readonly Regex QueryRegex = new Regex(@"quality=\d+", RegexOptions.Compiled);
+        private static readonly Regex QueryRegex = new Regex(@"quality=\d+", RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture | RegexOptions.IgnoreCase);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Quality"/> class.

--- a/src/ImageProcessor.Web/Processors/ReplaceColor.cs
+++ b/src/ImageProcessor.Web/Processors/ReplaceColor.cs
@@ -28,7 +28,7 @@ namespace ImageProcessor.Web.Processors
         /// <summary>
         /// The regular expression to search strings for.
         /// </summary>
-        private static readonly Regex QueryRegex = new Regex("replace=[^&]", RegexOptions.Compiled);
+        private static readonly Regex QueryRegex = new Regex("replace=[^&]", RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture | RegexOptions.IgnoreCase);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ReplaceColor"/> class.
@@ -60,8 +60,8 @@ namespace ImageProcessor.Web.Processors
         public int MatchRegexIndex(string queryString)
         {
             this.SortOrder = int.MaxValue;
-            Match match = this.RegexPattern.Match(queryString);
 
+            Match match = this.RegexPattern.Match(queryString);
             if (match.Success)
             {
                 this.SortOrder = match.Index;

--- a/src/ImageProcessor.Web/Processors/Resize.cs
+++ b/src/ImageProcessor.Web/Processors/Resize.cs
@@ -31,7 +31,7 @@ namespace ImageProcessor.Web.Processors
         /// <summary>
         /// The regular expression to search strings for.
         /// </summary>
-        private static readonly Regex QueryRegex = new Regex(@"(width|height)=((.)?\d+|\d+(.\d+)?)+(px)?", RegexOptions.Compiled);
+        private static readonly Regex QueryRegex = new Regex(@"(width|height)=((.)?\d+|\d+(.\d+)?)+(px)?", RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture | RegexOptions.IgnoreCase);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Resize"/> class.
@@ -65,8 +65,8 @@ namespace ImageProcessor.Web.Processors
         public int MatchRegexIndex(string queryString)
         {
             this.SortOrder = int.MaxValue;
-            Match match = this.RegexPattern.Match(queryString);
 
+            Match match = this.RegexPattern.Match(queryString);
             if (match.Success)
             {
                 this.SortOrder = match.Index;
@@ -79,7 +79,7 @@ namespace ImageProcessor.Web.Processors
                                     ? QueryParamParser.Instance.ParseValue<float[]>(queryCollection["center"]) :
                                     new float[] { };
 
-                this.Processor.DynamicParameter = (ResizeLayer)new ResizeLayer(size)
+                this.Processor.DynamicParameter = new ResizeLayer(size)
                 {
                     ResizeMode = mode,
                     AnchorPosition = position,

--- a/src/ImageProcessor.Web/Processors/Rotate.cs
+++ b/src/ImageProcessor.Web/Processors/Rotate.cs
@@ -25,7 +25,7 @@ namespace ImageProcessor.Web.Processors
         /// <summary>
         /// The regular expression to search strings for.
         /// </summary>
-        private static readonly Regex QueryRegex = new Regex("rotate=[^&]", RegexOptions.Compiled);
+        private static readonly Regex QueryRegex = new Regex("rotate=[^&]", RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture | RegexOptions.IgnoreCase);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Rotate"/> class.
@@ -40,11 +40,7 @@ namespace ImageProcessor.Web.Processors
         /// <summary>
         /// Gets the order in which this processor is to be used in a chain.
         /// </summary>
-        public int SortOrder
-        {
-            get;
-            private set;
-        }
+        public int SortOrder { get; private set; }
 
         /// <summary>
         /// Gets the associated graphics processor.
@@ -63,11 +59,12 @@ namespace ImageProcessor.Web.Processors
         public int MatchRegexIndex(string queryString)
         {
             this.SortOrder = int.MaxValue;
-            Match match = this.RegexPattern.Match(queryString);
 
+            Match match = this.RegexPattern.Match(queryString);
             if (match.Success)
             {
                 this.SortOrder = match.Index;
+
                 NameValueCollection queryCollection = HttpUtility.ParseQueryString(queryString);
                 this.Processor.DynamicParameter = QueryParamParser.Instance.ParseValue<float>(queryCollection["rotate"]);
             }

--- a/src/ImageProcessor.Web/Processors/RotateBounded.cs
+++ b/src/ImageProcessor.Web/Processors/RotateBounded.cs
@@ -26,12 +26,12 @@ namespace ImageProcessor.Web.Processors
         /// <summary>
         /// The regular expression to search strings for.
         /// </summary>
-        private static readonly Regex QueryRegex = new Regex("rotatebounded=[^&]", RegexOptions.Compiled);
+        private static readonly Regex QueryRegex = new Regex("rotatebounded=[^&]", RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture | RegexOptions.IgnoreCase);
 
         /// <summary>
         /// The regular expression to search for.
         /// </summary>
-        private static readonly Regex BoundRegex = new Regex("rotatebounded.keepsize=true", RegexOptions.Compiled);
+        private static readonly Regex BoundRegex = new Regex("rotatebounded.keepsize=true", RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture | RegexOptions.IgnoreCase);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RotateBounded"/> class.
@@ -46,11 +46,7 @@ namespace ImageProcessor.Web.Processors
         /// <summary>
         /// Gets the order in which this processor is to be used in a chain.
         /// </summary>
-        public int SortOrder
-        {
-            get;
-            private set;
-        }
+        public int SortOrder { get; private set; }
 
         /// <summary>
         /// Gets the associated graphics processor.
@@ -69,14 +65,14 @@ namespace ImageProcessor.Web.Processors
         public int MatchRegexIndex(string queryString)
         {
             this.SortOrder = int.MaxValue;
-            Match match = this.RegexPattern.Match(queryString);
 
+            Match match = this.RegexPattern.Match(queryString);
             if (match.Success)
             {
                 this.SortOrder = match.Index;
                 NameValueCollection queryCollection = HttpUtility.ParseQueryString(queryString);
                 float angle = QueryParamParser.Instance.ParseValue<float>(queryCollection["rotatebounded"]);
-                bool keepSize = BoundRegex.Match(queryString).Success;
+                bool keepSize = BoundRegex.IsMatch(queryString);
 
                 this.Processor.DynamicParameter = new Tuple<float, bool>(angle, keepSize);
             }

--- a/src/ImageProcessor.Web/Processors/RoundedCorners.cs
+++ b/src/ImageProcessor.Web/Processors/RoundedCorners.cs
@@ -26,7 +26,7 @@ namespace ImageProcessor.Web.Processors
         /// <summary>
         /// The regular expression to search strings for.
         /// </summary>
-        private static readonly Regex QueryRegex = new Regex(@"roundedcorners=\d+", RegexOptions.Compiled);
+        private static readonly Regex QueryRegex = new Regex(@"roundedcorners=\d+", RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture | RegexOptions.IgnoreCase);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RoundedCorners"/> class.
@@ -58,14 +58,14 @@ namespace ImageProcessor.Web.Processors
         public int MatchRegexIndex(string queryString)
         {
             this.SortOrder = int.MaxValue;
-            Match match = this.RegexPattern.Match(queryString);
 
+            Match match = this.RegexPattern.Match(queryString);
             if (match.Success)
             {
                 this.SortOrder = match.Index;
                 NameValueCollection queryCollection = HttpUtility.ParseQueryString(queryString);
 
-                this.Processor.DynamicParameter = (RoundedCornerLayer)new RoundedCornerLayer(
+                this.Processor.DynamicParameter = new RoundedCornerLayer(
                     QueryParamParser.Instance.ParseValue<int>(queryCollection["roundedcorners"]),
                     this.ParseCorner(queryCollection, "tl"),
                     this.ParseCorner(queryCollection, "tr"),

--- a/src/ImageProcessor.Web/Processors/Saturation.cs
+++ b/src/ImageProcessor.Web/Processors/Saturation.cs
@@ -26,7 +26,7 @@ namespace ImageProcessor.Web.Processors
         /// <summary>
         /// The regular expression to search strings for.
         /// </summary>
-        private static readonly Regex QueryRegex = new Regex(@"saturation=(-)?\d+", RegexOptions.Compiled);
+        private static readonly Regex QueryRegex = new Regex(@"saturation=(-)?\d+", RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture | RegexOptions.IgnoreCase);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Saturation"/> class.
@@ -58,8 +58,8 @@ namespace ImageProcessor.Web.Processors
         public int MatchRegexIndex(string queryString)
         {
             this.SortOrder = int.MaxValue;
-            Match match = this.RegexPattern.Match(queryString);
 
+            Match match = this.RegexPattern.Match(queryString);
             if (match.Success)
             {
                 this.SortOrder = match.Index;

--- a/src/ImageProcessor.Web/Processors/Tint.cs
+++ b/src/ImageProcessor.Web/Processors/Tint.cs
@@ -26,7 +26,7 @@ namespace ImageProcessor.Web.Processors
         /// <summary>
         /// The regular expression to search strings for.
         /// </summary>
-        private static readonly Regex QueryRegex = new Regex("tint=[^&]", RegexOptions.Compiled);
+        private static readonly Regex QueryRegex = new Regex("tint=[^&]", RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture | RegexOptions.IgnoreCase);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Tint"/> class.
@@ -58,8 +58,8 @@ namespace ImageProcessor.Web.Processors
         public int MatchRegexIndex(string queryString)
         {
             this.SortOrder = int.MaxValue;
-            Match match = this.RegexPattern.Match(queryString);
 
+            Match match = this.RegexPattern.Match(queryString);
             if (match.Success)
             {
                 this.SortOrder = match.Index;

--- a/src/ImageProcessor.Web/Processors/Vignette.cs
+++ b/src/ImageProcessor.Web/Processors/Vignette.cs
@@ -26,7 +26,7 @@ namespace ImageProcessor.Web.Processors
         /// <summary>
         /// The regular expression to search strings for.
         /// </summary>
-        private static readonly Regex QueryRegex = new Regex("vignette(=true)?[^&]+", RegexOptions.Compiled);
+        private static readonly Regex QueryRegex = new Regex("vignette(=true)?[^&]+", RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture | RegexOptions.IgnoreCase);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Vignette"/> class.
@@ -60,11 +60,12 @@ namespace ImageProcessor.Web.Processors
         public int MatchRegexIndex(string queryString)
         {
             this.SortOrder = int.MaxValue;
-            Match match = this.RegexPattern.Match(queryString);
 
+            Match match = this.RegexPattern.Match(queryString);
             if (match.Success)
             {
                 this.SortOrder = match.Index;
+
                 NameValueCollection queryCollection = HttpUtility.ParseQueryString(queryString);
                 string vignette = queryCollection["vignette"];
                 bool doVignette = QueryParamParser.Instance.ParseValue<bool>(vignette);

--- a/src/ImageProcessor.Web/Processors/Watermark.cs
+++ b/src/ImageProcessor.Web/Processors/Watermark.cs
@@ -28,7 +28,7 @@ namespace ImageProcessor.Web.Processors
         /// <summary>
         /// The regular expression to search strings for.
         /// </summary>
-        private static readonly Regex QueryRegex = new Regex("watermark=", RegexOptions.Compiled);
+        private static readonly Regex QueryRegex = new Regex("watermark=", RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture | RegexOptions.IgnoreCase);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Watermark"/> class.
@@ -62,11 +62,12 @@ namespace ImageProcessor.Web.Processors
         public int MatchRegexIndex(string queryString)
         {
             this.SortOrder = int.MaxValue;
-            Match match = this.RegexPattern.Match(queryString);
 
+            Match match = this.RegexPattern.Match(queryString);
             if (match.Success)
             {
                 this.SortOrder = match.Index;
+
                 NameValueCollection queryCollection = HttpUtility.ParseQueryString(queryString);
                 var textLayer = new TextLayer
                 {

--- a/tests/ImageProcessor.Web.UnitTests/Extensions/StringExtensionsUnitTests.cs
+++ b/tests/ImageProcessor.Web.UnitTests/Extensions/StringExtensionsUnitTests.cs
@@ -95,7 +95,7 @@ namespace ImageProcessor.Web.UnitTests.Extensions
         public void TestToMd5Fingerprint(string input, string expected)
         {
             string result = input.ToMD5Fingerprint();
-            bool comparison = result.Equals(expected, StringComparison.InvariantCultureIgnoreCase);
+            bool comparison = result.Equals(expected);
             Assert.True(comparison);
         }
 
@@ -112,7 +112,7 @@ namespace ImageProcessor.Web.UnitTests.Extensions
         public void TestToSHA1Fingerprint(string input, string expected)
         {
             string result = input.ToSHA1Fingerprint();
-            bool comparison = result.Equals(expected, StringComparison.InvariantCultureIgnoreCase);
+            bool comparison = result.Equals(expected);
             Assert.True(comparison);
         }
 


### PR DESCRIPTION
In addition to PR #728, this changes the Regex options to ignore casing within the query string, use culture invariant and explicit capture to improve performance and correctly escapes input used in the patterns.

Because processors are matched using a Regex expression, but (if matched) use the case insensitive query string (`NameValueCollection`), some weird behavior can be experienced:
- `image.jpg?width=300` - resizes to 300
- `image.jpg?Width=300` - returns original image, no processing is done!
- `image.jpg?width=300&height=200` - resizes to 300x200
- `image.jpg?Width=300&height=200` - resizes to 300x200, because height is matched in the Regex and the `Resize` processor then parses the query string in a case insensitive way and can successfully get both width and height!
