### PR TITLE
PostProcessor - Add option to disable TruePng via AppSetting

### DIFF
--- a/src/ImageProcessor.Web.Plugins.PostProcessor/ImageProcessor.Web.Plugins.PostProcessor.csproj
+++ b/src/ImageProcessor.Web.Plugins.PostProcessor/ImageProcessor.Web.Plugins.PostProcessor.csproj
@@ -34,6 +34,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
+    <Reference Include="System.configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Web" />
     <Reference Include="System.Xml.Linq" />

--- a/tests/ImageProcessor.TestWebsite/Web.config
+++ b/tests/ImageProcessor.TestWebsite/Web.config
@@ -26,6 +26,7 @@
     <add key="ImageProcessor.RemoteImageService.Timeout" value="29000" /> 
     <add key="ImageProcessor.GaussianBlur.MaxSize" value="20" />
     <add key="ImageProcessor.DiskCache.VirtualCachePath" value="~/App_Data/cache1" />
+    <add key="ImageProcessor.Web.PostProcessor.DisableTruePNG" value="false" />
   </appSettings>
   <system.web>
     <compilation debug="true" targetFramework="4.5.2" />


### PR DESCRIPTION
This PR adds the option to disable TruePng execution by the PostProcessor plugin. This is required as some environments don't allow TruePng to execute properly. 

I and @lars-erik believe it's likely that TruePng is utilizing GDI32 which isn't available on platforms such as Azure WebApps, however, we are unable to prove this as the source code for TruePng isn't available. 

Whilst it's likely that there may be alternative tools that could replace TruePng this project is in soft archive and so I am not exploring this. 

As the PostProcssor doesn't already have a configuration file and I don't want to add one at this stage, in order to disable TruePng you will need to add an AppSetting:

`<add key="ImageProcessor.Web.PostProcessor.DisableTruePNG" value="true" />`