### PR TITLE
Fix  809

### DIFF
--- a/build/build.ps1
+++ b/build/build.ps1
@@ -49,7 +49,7 @@ $imageprocessorWebConfig = @{
 
 $imageProcessorWebPluginsAzureBlobCache = @{
     name    = "ImageProcessor.Web.Plugins.AzureBlobCache"
-    version = "1.7.0"
+    version = "1.7.1"
     folder  = Join-Path $buildPath "src\ImageProcessor.Web.Plugins.AzureBlobCache"
     output  = Join-Path $binPath "ImageProcessor.Web.Plugins.AzureBlobCache\lib\net452"
     csproj  = "ImageProcessor.Web.Plugins.AzureBlobCache.csproj"


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/JimBobSquarePants/ImageProcessor/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practise as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
Checks the `RequestInformation.HttpStatusCode` of the `StorageException` to test for `304` response code. Additionaly simplifies logic and logs more information if a different exception occurs.

I've tested it all locally.

<!-- Thanks for contributing to ImageProcessor! -->
