### PR TITLE
Remove RecursivelyDeleteEmptyDirectories and fix DirectoryNotFoundException

### DIFF
--- a/src/ImageProcessor.Web/Caching/DiskCache.cs
+++ b/src/ImageProcessor.Web/Caching/DiskCache.cs
@@ -257,7 +257,7 @@ namespace ImageProcessor.Web.Caching
                             }
 
                             // If the directory is empty, delete it to remove the FCN
-                            if (Directory.GetFiles(directory, "*", SearchOption.TopDirectoryOnly).Length == 0
+                            if (count == 0
                                 && Directory.GetDirectories(directory, "*", SearchOption.TopDirectoryOnly).Length == 0)
                             {
                                 Directory.Delete(directory);


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/JimBobSquarePants/ImageProcessor/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practise as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
This removes the (unnecessary) `RecursivelyDeleteEmptyDirectories()` method and removes empty directories while trimming the files (see https://github.com/JimBobSquarePants/ImageProcessor/pull/795#issuecomment-651026443).