### PR TITLE
It loads very slow on the first initialization

### DIFF
--- a/src/ImageProcessor/Configuration/ImageProcessorBootstrapper.cs
+++ b/src/ImageProcessor/Configuration/ImageProcessorBootstrapper.cs
@@ -76,7 +76,7 @@ namespace ImageProcessor.Configuration
         /// </summary>
         /// <param name="logger"></param>
         public void SetLogger(ILogger logger) => this.Logger = logger;
-
+        public static bool DefaultLoadAssembilies=true;
         /// <summary>
         /// Creates a list, using reflection, of supported image formats that ImageProcessor can run.
         /// </summary>
@@ -94,6 +94,8 @@ namespace ImageProcessor.Configuration
             Type type = typeof(ISupportedImageFormat);
             if (this.SupportedImageFormats == null)
             {
+                if(DefaultLoadAssembilies)
+                {
                 var availableTypes =
                     TypeFinder.GetAssembliesWithKnownExclusions()
                         .SelectMany(a => a.GetLoadableTypes())
@@ -101,7 +103,7 @@ namespace ImageProcessor.Configuration
                         .ToList();
 
                 formats.AddRange(availableTypes.Select(f => Activator.CreateInstance(f) as ISupportedImageFormat).ToList());
-
+                }
                 this.SupportedImageFormats = formats;
             }
         }


### PR DESCRIPTION
I use imageFactory.Load(imgPath); as below:
using (ImageFactory imageFactory = new ImageFactory(preserveExifData: true))
        {
            imageFactory.Load(imgPath);
            imageFactory.ReplaceColor(source, target, 128);

            using (MemoryStream ms = new MemoryStream())
            {
                imageFactory.Save(ms);
                return Image.FromStream(ms);
            }
        }

I have lots of assemblies in our system . It loads very slow on the first initialization,It takes 9965 ms to load all my assemblies which is not what I want . The init formats is enough for me .

ImageProcessor.Configuration.ImageProcessorBootstrapper.LoadSupportedImageFormats() 9833 ms
System.Linq.Enumerable.ToList(IEnumerable[TSource])   7724 ms
ImageProcessor.Configuration.ImageProcessorBootstrapper+<>c.<LoadSupportedImageFormats>b__18_0(Assembly)             7718ms
ImageProcessor.Common.Extensions.AssemblyExtensions.GetLoadableTypes(Assembly)  7718ms
System.Reflection.Assembly.GetTypes()                              7718ms

### Prerequisites

- [ ] I have written a descriptive pull-request title
- [ ] I have verified that there are no overlapping [pull-requests](https://github.com/JimBobSquarePants/ImageProcessor/pulls) open
- [ ] I have verified that I am following matches the existing coding patterns and practise as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [ ] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->

<!-- Thanks for contributing to ImageProcessor! -->
