### PR TITLE
Cache redirects on browser for Amazon S3 and Azure Blob cache

### DIFF
--- a/src/ImageProcessor.Web.Plugins.AmazonS3Cache/AmazonS3Cache.cs
+++ b/src/ImageProcessor.Web.Plugins.AmazonS3Cache/AmazonS3Cache.cs
@@ -331,7 +331,7 @@ namespace ImageProcessor.Web.Plugins.AmazonS3Cache
                 CannedACL = S3CannedACL.PublicRead,
                 Headers =
                 {
-                    CacheControl = string.Format("public, max-age={0}",this.MaxDays* 86400),
+                    CacheControl = $"public, max-age={this.BrowserMaxDays * 86400}",
                     ContentType = contentType
                 }
             };

--- a/src/ImageProcessor.Web.Plugins.AmazonS3Cache/AmazonS3Cache.cs
+++ b/src/ImageProcessor.Web.Plugins.AmazonS3Cache/AmazonS3Cache.cs
@@ -488,7 +488,7 @@ namespace ImageProcessor.Web.Plugins.AmazonS3Cache
                 // Prevent redundant metadata request if paths match.
                 if (this.CachedPath == this.cachedRewritePath)
                 {
-                    ImageProcessingModule.AddCorsRequestHeaders(context);
+                    ImageProcessingModule.SetHeaders(context, null, null, this.BrowserMaxDays);
                     context.Response.Redirect(this.CachedPath, false);
                     return;
                 }
@@ -502,7 +502,8 @@ namespace ImageProcessor.Web.Plugins.AmazonS3Cache
                 {
                     response = (HttpWebResponse)request.GetResponse();
                     response.Dispose();
-                    ImageProcessingModule.AddCorsRequestHeaders(context);
+
+                    ImageProcessingModule.SetHeaders(context, null, null, this.BrowserMaxDays);
                     context.Response.Redirect(this.cachedRewritePath, false);
                 }
                 catch (WebException ex)
@@ -520,7 +521,8 @@ namespace ImageProcessor.Web.Plugins.AmazonS3Cache
                             || response.ResponseUri.AbsoluteUri.Equals(this.cachedRewritePath, StringComparison.OrdinalIgnoreCase))
                         {
                             response.Dispose();
-                            ImageProcessingModule.AddCorsRequestHeaders(context);
+
+                            ImageProcessingModule.SetHeaders(context, null, null, this.BrowserMaxDays);
                             context.Response.Redirect(this.cachedRewritePath, false);
                         }
                         else
@@ -532,7 +534,7 @@ namespace ImageProcessor.Web.Plugins.AmazonS3Cache
                     else
                     {
                         // It's a 404, we should redirect to the cached path we have just saved to.
-                        ImageProcessingModule.AddCorsRequestHeaders(context);
+                        ImageProcessingModule.SetHeaders(context, null, null, this.BrowserMaxDays);
                         context.Response.Redirect(this.CachedPath, false);
                     }
                 }

--- a/src/ImageProcessor.Web.Plugins.AzureBlobCache/AzureBlobCache.cs
+++ b/src/ImageProcessor.Web.Plugins.AzureBlobCache/AzureBlobCache.cs
@@ -406,7 +406,7 @@ namespace ImageProcessor.Web.Plugins.AzureBlobCache
                 // Prevent redundant metadata request if paths match.
                 if (this.CachedPath == this.cachedRewritePath)
                 {
-                    ImageProcessingModule.AddCorsRequestHeaders(context);
+                    ImageProcessingModule.SetHeaders(context, null, null, this.BrowserMaxDays);
                     context.Response.Redirect(this.CachedPath, false);
                     return;
                 }
@@ -422,7 +422,8 @@ namespace ImageProcessor.Web.Plugins.AzureBlobCache
                 {
                     response = (HttpWebResponse)request.GetResponse();
                     response.Dispose();
-                    ImageProcessingModule.AddCorsRequestHeaders(context);
+
+                    ImageProcessingModule.SetHeaders(context, null, null, this.BrowserMaxDays);
                     context.Response.Redirect(this.cachedRewritePath, false);
                 }
                 catch (WebException ex)
@@ -440,7 +441,8 @@ namespace ImageProcessor.Web.Plugins.AzureBlobCache
                             || response.ResponseUri.AbsoluteUri.Equals(this.cachedRewritePath, StringComparison.OrdinalIgnoreCase))
                         {
                             response.Dispose();
-                            ImageProcessingModule.AddCorsRequestHeaders(context);
+
+                            ImageProcessingModule.SetHeaders(context, null, null, this.BrowserMaxDays);
                             context.Response.Redirect(this.cachedRewritePath, false);
                         }
                         else
@@ -452,7 +454,7 @@ namespace ImageProcessor.Web.Plugins.AzureBlobCache
                     else
                     {
                         // It's a 404, we should redirect to the cached path we have just saved to.
-                        ImageProcessingModule.AddCorsRequestHeaders(context);
+                        ImageProcessingModule.SetHeaders(context, null, null, this.BrowserMaxDays);
                         context.Response.Redirect(this.CachedPath, false);
                     }
                 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/JimBobSquarePants/ImageProcessor/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practise as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
When the Amazon S3 and Azure Blob caches were redirecting the local request to the remote/CDN endpoints, it didn't add a `Cache-Control` header and honor the `BrowserMaxDays` setting. This makes sure the redirects are also cached with the same duration as the image itself.