### PR TITLE
Added byte cast to fix entropy crop web processor casting issue.

### DIFF
--- a/src/ImageProcessor.Web/Processors/EntropyCrop.cs
+++ b/src/ImageProcessor.Web/Processors/EntropyCrop.cs
@@ -67,7 +67,7 @@ namespace ImageProcessor.Web.Processors
                 byte threshold = QueryParamParser.Instance.ParseValue<byte>(queryCollection["entropycrop"]);
 
                 // Fallback to the default if 0.
-                this.Processor.DynamicParameter = threshold > 0 ? threshold : 128;
+                this.Processor.DynamicParameter = threshold > 0 ? threshold : (byte)128;
             }
 
             return this.SortOrder;


### PR DESCRIPTION
This is a fix for Issue #731 - I've added a cast to convert the literal 128 value into a byte within the ternary expression, this looks like it was originally removed in a bulk clean-up operation in commit [4af8de4a](https://github.com/JimBobSquarePants/ImageProcessor/commit/4af8de4a6376d9426fadd5c4596bc1de187899c0#diff-e424c650610a9bba9ed533296f341ca7).