### PR TITLE
Fix and cleanup GetHashCode and Equals

### DIFF
--- a/src/ImageProcessor.Plugins.Cair/ImageProcessor.Plugins.Cair.csproj
+++ b/src/ImageProcessor.Plugins.Cair/ImageProcessor.Plugins.Cair.csproj
@@ -38,6 +38,9 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.ValueTuple.4.5.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -62,6 +65,7 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Resources\Unmanaged\x86\CAIR.exe" />
+    <None Include="packages.config" />
     <None Include="Resources\Unmanaged\x86\GPL.txt" />
     <EmbeddedResource Include="Resources\Unmanaged\x86\pthreadVSE2.dll" />
     <None Include="Resources\Unmanaged\x86\ReadMe.txt" />

--- a/src/ImageProcessor.Plugins.Cair/Imaging/ContentAwareResizeLayer.cs
+++ b/src/ImageProcessor.Plugins.Cair/Imaging/ContentAwareResizeLayer.cs
@@ -10,18 +10,14 @@
 
 namespace ImageProcessor.Plugins.Cair.Imaging
 {
+    using System;
     using System.Drawing;
 
     /// <summary>
     /// Encapsulates the properties required to resize an image using content aware resizing.
     /// </summary>
-    public class ContentAwareResizeLayer
+    public class ContentAwareResizeLayer : IEquatable<ContentAwareResizeLayer>
     {
-        /// <summary>
-        /// The expected output type.
-        /// </summary>
-        private OutputType outputType = OutputType.Cair;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="ContentAwareResizeLayer"/> class.
         /// </summary>
@@ -32,6 +28,11 @@ namespace ImageProcessor.Plugins.Cair.Imaging
         {
             this.Size = size;
         }
+
+        /// <summary>
+        /// Gets or sets the size.
+        /// </summary>
+        public Size Size { get; set; }
 
         /// <summary>
         /// Gets or sets the content aware resize convolution type (Default ContentAwareResizeConvolutionType.Prewitt).
@@ -46,23 +47,7 @@ namespace ImageProcessor.Plugins.Cair.Imaging
         /// <summary>
         /// Gets or sets the expected output type.
         /// </summary>
-        public OutputType OutputType
-        {
-            get
-            {
-                return this.outputType;
-            }
-
-            set
-            {
-                this.outputType = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the size.
-        /// </summary>
-        public Size Size { get; set; }
+        public OutputType OutputType { get; set; } = OutputType.Cair;
 
         /// <summary>
         /// Gets or sets the the file path to a bitmap file that provides weight indicators specified using
@@ -94,21 +79,23 @@ namespace ImageProcessor.Plugins.Cair.Imaging
         /// <returns>
         ///   <c>true</c> if the specified <see cref="System.Object" /> is equal to this instance; otherwise, <c>false</c>.
         /// </returns>
-        public override bool Equals(object obj)
-        {
-            if (!(obj is ContentAwareResizeLayer resizeLayer))
-            {
-                return false;
-            }
+        public override bool Equals(object obj) => obj is ContentAwareResizeLayer contentAwareResizeLayer && this.Equals(contentAwareResizeLayer);
 
-            return this.Size == resizeLayer.Size
-                && this.ConvolutionType == resizeLayer.ConvolutionType
-                && this.EnergyFunction == resizeLayer.EnergyFunction
-                && this.OutputType == resizeLayer.OutputType
-                && this.Parallelize == resizeLayer.Parallelize
-                && this.Timeout == resizeLayer.Timeout
-                && this.WeightPath == resizeLayer.WeightPath;
-        }
+        /// <summary>
+        /// Indicates whether the current object is equal to another object of the same type.
+        /// </summary>
+        /// <param name="other">An object to compare with this object.</param>
+        /// <returns>
+        /// true if the current object is equal to the <paramref name="other" /> parameter; otherwise, false.
+        /// </returns>
+        public bool Equals(ContentAwareResizeLayer other) => other != null
+            && this.Size == other.Size
+            && this.ConvolutionType == other.ConvolutionType
+            && this.EnergyFunction == other.EnergyFunction
+            && this.OutputType == other.OutputType
+            && this.WeightPath == other.WeightPath
+            && this.Parallelize == other.Parallelize
+            && this.Timeout == other.Timeout;
 
         /// <summary>
         /// Returns a hash code for this instance.
@@ -116,6 +103,6 @@ namespace ImageProcessor.Plugins.Cair.Imaging
         /// <returns>
         /// A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table. 
         /// </returns>
-        public override int GetHashCode() => (this.ConvolutionType, this.EnergyFunction, this.Parallelize, this.OutputType, this.Timeout, this.Size, this.WeightPath).GetHashCode();
+        public override int GetHashCode() => (this.Size, this.ConvolutionType, this.EnergyFunction, this.OutputType, this.WeightPath, this.Parallelize, this.Timeout).GetHashCode();
     }
 }

--- a/src/ImageProcessor.Plugins.Cair/Imaging/ContentAwareResizeLayer.cs
+++ b/src/ImageProcessor.Plugins.Cair/Imaging/ContentAwareResizeLayer.cs
@@ -88,22 +88,15 @@ namespace ImageProcessor.Plugins.Cair.Imaging
         public int Timeout { get; set; } = 60000;
 
         /// <summary>
-        /// Returns a value that indicates whether the specified object is an 
-        /// <see cref="ContentAwareResizeLayer"/> object that is equivalent to 
-        /// this <see cref="ContentAwareResizeLayer"/> object.
+        /// Determines whether the specified <see cref="System.Object" />, is equal to this instance.
         /// </summary>
-        /// <param name="obj">
-        /// The object to test.
-        /// </param>
+        /// <param name="obj">The <see cref="System.Object" /> to compare with this instance.</param>
         /// <returns>
-        /// True if the given object  is an <see cref="ContentAwareResizeLayer"/> object that is equivalent to 
-        /// this <see cref="ContentAwareResizeLayer"/> object; otherwise, false.
+        ///   <c>true</c> if the specified <see cref="System.Object" /> is equal to this instance; otherwise, <c>false</c>.
         /// </returns>
         public override bool Equals(object obj)
         {
-            ContentAwareResizeLayer resizeLayer = obj as ContentAwareResizeLayer;
-
-            if (resizeLayer == null)
+            if (!(obj is ContentAwareResizeLayer resizeLayer))
             {
                 return false;
             }
@@ -118,24 +111,11 @@ namespace ImageProcessor.Plugins.Cair.Imaging
         }
 
         /// <summary>
-        /// Returns the hash code for this instance.
+        /// Returns a hash code for this instance.
         /// </summary>
         /// <returns>
-        /// A 32-bit signed integer that is the hash code for this instance.
+        /// A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table. 
         /// </returns>
-        public override int GetHashCode()
-        {
-            unchecked
-            {
-                int hashCode = (int)this.ConvolutionType;
-                hashCode = (hashCode * 397) ^ (int)this.EnergyFunction;
-                hashCode = (hashCode * 397) ^ this.Parallelize.GetHashCode();
-                hashCode = (hashCode * 397) ^ (int)this.OutputType;
-                hashCode = (hashCode * 397) ^ this.Timeout;
-                hashCode = (hashCode * 397) ^ this.Size.GetHashCode();
-                hashCode = (hashCode * 397) ^ (this.WeightPath != null ? this.WeightPath.GetHashCode() : 0);
-                return hashCode;
-            }
-        }
+        public override int GetHashCode() => (this.ConvolutionType, this.EnergyFunction, this.Parallelize, this.OutputType, this.Timeout, this.Size, this.WeightPath).GetHashCode();
     }
 }

--- a/src/ImageProcessor.Plugins.Cair/packages.config
+++ b/src/ImageProcessor.Plugins.Cair/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net452" />
+</packages>

--- a/src/ImageProcessor/ImageProcessor.csproj
+++ b/src/ImageProcessor/ImageProcessor.csproj
@@ -42,6 +42,9 @@
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.ValueTuple.4.5.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -201,6 +204,9 @@
     <Compile Include="Processors\Vignette.cs" />
     <Compile Include="Processors\Watermark.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/src/ImageProcessor/Imaging/Colors/CmykColor.cs
+++ b/src/ImageProcessor/Imaging/Colors/CmykColor.cs
@@ -262,7 +262,11 @@ namespace ImageProcessor.Imaging.Colors
         /// <returns>
         /// true if the current object is equal to the <paramref name="other" /> parameter; otherwise, false.
         /// </returns>
-        public bool Equals(CmykColor other) => ((Color)this).Equals((Color)other);
+        public bool Equals(CmykColor other) =>
+            this.C == other.C
+            && this.M == other.M
+            && this.Y == other.Y
+            && this.K == other.K;
 
         /// <summary>
         /// Returns a hash code for this instance.
@@ -270,7 +274,7 @@ namespace ImageProcessor.Imaging.Colors
         /// <returns>
         /// A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table. 
         /// </returns>
-        public override int GetHashCode() => ((Color)this).GetHashCode();
+        public override int GetHashCode() => (this.C, this.M, this.Y, this.K).GetHashCode();
 
         /// <summary>
         /// Checks the range of the given value to ensure that it remains within the acceptable boundaries.

--- a/src/ImageProcessor/Imaging/Colors/CmykColor.cs
+++ b/src/ImageProcessor/Imaging/Colors/CmykColor.cs
@@ -247,54 +247,45 @@ namespace ImageProcessor.Imaging.Colors
         }
 
         /// <summary>
-        /// Indicates whether this instance and a specified object are equal.
+        /// Determines whether the specified <see cref="System.Object" />, is equal to this instance.
         /// </summary>
+        /// <param name="obj">The <see cref="System.Object" /> to compare with this instance.</param>
         /// <returns>
-        /// true if <paramref name="obj"/> and this instance are the same type and represent the same value; otherwise, false.
+        ///   <c>true</c> if the specified <see cref="System.Object" /> is equal to this instance; otherwise, <c>false</c>.
         /// </returns>
-        /// <param name="obj">Another object to compare to. </param>
         public override bool Equals(object obj) => obj is CmykColor cmykColor && this.Equals(cmykColor);
 
         /// <summary>
         /// Indicates whether the current object is equal to another object of the same type.
         /// </summary>
         /// <param name="other">An object to compare with this object.</param>
-        /// <returns>true if the current object is equal to the <paramref name="other" /> parameter; otherwise, false.</returns>
-        public bool Equals(CmykColor other)
-        {
-            Color thisColor = this;
-            Color otherColor = other;
-            return thisColor.Equals(otherColor);
-        }
+        /// <returns>
+        /// true if the current object is equal to the <paramref name="other" /> parameter; otherwise, false.
+        /// </returns>
+        public bool Equals(CmykColor other) => ((Color)this).Equals((Color)other);
 
         /// <summary>
-        /// Returns the hash code for this instance.
+        /// Returns a hash code for this instance.
         /// </summary>
         /// <returns>
-        /// A 32-bit signed integer that is the hash code for this instance.
+        /// A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table. 
         /// </returns>
-        public override int GetHashCode()
-        {
-            Color thisColor = this;
-            return thisColor.GetHashCode();
-        }
+        public override int GetHashCode() => ((Color)this).GetHashCode();
 
         /// <summary>
         /// Checks the range of the given value to ensure that it remains within the acceptable boundaries.
         /// </summary>
-        /// <param name="value">
-        /// The value to check.
-        /// </param>
+        /// <param name="value">The value to check.</param>
         /// <returns>
-        /// The sanitized <see cref="float"/>.
+        /// The sanitized <see cref="float" />.
         /// </returns>
         private static float Clamp(float value) => ImageMaths.Clamp(value, 0, 100);
 
         /// <summary>
-        /// Returns a value indicating whether the current instance is empty.
+        /// Determines whether this instance is empty.
         /// </summary>
         /// <returns>
-        /// The true if this instance is empty; otherwise, false.
+        ///   <c>true</c> if this instance is empty; otherwise, <c>false</c>.
         /// </returns>
         private bool IsEmpty()
         {

--- a/src/ImageProcessor/Imaging/Colors/Color32.cs
+++ b/src/ImageProcessor/Imaging/Colors/Color32.cs
@@ -86,47 +86,29 @@ namespace ImageProcessor.Imaging.Colors
         public Color Color => Color.FromArgb(this.A, this.R, this.G, this.B);
 
         /// <summary>
-        /// Indicates whether this instance and a specified object are equal.
+        /// Determines whether the specified <see cref="System.Object" />, is equal to this instance.
         /// </summary>
+        /// <param name="obj">The <see cref="System.Object" /> to compare with this instance.</param>
         /// <returns>
-        /// true if <paramref name="obj"/> and this instance are the same type and represent the same value; otherwise, false.
+        ///   <c>true</c> if the specified <see cref="System.Object" /> is equal to this instance; otherwise, <c>false</c>.
         /// </returns>
-        /// <param name="obj">Another object to compare to. </param>
         public override bool Equals(object obj) => obj is Color32 color32 && this.Equals(color32);
 
         /// <summary>
         /// Indicates whether the current object is equal to another object of the same type.
         /// </summary>
         /// <param name="other">An object to compare with this object.</param>
-        /// <returns>true if the current object is equal to the <paramref name="other" /> parameter; otherwise, false.</returns>
+        /// <returns>
+        /// true if the current object is equal to the <paramref name="other" /> parameter; otherwise, false.
+        /// </returns>
         public bool Equals(Color32 other) => this.Argb.Equals(other.Argb);
 
         /// <summary>
-        /// Returns the hash code for this instance.
+        /// Returns a hash code for this instance.
         /// </summary>
         /// <returns>
-        /// A 32-bit signed integer that is the hash code for this instance.
+        /// A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table. 
         /// </returns>
-        public override int GetHashCode() => this.GetHashCode(this);
-
-        /// <summary>
-        /// Returns the hash code for the given instance.
-        /// </summary>
-        /// <param name="obj">
-        /// The instance of <see cref="Color32"/> to return the hash code for.
-        /// </param>
-        /// <returns>
-        /// A 32-bit signed integer that is the hash code for this instance.
-        /// </returns>
-        private int GetHashCode(Color32 obj)
-        {
-            unchecked
-            {
-                int hashCode = obj.B.GetHashCode();
-                hashCode = (hashCode * 397) ^ obj.G.GetHashCode();
-                hashCode = (hashCode * 397) ^ obj.R.GetHashCode();
-                return (hashCode * 397) ^ obj.A.GetHashCode();
-            }
-        }
+        public override int GetHashCode() => this.Argb.GetHashCode();
     }
 }

--- a/src/ImageProcessor/Imaging/Colors/Color32.cs
+++ b/src/ImageProcessor/Imaging/Colors/Color32.cs
@@ -101,7 +101,7 @@ namespace ImageProcessor.Imaging.Colors
         /// <returns>
         /// true if the current object is equal to the <paramref name="other" /> parameter; otherwise, false.
         /// </returns>
-        public bool Equals(Color32 other) => this.Argb.Equals(other.Argb);
+        public bool Equals(Color32 other) => this.Argb == other.Argb;
 
         /// <summary>
         /// Returns a hash code for this instance.

--- a/src/ImageProcessor/Imaging/Colors/HSLAColor.cs
+++ b/src/ImageProcessor/Imaging/Colors/HSLAColor.cs
@@ -257,7 +257,11 @@ namespace ImageProcessor.Imaging.Colors
         /// <returns>
         /// true if the current object is equal to the <paramref name="other" /> parameter; otherwise, false.
         /// </returns>
-        public bool Equals(HslaColor other) => ((Color)this).Equals((Color)other);
+        public bool Equals(HslaColor other) =>
+            this.H == other.H
+            && this.S == other.S
+            && this.L == other.L
+            && this.A == other.A;
 
         /// <summary>
         /// Returns a hash code for this instance.
@@ -265,7 +269,7 @@ namespace ImageProcessor.Imaging.Colors
         /// <returns>
         /// A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table. 
         /// </returns>
-        public override int GetHashCode() => ((Color)this).GetHashCode();
+        public override int GetHashCode() => (this.H, this.S, this.L, this.A).GetHashCode();
 
         /// <summary>
         /// Gets the color component from the given hue values.

--- a/src/ImageProcessor/Imaging/Colors/HSLAColor.cs
+++ b/src/ImageProcessor/Imaging/Colors/HSLAColor.cs
@@ -242,37 +242,30 @@ namespace ImageProcessor.Imaging.Colors
         }
 
         /// <summary>
-        /// Indicates whether this instance and a specified object are equal.
+        /// Determines whether the specified <see cref="System.Object" />, is equal to this instance.
         /// </summary>
+        /// <param name="obj">The <see cref="System.Object" /> to compare with this instance.</param>
         /// <returns>
-        /// true if <paramref name="obj"/> and this instance are the same type and represent the same value; otherwise, false.
+        ///   <c>true</c> if the specified <see cref="System.Object" /> is equal to this instance; otherwise, <c>false</c>.
         /// </returns>
-        /// <param name="obj">Another object to compare to. </param>
         public override bool Equals(object obj) => obj is HslaColor hslaColor && this.Equals(hslaColor);
 
         /// <summary>
         /// Indicates whether the current object is equal to another object of the same type.
         /// </summary>
         /// <param name="other">An object to compare with this object.</param>
-        /// <returns>true if the current object is equal to the <paramref name="other" /> parameter; otherwise, false.</returns>
-        public bool Equals(HslaColor other)
-        {
-            Color thisColor = this;
-            Color otherColor = other;
-            return thisColor.Equals(otherColor);
-        }
+        /// <returns>
+        /// true if the current object is equal to the <paramref name="other" /> parameter; otherwise, false.
+        /// </returns>
+        public bool Equals(HslaColor other) => ((Color)this).Equals((Color)other);
 
         /// <summary>
-        /// Returns the hash code for this instance.
+        /// Returns a hash code for this instance.
         /// </summary>
         /// <returns>
-        /// A 32-bit signed integer that is the hash code for this instance.
+        /// A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table. 
         /// </returns>
-        public override int GetHashCode()
-        {
-            Color thisColor = this;
-            return thisColor.GetHashCode();
-        }
+        public override int GetHashCode() => ((Color)this).GetHashCode();
 
         /// <summary>
         /// Gets the color component from the given hue values.

--- a/src/ImageProcessor/Imaging/Colors/RGBAColor.cs
+++ b/src/ImageProcessor/Imaging/Colors/RGBAColor.cs
@@ -190,36 +190,29 @@ namespace ImageProcessor.Imaging.Colors
         }
 
         /// <summary>
-        /// Indicates whether this instance and a specified object are equal.
+        /// Determines whether the specified <see cref="System.Object" />, is equal to this instance.
         /// </summary>
+        /// <param name="obj">The <see cref="System.Object" /> to compare with this instance.</param>
         /// <returns>
-        /// true if <paramref name="obj"/> and this instance are the same type and represent the same value; otherwise, false.
+        ///   <c>true</c> if the specified <see cref="System.Object" /> is equal to this instance; otherwise, <c>false</c>.
         /// </returns>
-        /// <param name="obj">Another object to compare to. </param>
         public override bool Equals(object obj) => obj is RgbaColor rgbaColor && this.Equals(rgbaColor);
 
         /// <summary>
         /// Indicates whether the current object is equal to another object of the same type.
         /// </summary>
         /// <param name="other">An object to compare with this object.</param>
-        /// <returns>true if the current object is equal to the <paramref name="other" /> parameter; otherwise, false.</returns>
-        public bool Equals(RgbaColor other)
-        {
-            Color thisColor = this;
-            Color otherColor = other;
-            return thisColor.Equals(otherColor);
-        }
+        /// <returns>
+        /// true if the current object is equal to the <paramref name="other" /> parameter; otherwise, false.
+        /// </returns>
+        public bool Equals(RgbaColor other) => ((Color)this).Equals((Color)other);
 
         /// <summary>
-        /// Returns the hash code for this instance.
+        /// Returns a hash code for this instance.
         /// </summary>
         /// <returns>
-        /// A 32-bit signed integer that is the hash code for this instance.
+        /// A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table. 
         /// </returns>
-        public override int GetHashCode()
-        {
-            Color thisColor = this;
-            return thisColor.GetHashCode();
-        }
+        public override int GetHashCode() => ((Color)this).GetHashCode();
     }
 }

--- a/src/ImageProcessor/Imaging/Colors/RGBAColor.cs
+++ b/src/ImageProcessor/Imaging/Colors/RGBAColor.cs
@@ -205,7 +205,11 @@ namespace ImageProcessor.Imaging.Colors
         /// <returns>
         /// true if the current object is equal to the <paramref name="other" /> parameter; otherwise, false.
         /// </returns>
-        public bool Equals(RgbaColor other) => ((Color)this).Equals((Color)other);
+        public bool Equals(RgbaColor other) =>
+            this.R == other.R
+            && this.G == other.G
+            && this.B == other.B
+            && this.A == other.A;
 
         /// <summary>
         /// Returns a hash code for this instance.
@@ -213,6 +217,6 @@ namespace ImageProcessor.Imaging.Colors
         /// <returns>
         /// A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table. 
         /// </returns>
-        public override int GetHashCode() => ((Color)this).GetHashCode();
+        public override int GetHashCode() => (this.R, this.G, this.B, this.A).GetHashCode();
     }
 }

--- a/src/ImageProcessor/Imaging/Colors/YCbCrColor.cs
+++ b/src/ImageProcessor/Imaging/Colors/YCbCrColor.cs
@@ -168,37 +168,30 @@ namespace ImageProcessor.Imaging.Colors
         }
 
         /// <summary>
-        /// Indicates whether this instance and a specified object are equal.
+        /// Determines whether the specified <see cref="System.Object" />, is equal to this instance.
         /// </summary>
+        /// <param name="obj">The <see cref="System.Object" /> to compare with this instance.</param>
         /// <returns>
-        /// true if <paramref name="obj"/> and this instance are the same type and represent the same value; otherwise, false.
+        ///   <c>true</c> if the specified <see cref="System.Object" /> is equal to this instance; otherwise, <c>false</c>.
         /// </returns>
-        /// <param name="obj">Another object to compare to. </param>
         public override bool Equals(object obj) => obj is YCbCrColor yCbCrColor && this.Equals(yCbCrColor);
 
         /// <summary>
         /// Indicates whether the current object is equal to another object of the same type.
         /// </summary>
         /// <param name="other">An object to compare with this object.</param>
-        /// <returns>true if the current object is equal to the <paramref name="other" /> parameter; otherwise, false.</returns>
-        public bool Equals(YCbCrColor other)
-        {
-            Color thisColor = this;
-            Color otherColor = other;
-            return thisColor.Equals(otherColor);
-        }
+        /// <returns>
+        /// true if the current object is equal to the <paramref name="other" /> parameter; otherwise, false.
+        /// </returns>
+        public bool Equals(YCbCrColor other) => ((Color)this).Equals((Color)other);
 
         /// <summary>
-        /// Returns the hash code for this instance.
+        /// Returns a hash code for this instance.
         /// </summary>
         /// <returns>
-        /// A 32-bit signed integer that is the hash code for this instance.
+        /// A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table. 
         /// </returns>
-        public override int GetHashCode()
-        {
-            Color thisColor = this;
-            return thisColor.GetHashCode();
-        }
+        public override int GetHashCode() => ((Color)this).GetHashCode();
 
         /// <summary>
         /// Returns a value indicating whether the current instance is empty.

--- a/src/ImageProcessor/Imaging/Colors/YCbCrColor.cs
+++ b/src/ImageProcessor/Imaging/Colors/YCbCrColor.cs
@@ -183,7 +183,10 @@ namespace ImageProcessor.Imaging.Colors
         /// <returns>
         /// true if the current object is equal to the <paramref name="other" /> parameter; otherwise, false.
         /// </returns>
-        public bool Equals(YCbCrColor other) => ((Color)this).Equals((Color)other);
+        public bool Equals(YCbCrColor other) =>
+            this.Y == other.Y
+            && this.Cb == other.Cb
+            && this.Cr == other.Cr;
 
         /// <summary>
         /// Returns a hash code for this instance.
@@ -191,7 +194,7 @@ namespace ImageProcessor.Imaging.Colors
         /// <returns>
         /// A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table. 
         /// </returns>
-        public override int GetHashCode() => ((Color)this).GetHashCode();
+        public override int GetHashCode() => (this.Y, this.Cb, this.Cr).GetHashCode();
 
         /// <summary>
         /// Returns a value indicating whether the current instance is empty.

--- a/src/ImageProcessor/Imaging/CropLayer.cs
+++ b/src/ImageProcessor/Imaging/CropLayer.cs
@@ -31,9 +31,24 @@ namespace ImageProcessor.Imaging
         /// </remarks>
         public CropLayer(float left, float top, float right, float bottom, CropMode cropMode = CropMode.Percentage)
         {
-            if (left < 0 || top < 0 || right < 0 || bottom < 0)
+            if (left < 0)
             {
-                throw new ArgumentOutOfRangeException();
+                throw new ArgumentOutOfRangeException(nameof(left));
+            }
+
+            if (top < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(top));
+            }
+
+            if (right < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(right));
+            }
+
+            if (bottom < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(bottom));
             }
 
             this.Left = left;
@@ -85,11 +100,10 @@ namespace ImageProcessor.Imaging
         /// true if the current object is equal to the <paramref name="other" /> parameter; otherwise, false.
         /// </returns>
         public bool Equals(CropLayer other) => other != null
-            // Define the tolerance for variation in their values 
-            && Math.Abs(this.Left - other.Left) <= Math.Abs(this.Left * .0001)
-            && Math.Abs(this.Top - other.Top) <= Math.Abs(this.Top * .0001)
-            && Math.Abs(this.Right - other.Right) <= Math.Abs(this.Right * .0001)
-            && Math.Abs(this.Bottom - other.Bottom) <= Math.Abs(this.Bottom * .0001)
+            && this.Left == other.Left
+            && this.Top == other.Top
+            && this.Right == other.Right
+            && this.Bottom == other.Bottom
             && this.CropMode == other.CropMode;
 
         /// <summary>

--- a/src/ImageProcessor/Imaging/CropLayer.cs
+++ b/src/ImageProcessor/Imaging/CropLayer.cs
@@ -15,7 +15,7 @@ namespace ImageProcessor.Imaging
     /// <summary>
     /// Encapsulates the properties required to crop an image.
     /// </summary>
-    public class CropLayer
+    public class CropLayer : IEquatable<CropLayer>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="CropLayer"/> class.
@@ -75,20 +75,22 @@ namespace ImageProcessor.Imaging
         /// <returns>
         ///   <c>true</c> if the specified <see cref="System.Object" /> is equal to this instance; otherwise, <c>false</c>.
         /// </returns>
-        public override bool Equals(object obj)
-        {
-            if (!(obj is CropLayer cropLayer))
-            {
-                return false;
-            }
+        public override bool Equals(object obj) => obj is CropLayer cropLayer && this.Equals(cropLayer);
 
+        /// <summary>
+        /// Indicates whether the current object is equal to another object of the same type.
+        /// </summary>
+        /// <param name="other">An object to compare with this object.</param>
+        /// <returns>
+        /// true if the current object is equal to the <paramref name="other" /> parameter; otherwise, false.
+        /// </returns>
+        public bool Equals(CropLayer other) => other != null
             // Define the tolerance for variation in their values 
-            return Math.Abs(this.Top - cropLayer.Top) <= Math.Abs(this.Top * .0001)
-                   && Math.Abs(this.Right - cropLayer.Right) <= Math.Abs(this.Right * .0001)
-                   && Math.Abs(this.Bottom - cropLayer.Bottom) <= Math.Abs(this.Bottom * .0001)
-                   && Math.Abs(this.Left - cropLayer.Left) <= Math.Abs(this.Left * .0001)
-                   && this.CropMode.Equals(cropLayer.CropMode);
-        }
+            && Math.Abs(this.Left - other.Left) <= Math.Abs(this.Left * .0001)
+            && Math.Abs(this.Top - other.Top) <= Math.Abs(this.Top * .0001)
+            && Math.Abs(this.Right - other.Right) <= Math.Abs(this.Right * .0001)
+            && Math.Abs(this.Bottom - other.Bottom) <= Math.Abs(this.Bottom * .0001)
+            && this.CropMode == other.CropMode;
 
         /// <summary>
         /// Returns a hash code for this instance.

--- a/src/ImageProcessor/Imaging/CropLayer.cs
+++ b/src/ImageProcessor/Imaging/CropLayer.cs
@@ -69,15 +69,11 @@ namespace ImageProcessor.Imaging
         public CropMode CropMode { get; set; }
 
         /// <summary>
-        /// Determines whether the specified <see cref="System.Object" />, is 
-        /// equal to this instance.
+        /// Determines whether the specified <see cref="System.Object" />, is equal to this instance.
         /// </summary>
-        /// <param name="obj">
-        /// The <see cref="System.Object" /> to compare with this instance.
-        /// </param>
+        /// <param name="obj">The <see cref="System.Object" /> to compare with this instance.</param>
         /// <returns>
-        ///   <c>true</c> if the specified <see cref="System.Object" /> is equal to 
-        ///   this instance; otherwise, <c>false</c>.
+        ///   <c>true</c> if the specified <see cref="System.Object" /> is equal to this instance; otherwise, <c>false</c>.
         /// </returns>
         public override bool Equals(object obj)
         {
@@ -95,21 +91,11 @@ namespace ImageProcessor.Imaging
         }
 
         /// <summary>
-        /// Serves as a hash function for a particular type. 
+        /// Returns a hash code for this instance.
         /// </summary>
         /// <returns>
-        /// A hash code for the current <see cref="T:System.Object"/>.
+        /// A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table. 
         /// </returns>
-        public override int GetHashCode()
-        {
-            unchecked
-            {
-                int hashCode = this.Left.GetHashCode();
-                hashCode = (hashCode * 397) ^ this.Top.GetHashCode();
-                hashCode = (hashCode * 397) ^ this.Right.GetHashCode();
-                hashCode = (hashCode * 397) ^ this.Bottom.GetHashCode();
-                return (hashCode * 397) ^ (int)this.CropMode;
-            }
-        }
+        public override int GetHashCode() => (this.Left, this.Top, this.Right, this.Bottom, this.CropMode).GetHashCode();
     }
 }

--- a/src/ImageProcessor/Imaging/FastBitmap.cs
+++ b/src/ImageProcessor/Imaging/FastBitmap.cs
@@ -20,7 +20,7 @@ namespace ImageProcessor.Imaging
     /// <summary>
     /// Allows fast access to <see cref="System.Drawing.Bitmap"/>'s pixel data.
     /// </summary>
-    public unsafe class FastBitmap : IDisposable
+    public unsafe class FastBitmap : IDisposable, IEquatable<FastBitmap>
     {
         /// <summary>
         /// The integral representation of the 8bppIndexed pixel format.
@@ -406,15 +406,17 @@ namespace ImageProcessor.Imaging
         /// <returns>
         ///   <c>true</c> if the specified <see cref="System.Object" /> is equal to this instance; otherwise, <c>false</c>.
         /// </returns>
-        public override bool Equals(object obj)
-        {
-            if (!(obj is FastBitmap fastBitmap))
-            {
-                return false;
-            }
+        public override bool Equals(object obj) => obj is FastBitmap fastBitmap && this.Equals(fastBitmap);
 
-            return this.bitmap == fastBitmap.bitmap;
-        }
+        /// <summary>
+        /// Indicates whether the current object is equal to another object of the same type.
+        /// </summary>
+        /// <param name="other">An object to compare with this object.</param>
+        /// <returns>
+        /// true if the current object is equal to the <paramref name="other" /> parameter; otherwise, false.
+        /// </returns>
+        public bool Equals(FastBitmap other) => other != null
+            && this.bitmap == other.bitmap;
 
         /// <summary>
         /// Returns a hash code for this instance.

--- a/src/ImageProcessor/Imaging/FastBitmap.cs
+++ b/src/ImageProcessor/Imaging/FastBitmap.cs
@@ -400,12 +400,12 @@ namespace ImageProcessor.Imaging
         }
 
         /// <summary>
-        /// Determines whether the specified <see cref="T:System.Object"/> is equal to the current <see cref="T:System.Object"/>.
+        /// Determines whether the specified <see cref="System.Object" />, is equal to this instance.
         /// </summary>
+        /// <param name="obj">The <see cref="System.Object" /> to compare with this instance.</param>
         /// <returns>
-        /// true if the specified object  is equal to the current object; otherwise, false.
+        ///   <c>true</c> if the specified <see cref="System.Object" /> is equal to this instance; otherwise, <c>false</c>.
         /// </returns>
-        /// <param name="obj">The object to compare with the current object. </param>
         public override bool Equals(object obj)
         {
             if (!(obj is FastBitmap fastBitmap))
@@ -417,10 +417,10 @@ namespace ImageProcessor.Imaging
         }
 
         /// <summary>
-        /// Serves as a hash function for a particular type. 
+        /// Returns a hash code for this instance.
         /// </summary>
         /// <returns>
-        /// A hash code for the current <see cref="T:System.Object"/>.
+        /// A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table. 
         /// </returns>
         public override int GetHashCode() => this.bitmap.GetHashCode();
 

--- a/src/ImageProcessor/Imaging/Filters/Photo/MatrixFilterBase.cs
+++ b/src/ImageProcessor/Imaging/Filters/Photo/MatrixFilterBase.cs
@@ -52,7 +52,33 @@ namespace ImageProcessor.Imaging.Filters.Photo
         /// </returns>
         public bool Equals(IMatrixFilter other) => other != null
             && this.GetType() == other.GetType()
-            && this.Matrix == other.Matrix;
+            && (this.Matrix == null || other.Matrix == null ? this.Matrix == other.Matrix : (
+                this.Matrix.Matrix00 == other.Matrix.Matrix00
+                && this.Matrix.Matrix01 == other.Matrix.Matrix01
+                && this.Matrix.Matrix02 == other.Matrix.Matrix02
+                && this.Matrix.Matrix03 == other.Matrix.Matrix03
+                && this.Matrix.Matrix04 == other.Matrix.Matrix04
+                && this.Matrix.Matrix10 == other.Matrix.Matrix10
+                && this.Matrix.Matrix11 == other.Matrix.Matrix11
+                && this.Matrix.Matrix12 == other.Matrix.Matrix12
+                && this.Matrix.Matrix13 == other.Matrix.Matrix13
+                && this.Matrix.Matrix14 == other.Matrix.Matrix14
+                && this.Matrix.Matrix20 == other.Matrix.Matrix20
+                && this.Matrix.Matrix21 == other.Matrix.Matrix21
+                && this.Matrix.Matrix22 == other.Matrix.Matrix22
+                && this.Matrix.Matrix23 == other.Matrix.Matrix23
+                && this.Matrix.Matrix24 == other.Matrix.Matrix24
+                && this.Matrix.Matrix30 == other.Matrix.Matrix30
+                && this.Matrix.Matrix31 == other.Matrix.Matrix31
+                && this.Matrix.Matrix32 == other.Matrix.Matrix32
+                && this.Matrix.Matrix33 == other.Matrix.Matrix33
+                && this.Matrix.Matrix34 == other.Matrix.Matrix34
+                && this.Matrix.Matrix40 == other.Matrix.Matrix40
+                && this.Matrix.Matrix41 == other.Matrix.Matrix41
+                && this.Matrix.Matrix42 == other.Matrix.Matrix42
+                && this.Matrix.Matrix43 == other.Matrix.Matrix43
+                && this.Matrix.Matrix44 == other.Matrix.Matrix44
+            ));
 
         /// <summary>
         /// Returns a hash code for this instance.
@@ -60,6 +86,32 @@ namespace ImageProcessor.Imaging.Filters.Photo
         /// <returns>
         /// A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table. 
         /// </returns>
-        public override int GetHashCode() => (this.GetType(), this.Matrix).GetHashCode();
+        public override int GetHashCode() => (
+            this.GetType(),
+            this.Matrix?.Matrix00,
+            this.Matrix?.Matrix01,
+            this.Matrix?.Matrix02,
+            this.Matrix?.Matrix03,
+            this.Matrix?.Matrix04,
+            this.Matrix?.Matrix10,
+            this.Matrix?.Matrix11,
+            this.Matrix?.Matrix12,
+            this.Matrix?.Matrix13,
+            this.Matrix?.Matrix14,
+            this.Matrix?.Matrix20,
+            this.Matrix?.Matrix21,
+            this.Matrix?.Matrix22,
+            this.Matrix?.Matrix23,
+            this.Matrix?.Matrix24,
+            this.Matrix?.Matrix30,
+            this.Matrix?.Matrix31,
+            this.Matrix?.Matrix32,
+            this.Matrix?.Matrix33,
+            this.Matrix?.Matrix34,
+            this.Matrix?.Matrix40,
+            this.Matrix?.Matrix41,
+            this.Matrix?.Matrix42,
+            this.Matrix?.Matrix43,
+            this.Matrix?.Matrix44).GetHashCode();
     }
 }

--- a/src/ImageProcessor/Imaging/Filters/Photo/MatrixFilterBase.cs
+++ b/src/ImageProcessor/Imaging/Filters/Photo/MatrixFilterBase.cs
@@ -29,16 +29,16 @@ namespace ImageProcessor.Imaging.Filters.Photo
         /// <param name="source">The current image to process</param>
         /// <param name="destination">The new image to return</param>
         /// <returns>
-        /// The processed <see cref="System.Drawing.Bitmap"/>.
+        /// The processed <see cref="System.Drawing.Bitmap" />.
         /// </returns>
         public abstract Bitmap TransformImage(Image source, Image destination);
 
         /// <summary>
-        /// Determines whether the specified <see cref="IMatrixFilter" />, is equal to this instance.
+        /// Determines whether the specified <see cref="System.Object" />, is equal to this instance.
         /// </summary>
-        /// <param name="obj">The <see cref="IMatrixFilter" /> to compare with this instance.</param>
+        /// <param name="obj">The <see cref="System.Object" /> to compare with this instance.</param>
         /// <returns>
-        ///   <c>true</c> if the specified <see cref="IMatrixFilter" /> is equal to this instance; otherwise, <c>false</c>.
+        ///   <c>true</c> if the specified <see cref="System.Object" /> is equal to this instance; otherwise, <c>false</c>.
         /// </returns>
         public override bool Equals(object obj)
         {
@@ -47,23 +47,16 @@ namespace ImageProcessor.Imaging.Filters.Photo
                 return false;
             }
 
-            return this.GetType().Name == filter.GetType().Name
-                   && this.Matrix.Equals(filter.Matrix);
+            return this.GetType() == filter.GetType()
+                   && (this.Matrix == null || filter.Matrix == null ? this.Matrix == filter.Matrix : this.Matrix.Equals(filter.Matrix));
         }
 
         /// <summary>
-        /// Returns the hash code for this instance.
+        /// Returns a hash code for this instance.
         /// </summary>
         /// <returns>
-        /// A 32-bit signed integer that is the hash code for this instance.
+        /// A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table. 
         /// </returns>
-        public override int GetHashCode()
-        {
-            unchecked
-            {
-                int hashCode = this.GetType().Name.GetHashCode();
-                return (hashCode * 397) ^ this.Matrix.GetHashCode();
-            }
-        }
+        public override int GetHashCode() => (this.GetType(), this.Matrix).GetHashCode();
     }
 }

--- a/src/ImageProcessor/Imaging/Filters/Photo/MatrixFilterBase.cs
+++ b/src/ImageProcessor/Imaging/Filters/Photo/MatrixFilterBase.cs
@@ -10,13 +10,14 @@
 
 namespace ImageProcessor.Imaging.Filters.Photo
 {
+    using System;
     using System.Drawing;
     using System.Drawing.Imaging;
 
     /// <summary>
     /// The matrix filter base contains equality methods.
     /// </summary>
-    public abstract class MatrixFilterBase : IMatrixFilter
+    public abstract class MatrixFilterBase : IMatrixFilter, IEquatable<IMatrixFilter>
     {
         /// <summary>
         /// Gets the <see cref="T:System.Drawing.Imaging.ColorMatrix" /> for this filter instance.
@@ -40,16 +41,18 @@ namespace ImageProcessor.Imaging.Filters.Photo
         /// <returns>
         ///   <c>true</c> if the specified <see cref="System.Object" /> is equal to this instance; otherwise, <c>false</c>.
         /// </returns>
-        public override bool Equals(object obj)
-        {
-            if (!(obj is IMatrixFilter filter))
-            {
-                return false;
-            }
+        public override bool Equals(object obj) => obj is IMatrixFilter matrixFilter && this.Equals(matrixFilter);
 
-            return this.GetType() == filter.GetType()
-                   && (this.Matrix == null || filter.Matrix == null ? this.Matrix == filter.Matrix : this.Matrix.Equals(filter.Matrix));
-        }
+        /// <summary>
+        /// Indicates whether the current object is equal to another object of the same type.
+        /// </summary>
+        /// <param name="other">An object to compare with this object.</param>
+        /// <returns>
+        /// true if the current object is equal to the <paramref name="other" /> parameter; otherwise, false.
+        /// </returns>
+        public bool Equals(IMatrixFilter other) => other != null
+            && this.GetType() == other.GetType()
+            && this.Matrix == other.Matrix;
 
         /// <summary>
         /// Returns a hash code for this instance.

--- a/src/ImageProcessor/Imaging/Formats/FormatBase.cs
+++ b/src/ImageProcessor/Imaging/Formats/FormatBase.cs
@@ -123,11 +123,11 @@ namespace ImageProcessor.Imaging.Formats
         }
 
         /// <summary>
-        /// Determines whether the specified <see cref="object" />, is equal to this instance.
+        /// Determines whether the specified <see cref="System.Object" />, is equal to this instance.
         /// </summary>
-        /// <param name="obj">The <see cref="object" /> to compare with this instance.</param>
+        /// <param name="obj">The <see cref="System.Object" /> to compare with this instance.</param>
         /// <returns>
-        ///   <c>true</c> if the specified <see cref="object" /> is equal to this instance; otherwise, <c>false</c>.
+        ///   <c>true</c> if the specified <see cref="System.Object" /> is equal to this instance; otherwise, <c>false</c>.
         /// </returns>
         public override bool Equals(object obj)
         {
@@ -136,23 +136,16 @@ namespace ImageProcessor.Imaging.Formats
                 return false;
             }
 
-            return this.MimeType.Equals(format.MimeType) && this.IsIndexed.Equals(format.IsIndexed);
+            return (this.MimeType == null || format.MimeType == null ? this.MimeType == format.MimeType : this.MimeType.Equals(format.MimeType))
+                && this.IsIndexed.Equals(format.IsIndexed);
         }
 
         /// <summary>
-        /// Returns the hash code for this instance.
+        /// Returns a hash code for this instance.
         /// </summary>
         /// <returns>
-        /// A 32-bit signed integer that is the hash code for this instance.
+        /// A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table. 
         /// </returns>
-        public override int GetHashCode()
-        {
-            unchecked
-            {
-                int hashCode = this.MimeType.GetHashCode();
-                hashCode = (hashCode * 397) ^ this.IsIndexed.GetHashCode();
-                return (hashCode * 397) ^ this.Quality;
-            }
-        }
+        public override int GetHashCode() => (this.MimeType, this.IsIndexed, this.Quality).GetHashCode();
     }
 }

--- a/src/ImageProcessor/Imaging/Formats/FormatBase.cs
+++ b/src/ImageProcessor/Imaging/Formats/FormatBase.cs
@@ -148,6 +148,6 @@ namespace ImageProcessor.Imaging.Formats
         /// <returns>
         /// A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table. 
         /// </returns>
-        public override int GetHashCode() => (this.MimeType, this.IsIndexed, this.Quality).GetHashCode();
+        public override int GetHashCode() => (this.MimeType, this.IsIndexed).GetHashCode();
     }
 }

--- a/src/ImageProcessor/Imaging/Formats/FormatBase.cs
+++ b/src/ImageProcessor/Imaging/Formats/FormatBase.cs
@@ -18,7 +18,7 @@ namespace ImageProcessor.Imaging.Formats
     /// <summary>
     /// The supported format base. Implement this class when building a supported format.
     /// </summary>
-    public abstract class FormatBase : ISupportedImageFormat
+    public abstract class FormatBase : ISupportedImageFormat, IEquatable<ISupportedImageFormat>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="FormatBase"/> class.
@@ -129,16 +129,18 @@ namespace ImageProcessor.Imaging.Formats
         /// <returns>
         ///   <c>true</c> if the specified <see cref="System.Object" /> is equal to this instance; otherwise, <c>false</c>.
         /// </returns>
-        public override bool Equals(object obj)
-        {
-            if (!(obj is ISupportedImageFormat format))
-            {
-                return false;
-            }
+        public override bool Equals(object obj) => obj is ISupportedImageFormat format && this.Equals(format);
 
-            return (this.MimeType == null || format.MimeType == null ? this.MimeType == format.MimeType : this.MimeType.Equals(format.MimeType))
-                && this.IsIndexed.Equals(format.IsIndexed);
-        }
+        /// <summary>
+        /// Indicates whether the current object is equal to another object of the same type.
+        /// </summary>
+        /// <param name="other">An object to compare with this object.</param>
+        /// <returns>
+        /// true if the current object is equal to the <paramref name="other" /> parameter; otherwise, false.
+        /// </returns>
+        public bool Equals(ISupportedImageFormat other) => other != null
+            && this.MimeType == other.MimeType
+            && this.IsIndexed == other.IsIndexed;
 
         /// <summary>
         /// Returns a hash code for this instance.

--- a/src/ImageProcessor/Imaging/GaussianLayer.cs
+++ b/src/ImageProcessor/Imaging/GaussianLayer.cs
@@ -131,16 +131,11 @@ namespace ImageProcessor.Imaging
         }
 
         /// <summary>
-        /// Returns a value that indicates whether the specified object is an 
-        /// <see cref="GaussianLayer"/> object that is equivalent to 
-        /// this <see cref="GaussianLayer"/> object.
+        /// Determines whether the specified <see cref="System.Object" />, is equal to this instance.
         /// </summary>
-        /// <param name="obj">
-        /// The object to test.
-        /// </param>
+        /// <param name="obj">The <see cref="System.Object" /> to compare with this instance.</param>
         /// <returns>
-        /// True if the given object  is an <see cref="GaussianLayer"/> object that is equivalent to 
-        /// this <see cref="GaussianLayer"/> object; otherwise, false.
+        ///   <c>true</c> if the specified <see cref="System.Object" /> is equal to this instance; otherwise, <c>false</c>.
         /// </returns>
         public override bool Equals(object obj)
         {
@@ -155,19 +150,11 @@ namespace ImageProcessor.Imaging
         }
 
         /// <summary>
-        /// Serves as a hash function for a particular type. 
+        /// Returns a hash code for this instance.
         /// </summary>
         /// <returns>
-        /// A hash code for the current <see cref="T:System.Object"/>.
+        /// A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table. 
         /// </returns>
-        public override int GetHashCode()
-        {
-            unchecked
-            {
-                int hashCode = this.Size;
-                hashCode = (hashCode * 397) ^ this.Size.GetHashCode();
-                return (hashCode * 397) ^ this.Threshold;
-            }
-        }
+        public override int GetHashCode() => (this.Size, this.Threshold).GetHashCode();
     }
 }

--- a/src/ImageProcessor/Imaging/GaussianLayer.cs
+++ b/src/ImageProcessor/Imaging/GaussianLayer.cs
@@ -158,6 +158,6 @@ namespace ImageProcessor.Imaging
         /// <returns>
         /// A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table. 
         /// </returns>
-        public override int GetHashCode() => (this.Size, this.Threshold).GetHashCode();
+        public override int GetHashCode() => (this.Size, this.Sigma, this.Threshold).GetHashCode();
     }
 }

--- a/src/ImageProcessor/Imaging/GaussianLayer.cs
+++ b/src/ImageProcessor/Imaging/GaussianLayer.cs
@@ -15,7 +15,7 @@ namespace ImageProcessor.Imaging
     /// <summary>
     /// A Gaussian layer for applying sharpening and blurring methods to an image.
     /// </summary>
-    public class GaussianLayer
+    public class GaussianLayer : IEquatable<GaussianLayer>
     {
         /// <summary>
         /// The size.
@@ -137,17 +137,20 @@ namespace ImageProcessor.Imaging
         /// <returns>
         ///   <c>true</c> if the specified <see cref="System.Object" /> is equal to this instance; otherwise, <c>false</c>.
         /// </returns>
-        public override bool Equals(object obj)
-        {
-            if (!(obj is GaussianLayer gaussianLayer))
-            {
-                return false;
-            }
+        public override bool Equals(object obj) => obj is GaussianLayer gaussianLayer && this.Equals(gaussianLayer);
 
-            return this.Size == gaussianLayer.Size
-                && Math.Abs(this.Sigma - gaussianLayer.Sigma) < 0.0001
-                && this.Threshold == gaussianLayer.Threshold;
-        }
+        /// <summary>
+        /// Indicates whether the current object is equal to another object of the same type.
+        /// </summary>
+        /// <param name="other">An object to compare with this object.</param>
+        /// <returns>
+        /// true if the current object is equal to the <paramref name="other" /> parameter; otherwise, false.
+        /// </returns>
+        public bool Equals(GaussianLayer other) => other != null
+            && this.Size == other.Size
+            // Define the tolerance for variation in their values 
+            && Math.Abs(this.Sigma - other.Sigma) < 0.0001
+            && this.Threshold == other.Threshold;
 
         /// <summary>
         /// Returns a hash code for this instance.

--- a/src/ImageProcessor/Imaging/GaussianLayer.cs
+++ b/src/ImageProcessor/Imaging/GaussianLayer.cs
@@ -148,8 +148,7 @@ namespace ImageProcessor.Imaging
         /// </returns>
         public bool Equals(GaussianLayer other) => other != null
             && this.Size == other.Size
-            // Define the tolerance for variation in their values 
-            && Math.Abs(this.Sigma - other.Sigma) < 0.0001
+            && this.Sigma == other.Sigma
             && this.Threshold == other.Threshold;
 
         /// <summary>

--- a/src/ImageProcessor/Imaging/ImageLayer.cs
+++ b/src/ImageProcessor/Imaging/ImageLayer.cs
@@ -15,7 +15,7 @@ namespace ImageProcessor.Imaging
     /// <summary>
     /// Encapsulates the properties required to add an image layer to an image.
     /// </summary>
-    public class ImageLayer : IDisposable
+    public class ImageLayer : IDisposable, IEquatable<ImageLayer>
     {
         /// <summary>
         /// A value indicating whether this instance of the given entity has been disposed.
@@ -57,18 +57,20 @@ namespace ImageProcessor.Imaging
         /// <returns>
         ///   <c>true</c> if the specified <see cref="System.Object" /> is equal to this instance; otherwise, <c>false</c>.
         /// </returns>
-        public override bool Equals(object obj)
-        {
-            if (!(obj is ImageLayer imageLayer))
-            {
-                return false;
-            }
+        public override bool Equals(object obj) => obj is ImageLayer imageLayer && this.Equals(imageLayer);
 
-            return this.Image == imageLayer.Image
-                && this.Size == imageLayer.Size
-                && this.Opacity == imageLayer.Opacity
-                && this.Position == imageLayer.Position;
-        }
+        /// <summary>
+        /// Indicates whether the current object is equal to another object of the same type.
+        /// </summary>
+        /// <param name="other">An object to compare with this object.</param>
+        /// <returns>
+        /// true if the current object is equal to the <paramref name="other" /> parameter; otherwise, false.
+        /// </returns>
+        public bool Equals(ImageLayer other) => other != null
+            && this.Image == other.Image
+            && this.Size == other.Size
+            && this.Opacity == other.Opacity
+            && this.Position == other.Position;
 
         /// <summary>
         /// Returns a hash code for this instance.

--- a/src/ImageProcessor/Imaging/ImageLayer.cs
+++ b/src/ImageProcessor/Imaging/ImageLayer.cs
@@ -51,16 +51,11 @@ namespace ImageProcessor.Imaging
         public Point? Position { get; set; }
 
         /// <summary>
-        /// Returns a value that indicates whether the specified object is an
-        /// <see cref="ImageLayer"/> object that is equivalent to
-        /// this <see cref="ImageLayer"/> object.
+        /// Determines whether the specified <see cref="System.Object" />, is equal to this instance.
         /// </summary>
-        /// <param name="obj">
-        /// The object to test.
-        /// </param>
+        /// <param name="obj">The <see cref="System.Object" /> to compare with this instance.</param>
         /// <returns>
-        /// True if the given object  is an <see cref="ImageLayer"/> object that is equivalent to
-        /// this <see cref="ImageLayer"/> object; otherwise, false.
+        ///   <c>true</c> if the specified <see cref="System.Object" /> is equal to this instance; otherwise, <c>false</c>.
         /// </returns>
         public override bool Equals(object obj)
         {
@@ -76,21 +71,12 @@ namespace ImageProcessor.Imaging
         }
 
         /// <summary>
-        /// Returns the hash code for this instance.
+        /// Returns a hash code for this instance.
         /// </summary>
         /// <returns>
-        /// A 32-bit signed integer that is the hash code for this instance.
+        /// A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table.
         /// </returns>
-        public override int GetHashCode()
-        {
-            unchecked
-            {
-                int hashCode = this.Image.GetHashCode();
-                hashCode = (hashCode * 397) ^ this.Size.GetHashCode();
-                hashCode = (hashCode * 397) ^ this.Opacity;
-                return (hashCode * 397) ^ this.Position.GetHashCode();
-            }
-        }
+        public override int GetHashCode() => (this.Image, this.Size, this.Opacity, this.Position).GetHashCode();
 
         /// <summary>
         /// Disposes the object and frees resources for the Garbage Collector.

--- a/src/ImageProcessor/Imaging/MetaData/Rational.cs
+++ b/src/ImageProcessor/Imaging/MetaData/Rational.cs
@@ -1000,27 +1000,20 @@ namespace ImageProcessor.Imaging.MetaData
         public override string ToString() => Convert.ToString(this, CultureInfo.InvariantCulture);
 
         /// <summary>
-        /// Indicates whether this instance and a specified object are equal.
+        /// Determines whether the specified <see cref="System.Object" />, is equal to this instance.
         /// </summary>
+        /// <param name="obj">The <see cref="System.Object" /> to compare with this instance.</param>
         /// <returns>
-        /// true if <paramref name="obj"/> and this instance are the same type and represent the same value; 
-        /// otherwise, false. 
+        ///   <c>true</c> if the specified <see cref="System.Object" /> is equal to this instance; otherwise, <c>false</c>.
         /// </returns>
-        /// <param name="obj">The object to compare with the current instance. </param>
         public override bool Equals(object obj) => this.CompareTo(obj) == 0;
 
         /// <summary>
-        /// Returns the hash code for this instance.
+        /// Returns a hash code for this instance.
         /// </summary>
         /// <returns>
-        /// A 32-bit signed integer that is the hash code for this instance.
+        /// A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table. 
         /// </returns>
-        public override int GetHashCode()
-        {
-            // Adapted from Anonymous Type: { uint Numerator, uint Denominator }
-            int num = 0x1fb8d67d;
-            num = (-1521134295 * num) + EqualityComparer<T>.Default.GetHashCode(this.numerator);
-            return (-1521134295 * num) + EqualityComparer<T>.Default.GetHashCode(this.denominator);
-        }
+        public override int GetHashCode() => (this.Numerator, this.Denominator).GetHashCode();
     }
 }

--- a/src/ImageProcessor/Imaging/ResizeLayer.cs
+++ b/src/ImageProcessor/Imaging/ResizeLayer.cs
@@ -143,6 +143,6 @@ namespace ImageProcessor.Imaging
         /// <returns>
         /// A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table. 
         /// </returns>
-        public override int GetHashCode() => (this.Size, this.MaxSize, this.RestrictedSizes, this.ResizeMode, this.AnchorPosition, this.Upscale, this.CenterCoordinates, this.AnchorPoint).GetHashCode();
+        public override int GetHashCode() => (this.Size, this.MaxSize, this.ResizeMode, this.AnchorPosition, this.Upscale, this.AnchorPoint).GetHashCode();
     }
 }

--- a/src/ImageProcessor/Imaging/ResizeLayer.cs
+++ b/src/ImageProcessor/Imaging/ResizeLayer.cs
@@ -118,8 +118,7 @@ namespace ImageProcessor.Imaging
         /// <returns>
         ///   <c>true</c> if the specified <see cref="System.Object" /> is equal to this instance; otherwise, <c>false</c>.
         /// </returns>
-        public override bool Equals(object obj)
-            => this.Equals(obj as ResizeLayer);
+        public override bool Equals(object obj) => obj is ResizeLayer resizeLayer && this.Equals(resizeLayer);
 
         /// <summary>
         /// Indicates whether the current object is equal to another object of the same type.
@@ -128,8 +127,7 @@ namespace ImageProcessor.Imaging
         /// <returns>
         /// true if the current object is equal to the <paramref name="other" /> parameter; otherwise, false.
         /// </returns>
-        public bool Equals(ResizeLayer other)
-            => other != null
+        public bool Equals(ResizeLayer other) => other != null
             && this.Size == other.Size
             && this.MaxSize == other.MaxSize
             && (this.RestrictedSizes == null || other.RestrictedSizes == null ? this.RestrictedSizes == other.RestrictedSizes : this.RestrictedSizes.SequenceEqual(other.RestrictedSizes))

--- a/src/ImageProcessor/Imaging/ResizeLayer.cs
+++ b/src/ImageProcessor/Imaging/ResizeLayer.cs
@@ -10,6 +10,7 @@
 
 namespace ImageProcessor.Imaging
 {
+    using System;
     using System.Collections.Generic;
     using System.Drawing;
     using System.Linq;
@@ -17,7 +18,8 @@ namespace ImageProcessor.Imaging
     /// <summary>
     /// Encapsulates the properties required to resize an image.
     /// </summary>
-    public class ResizeLayer
+    /// <seealso cref="T:System.IEquatable{ImageProcessor.Imaging.ResizeLayer}" />
+    public class ResizeLayer : IEquatable<ResizeLayer>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ResizeLayer"/> class.
@@ -110,59 +112,39 @@ namespace ImageProcessor.Imaging
         public Point? AnchorPoint { get; set; }
 
         /// <summary>
-        /// Returns a value that indicates whether the specified object is an 
-        /// <see cref="ResizeLayer"/> object that is equivalent to 
-        /// this <see cref="ResizeLayer"/> object.
+        /// Determines whether the specified <see cref="System.Object" />, is equal to this instance.
         /// </summary>
-        /// <param name="obj">
-        /// The object to test.
-        /// </param>
+        /// <param name="obj">The <see cref="System.Object" /> to compare with this instance.</param>
         /// <returns>
-        /// True if the given object  is an <see cref="ResizeLayer"/> object that is equivalent to 
-        /// this <see cref="ResizeLayer"/> object; otherwise, false.
+        ///   <c>true</c> if the specified <see cref="System.Object" /> is equal to this instance; otherwise, <c>false</c>.
         /// </returns>
         public override bool Equals(object obj)
-        {
-            if (!(obj is ResizeLayer resizeLayer))
-            {
-                return false;
-            }
-
-            return this.Size == resizeLayer.Size
-                && this.ResizeMode == resizeLayer.ResizeMode
-                && this.AnchorPosition == resizeLayer.AnchorPosition
-                && this.Upscale == resizeLayer.Upscale
-                && ((this.CenterCoordinates != null
-                    && resizeLayer.CenterCoordinates != null
-                    && this.CenterCoordinates.SequenceEqual(resizeLayer.CenterCoordinates))
-                    || (this.CenterCoordinates == resizeLayer.CenterCoordinates))
-                && this.MaxSize == resizeLayer.MaxSize
-                && ((this.RestrictedSizes != null
-                    && resizeLayer.RestrictedSizes != null
-                    && this.RestrictedSizes.SequenceEqual(resizeLayer.RestrictedSizes))
-                    || (this.RestrictedSizes == resizeLayer.RestrictedSizes))
-                && this.AnchorPoint == resizeLayer.AnchorPoint;
-        }
+            => this.Equals(obj as ResizeLayer);
 
         /// <summary>
-        /// Returns the hash code for this instance.
+        /// Indicates whether the current object is equal to another object of the same type.
+        /// </summary>
+        /// <param name="other">An object to compare with this object.</param>
+        /// <returns>
+        /// true if the current object is equal to the <paramref name="other" /> parameter; otherwise, false.
+        /// </returns>
+        public bool Equals(ResizeLayer other)
+            => other != null
+            && this.Size == other.Size
+            && this.MaxSize == other.MaxSize
+            && (this.RestrictedSizes == null || other.RestrictedSizes == null ? this.RestrictedSizes == other.RestrictedSizes : this.RestrictedSizes.SequenceEqual(other.RestrictedSizes))
+            && this.ResizeMode == other.ResizeMode
+            && this.AnchorPosition == other.AnchorPosition
+            && this.Upscale == other.Upscale
+            && (this.CenterCoordinates == null || other.CenterCoordinates == null ? this.CenterCoordinates == other.CenterCoordinates : this.CenterCoordinates.SequenceEqual(other.CenterCoordinates))
+            && this.AnchorPoint == other.AnchorPoint;
+
+        /// <summary>
+        /// Returns a hash code for this instance.
         /// </summary>
         /// <returns>
-        /// A 32-bit signed integer that is the hash code for this instance.
+        /// A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table. 
         /// </returns>
-        public override int GetHashCode()
-        {
-            unchecked
-            {
-                int hashCode = this.Size.GetHashCode();
-                hashCode = (hashCode * 397) ^ this.MaxSize.GetHashCode();
-                hashCode = (hashCode * 397) ^ (this.RestrictedSizes?.GetHashCode() ?? 0);
-                hashCode = (hashCode * 397) ^ (int)this.ResizeMode;
-                hashCode = (hashCode * 397) ^ (int)this.AnchorPosition;
-                hashCode = (hashCode * 397) ^ this.Upscale.GetHashCode();
-                hashCode = (hashCode * 397) ^ (this.CenterCoordinates?.GetHashCode() ?? 0);
-                return (hashCode * 397) ^ this.AnchorPoint.GetHashCode();
-            }
-        }
+        public override int GetHashCode() => (this.Size, this.MaxSize, this.RestrictedSizes, this.ResizeMode, this.AnchorPosition, this.Upscale, this.CenterCoordinates, this.AnchorPoint).GetHashCode();
     }
 }

--- a/src/ImageProcessor/Imaging/RoundedCornerLayer.cs
+++ b/src/ImageProcessor/Imaging/RoundedCornerLayer.cs
@@ -68,16 +68,11 @@ namespace ImageProcessor.Imaging
         public bool BottomRight { get; set; }
 
         /// <summary>
-        /// Returns a value that indicates whether the specified object is an 
-        /// <see cref="RoundedCornerLayer"/> object that is equivalent to 
-        /// this <see cref="RoundedCornerLayer"/> object.
+        /// Determines whether the specified <see cref="System.Object" />, is equal to this instance.
         /// </summary>
-        /// <param name="obj">
-        /// The object to test.
-        /// </param>
+        /// <param name="obj">The <see cref="System.Object" /> to compare with this instance.</param>
         /// <returns>
-        /// True if the given object is an <see cref="RoundedCornerLayer"/> object that is equivalent to 
-        /// this <see cref="RoundedCornerLayer"/> object; otherwise, false.
+        ///   <c>true</c> if the specified <see cref="System.Object" /> is equal to this instance; otherwise, <c>false</c>.
         /// </returns>
         public override bool Equals(object obj)
         {
@@ -87,26 +82,18 @@ namespace ImageProcessor.Imaging
             }
 
             return this.Radius == rounded.Radius
-                   && this.TopLeft == rounded.TopLeft && this.TopRight == rounded.TopRight
-                   && this.BottomLeft == rounded.BottomLeft && this.BottomRight == rounded.BottomRight;
+                   && this.TopLeft == rounded.TopLeft
+                   && this.TopRight == rounded.TopRight
+                   && this.BottomLeft == rounded.BottomLeft
+                   && this.BottomRight == rounded.BottomRight;
         }
 
         /// <summary>
-        /// Returns the hash code for this instance.
+        /// Returns a hash code for this instance.
         /// </summary>
         /// <returns>
-        /// A 32-bit signed integer that is the hash code for this instance.
+        /// A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table.
         /// </returns>
-        public override int GetHashCode()
-        {
-            unchecked
-            {
-                int hashCode = this.Radius;
-                hashCode = (hashCode * 397) ^ this.TopLeft.GetHashCode();
-                hashCode = (hashCode * 397) ^ this.TopRight.GetHashCode();
-                hashCode = (hashCode * 397) ^ this.BottomLeft.GetHashCode();
-                return (hashCode * 397) ^ this.BottomRight.GetHashCode();
-            }
-        }
+        public override int GetHashCode() => (this.Radius, this.TopLeft, this.TopRight, this.BottomLeft, this.BottomRight).GetHashCode();
     }
 }

--- a/src/ImageProcessor/Imaging/RoundedCornerLayer.cs
+++ b/src/ImageProcessor/Imaging/RoundedCornerLayer.cs
@@ -10,10 +10,12 @@
 
 namespace ImageProcessor.Imaging
 {
+    using System;
+
     /// <summary>
     /// Encapsulates the properties required to add rounded corners to an image.
     /// </summary>
-    public class RoundedCornerLayer
+    public class RoundedCornerLayer : IEquatable<RoundedCornerLayer>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="RoundedCornerLayer"/> class.
@@ -74,19 +76,21 @@ namespace ImageProcessor.Imaging
         /// <returns>
         ///   <c>true</c> if the specified <see cref="System.Object" /> is equal to this instance; otherwise, <c>false</c>.
         /// </returns>
-        public override bool Equals(object obj)
-        {
-            if (!(obj is RoundedCornerLayer rounded))
-            {
-                return false;
-            }
+        public override bool Equals(object obj) => obj is RoundedCornerLayer roundedCornerLayer && this.Equals(roundedCornerLayer);
 
-            return this.Radius == rounded.Radius
-                   && this.TopLeft == rounded.TopLeft
-                   && this.TopRight == rounded.TopRight
-                   && this.BottomLeft == rounded.BottomLeft
-                   && this.BottomRight == rounded.BottomRight;
-        }
+        /// <summary>
+        /// Indicates whether the current object is equal to another object of the same type.
+        /// </summary>
+        /// <param name="other">An object to compare with this object.</param>
+        /// <returns>
+        /// true if the current object is equal to the <paramref name="other" /> parameter; otherwise, false.
+        /// </returns>
+        public bool Equals(RoundedCornerLayer other) => other != null
+            && this.Radius == other.Radius
+            && this.TopLeft == other.TopLeft
+            && this.TopRight == other.TopRight
+            && this.BottomLeft == other.BottomLeft
+            && this.BottomRight == other.BottomRight;
 
         /// <summary>
         /// Returns a hash code for this instance.

--- a/src/ImageProcessor/Imaging/TextLayer.cs
+++ b/src/ImageProcessor/Imaging/TextLayer.cs
@@ -96,16 +96,11 @@ namespace ImageProcessor.Imaging
         public bool RightToLeft { get; set; }
 
         /// <summary>
-        /// Returns a value that indicates whether the specified object is an 
-        /// <see cref="TextLayer"/> object that is equivalent to 
-        /// this <see cref="TextLayer"/> object.
+        /// Determines whether the specified <see cref="System.Object" />, is equal to this instance.
         /// </summary>
-        /// <param name="obj">
-        /// The object to test.
-        /// </param>
+        /// <param name="obj">The <see cref="System.Object" /> to compare with this instance.</param>
         /// <returns>
-        /// True if the given object  is an <see cref="TextLayer"/> object that is equivalent to 
-        /// this <see cref="TextLayer"/> object; otherwise, false.
+        ///   <c>true</c> if the specified <see cref="System.Object" /> is equal to this instance; otherwise, <c>false</c>.
         /// </returns>
         public override bool Equals(object obj)
         {
@@ -116,38 +111,23 @@ namespace ImageProcessor.Imaging
 
             return this.Text == textLayer.Text
                 && this.FontColor == textLayer.FontColor
-                && this.FontFamily.Equals(textLayer.FontFamily)
+                && (this.FontFamily == null || textLayer.FontFamily == null ? this.FontFamily == textLayer.FontFamily : this.FontFamily.Equals(textLayer.FontFamily))
                 && this.FontSize == textLayer.FontSize
                 && this.Style == textLayer.Style
-                && this.DropShadow == textLayer.DropShadow
                 && this.Opacity == textLayer.Opacity
                 && this.Position == textLayer.Position
+                && this.DropShadow == textLayer.DropShadow
                 && this.Vertical == textLayer.Vertical
                 && this.RightToLeft == textLayer.RightToLeft;
         }
 
         /// <summary>
-        /// Returns the hash code for this instance.
+        /// Returns a hash code for this instance.
         /// </summary>
         /// <returns>
-        /// A 32-bit signed integer that is the hash code for this instance.
+        /// A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table.
         /// </returns>
-        public override int GetHashCode()
-        {
-            unchecked
-            {
-                int hashCode = this.Text?.GetHashCode() ?? 0;
-                hashCode = (hashCode * 397) ^ this.DropShadow.GetHashCode();
-                hashCode = (hashCode * 397) ^ (this.FontFamily?.GetHashCode() ?? 0);
-                hashCode = (hashCode * 397) ^ (int)this.Style;
-                hashCode = (hashCode * 397) ^ this.FontColor.GetHashCode();
-                hashCode = (hashCode * 397) ^ this.Opacity;
-                hashCode = (hashCode * 397) ^ this.FontSize;
-                hashCode = (hashCode * 397) ^ this.Position.GetHashCode();
-                hashCode = (hashCode * 397) ^ this.Vertical.GetHashCode();
-                return (hashCode * 397) ^ this.RightToLeft.GetHashCode();
-            }
-        }
+        public override int GetHashCode() => (this.Text, this.FontColor, this.FontFamily, this.FontSize, this.Style, this.Opacity, this.Position, this.DropShadow, this.Vertical, this.RightToLeft).GetHashCode();
 
         /// <summary>
         /// Disposes the object and frees resources for the Garbage Collector.

--- a/src/ImageProcessor/Imaging/TextLayer.cs
+++ b/src/ImageProcessor/Imaging/TextLayer.cs
@@ -18,7 +18,7 @@ namespace ImageProcessor.Imaging
     /// <summary>
     /// Encapsulates the properties required to add a layer of text to an image.
     /// </summary>
-    public class TextLayer : IDisposable
+    public class TextLayer : IDisposable, IEquatable<TextLayer>
     {
         /// <summary>
         /// A value indicating whether this instance of the given entity has been disposed.
@@ -102,24 +102,26 @@ namespace ImageProcessor.Imaging
         /// <returns>
         ///   <c>true</c> if the specified <see cref="System.Object" /> is equal to this instance; otherwise, <c>false</c>.
         /// </returns>
-        public override bool Equals(object obj)
-        {
-            if (!(obj is TextLayer textLayer))
-            {
-                return false;
-            }
+        public override bool Equals(object obj) => obj is TextLayer textLayer && this.Equals(textLayer);
 
-            return this.Text == textLayer.Text
-                && this.FontColor == textLayer.FontColor
-                && (this.FontFamily == null || textLayer.FontFamily == null ? this.FontFamily == textLayer.FontFamily : this.FontFamily.Equals(textLayer.FontFamily))
-                && this.FontSize == textLayer.FontSize
-                && this.Style == textLayer.Style
-                && this.Opacity == textLayer.Opacity
-                && this.Position == textLayer.Position
-                && this.DropShadow == textLayer.DropShadow
-                && this.Vertical == textLayer.Vertical
-                && this.RightToLeft == textLayer.RightToLeft;
-        }
+        /// <summary>
+        /// Indicates whether the current object is equal to another object of the same type.
+        /// </summary>
+        /// <param name="other">An object to compare with this object.</param>
+        /// <returns>
+        /// true if the current object is equal to the <paramref name="other" /> parameter; otherwise, false.
+        /// </returns>
+        public bool Equals(TextLayer other) => other != null
+            && this.Text == other.Text
+            && this.FontColor == other.FontColor
+            && (this.FontFamily == null || other.FontFamily == null ? this.FontFamily == other.FontFamily : this.FontFamily.Equals(other.FontFamily))
+            && this.FontSize == other.FontSize
+            && this.Style == other.Style
+            && this.Opacity == other.Opacity
+            && this.Position == other.Position
+            && this.DropShadow == other.DropShadow
+            && this.Vertical == other.Vertical
+            && this.RightToLeft == other.RightToLeft;
 
         /// <summary>
         /// Returns a hash code for this instance.

--- a/src/ImageProcessor/packages.config
+++ b/src/ImageProcessor/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net452" />
+</packages>

--- a/tests/ImageProcessor.UnitTests/Imaging/Filters/Photo/MatrixFilterBaseTests.cs
+++ b/tests/ImageProcessor.UnitTests/Imaging/Filters/Photo/MatrixFilterBaseTests.cs
@@ -29,7 +29,7 @@ namespace ImageProcessor.UnitTests.Imaging.Filters.Photo
             VariantFilterBase first = new VariantFilterBase();
             VariantFilterBase second = new VariantFilterBase();
 
-            first.Equals(second).Should().BeFalse();
+            first.Equals(second).Should().BeTrue();
         }
 
         internal static ColorMatrix InvariantColorMatrix = new ColorMatrix(new[]


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/JimBobSquarePants/ImageProcessor/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practise as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

This fixes some possible `NullReferenceException`s in the `Equals` implementations and uses `ValueTuple` to generate the hash codes, as that's a lot easier, cleaner and heavily optimized:
- https://stackoverflow.com/a/4630550
- https://intellitect.com/overidingobjectusingtuple/
- https://montemagno.com/optimizing-c-struct-equality-with-iequatable/