### PR TITLE
Add support for .NET Standard 2.1 and other frameworks

### DIFF
--- a/src/ImageProcessor.Plugins.WebP/ImageProcessor.Plugins.WebP.csproj
+++ b/src/ImageProcessor.Plugins.WebP/ImageProcessor.Plugins.WebP.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net452</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
 

--- a/src/ImageProcessor/ImageProcessor.csproj
+++ b/src/ImageProcessor/ImageProcessor.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net452</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
 
@@ -35,6 +35,30 @@
 
   <ItemGroup>
     <Folder Include="Colorspaces\" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net48'">
+    <PackageReference Include="System.Drawing.Common">
+      <Version>4.7.0</Version>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="System.Drawing.Common">
+      <Version>4.7.0</Version>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
+    <PackageReference Include="System.Drawing.Common">
+      <Version>4.7.0</Version>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
+    <PackageReference Include="System.Drawing.Common">
+      <Version>4.7.0</Version>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/tests/ImageProcessor.Tests/ImageProcessor.Tests.csproj
+++ b/tests/ImageProcessor.Tests/ImageProcessor.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net452</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
 
     <IsPackable>false</IsPackable>


### PR DESCRIPTION
### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have verified that there are no overlapping [pull-requests](https://github.com/JimBobSquarePants/ImageProcessor/pulls) open
- [N/A] I have verified that I am following matches the existing coding patterns and practise as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [N/A] I have provided test coverage for my change (where applicable)

### Description
This adds support for .NET Standard 2.1, 2.0 and .NET Framework 4.7.2. It's up to you whether you want to add these changes, it has been helpful with my project.

<!-- Thanks for contributing to ImageProcessor! -->
