### PR TITLE
Added Polly for retry/failover resilience on remote file handler to prevent 500 errors

### DIFF
--- a/src/ImageProcessor.Web/Configuration/Resources/security.config.transform
+++ b/src/ImageProcessor.Web/Configuration/Resources/security.config.transform
@@ -15,6 +15,8 @@
         <setting key="MaxBytes" value="4194304"/>
         <setting key="Timeout" value="3000"/>
         <setting key="Protocol" value="http"/>
+        <setting key="MaxRetryAttempts" value="3"/>
+        <setting key="PauseBetweenFailures" value="3"/>
       </settings>
       <whitelist>
       </whitelist>

--- a/src/ImageProcessor.Web/ImageProcessor.Web.csproj
+++ b/src/ImageProcessor.Web/ImageProcessor.Web.csproj
@@ -40,12 +40,24 @@
     <Reference Include="Microsoft.IO.RecyclableMemoryStream, Version=1.2.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.IO.RecyclableMemoryStream.1.2.2\lib\net45\Microsoft.IO.RecyclableMemoryStream.dll</HintPath>
     </Reference>
+    <Reference Include="Polly, Version=7.0.0.0, Culture=neutral, PublicKeyToken=c8a3ffc3f8f825cc, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Polly.7.1.0\lib\netstandard1.1\Polly.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
+    <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.IO.Compression" />
     <Reference Include="System.Net.Http" />
+    <Reference Include="System.Numerics" />
     <Reference Include="System.Runtime.Caching" />
+    <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Runtime.InteropServices.RuntimeInformation.4.3.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
+    </Reference>
+    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.ValueTuple.4.5.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+    </Reference>
     <Reference Include="System.Web" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/src/ImageProcessor.Web/Services/RemoteImageService.cs
+++ b/src/ImageProcessor.Web/Services/RemoteImageService.cs
@@ -153,7 +153,7 @@ namespace ImageProcessor.Web.Services
                         }
                     }
                 }
-            });
+            }).ConfigureAwait(false);
 
             return buffer;
         }

--- a/src/ImageProcessor.Web/packages.config
+++ b/src/ImageProcessor.Web/packages.config
@@ -2,4 +2,38 @@
 <packages>
   <package id="ConfigureAwaitChecker.Analyzer" version="1.0.0" targetFramework="net45" developmentDependency="true" />
   <package id="Microsoft.IO.RecyclableMemoryStream" version="1.2.2" targetFramework="net45" />
+  <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="net452" />
+  <package id="NETStandard.Library" version="1.6.1" targetFramework="net452" />
+  <package id="Polly" version="7.1.0" targetFramework="net452" />
+  <package id="System.Collections" version="4.3.0" targetFramework="net452" />
+  <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net452" />
+  <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net452" />
+  <package id="System.Diagnostics.Tools" version="4.3.0" targetFramework="net452" />
+  <package id="System.Diagnostics.Tracing" version="4.3.0" targetFramework="net452" />
+  <package id="System.Globalization" version="4.3.0" targetFramework="net452" />
+  <package id="System.IO" version="4.3.0" targetFramework="net452" />
+  <package id="System.IO.Compression" version="4.3.0" targetFramework="net452" />
+  <package id="System.Linq" version="4.3.0" targetFramework="net452" />
+  <package id="System.Linq.Expressions" version="4.3.0" targetFramework="net452" />
+  <package id="System.Net.Http" version="4.3.0" targetFramework="net452" />
+  <package id="System.Net.Primitives" version="4.3.0" targetFramework="net452" />
+  <package id="System.ObjectModel" version="4.3.0" targetFramework="net452" />
+  <package id="System.Reflection" version="4.3.0" targetFramework="net452" />
+  <package id="System.Reflection.Extensions" version="4.3.0" targetFramework="net452" />
+  <package id="System.Reflection.Primitives" version="4.3.0" targetFramework="net452" />
+  <package id="System.Resources.ResourceManager" version="4.3.0" targetFramework="net452" />
+  <package id="System.Runtime" version="4.3.0" targetFramework="net452" />
+  <package id="System.Runtime.Extensions" version="4.3.0" targetFramework="net452" />
+  <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="net452" />
+  <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net452" />
+  <package id="System.Runtime.Numerics" version="4.3.0" targetFramework="net452" />
+  <package id="System.Text.Encoding" version="4.3.0" targetFramework="net452" />
+  <package id="System.Text.Encoding.Extensions" version="4.3.0" targetFramework="net452" />
+  <package id="System.Text.RegularExpressions" version="4.3.0" targetFramework="net452" />
+  <package id="System.Threading" version="4.3.0" targetFramework="net452" />
+  <package id="System.Threading.Tasks" version="4.3.0" targetFramework="net452" />
+  <package id="System.Threading.Timer" version="4.3.0" targetFramework="net452" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net452" />
+  <package id="System.Xml.ReaderWriter" version="4.3.0" targetFramework="net452" />
+  <package id="System.Xml.XDocument" version="4.3.0" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have verified that there are no overlapping [pull-requests](https://github.com/JimBobSquarePants/ImageProcessor/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practise as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [X] I have provided test coverage for my change (where applicable)

### Description
This change adds failover resilience when resizing many (>10) remote images using `/remote.axd`. Currently, the library just fails and returns a 500 error and prevents the images from loading at all. This update fixes that issue and allows the user to configure it.

I made this update for a project we were working on that was loading up to 30+ (in some cases) images from a CDN that didn't have size options available. It's been running in production now with no issues.

<!-- Thanks for contributing to ImageProcessor! -->
