### PR TITLE
Sanitize Metadata on Jpeg Save.

### DIFF
--- a/build/build.ps1
+++ b/build/build.ps1
@@ -8,7 +8,7 @@ $nugetOutput = Join-Path $binPath "NuGets";
 # Projects (NuGet dependencies are handled in the nuspec files themselves)
 $imageprocessor = @{
     name    = "ImageProcessor"
-    version = "2.9.0"
+    version = "2.9.1"
     folder  = Join-Path $buildPath "src\ImageProcessor"
     output  = Join-Path $binPath "ImageProcessor\lib\net452"
     csproj  = "ImageProcessor.csproj"

--- a/src/ImageProcessor/Imaging/Formats/JpegFormat.cs
+++ b/src/ImageProcessor/Imaging/Formats/JpegFormat.cs
@@ -11,10 +11,12 @@
 namespace ImageProcessor.Imaging.Formats
 {
     using System;
+    using System.Collections.Generic;
     using System.Drawing;
     using System.Drawing.Imaging;
     using System.IO;
     using System.Text;
+    using ImageProcessor.Imaging.MetaData;
 
     /// <summary>
     /// Provides the necessary information to support jpeg images.
@@ -66,6 +68,8 @@ namespace ImageProcessor.Imaging.Formats
         /// </returns>
         public override Image Save(Stream stream, Image image, long bitDepth)
         {
+            SantizeMetadata(image);
+
             // Jpegs can be saved with different settings to include a quality setting for the JPEG compression.
             // This improves output compression and quality.
             using (EncoderParameters encoderParameters = FormatUtilities.GetEncodingParameters(this.Quality))
@@ -97,6 +101,8 @@ namespace ImageProcessor.Imaging.Formats
         /// </returns>
         public override Image Save(string path, Image image, long bitDepth)
         {
+            SantizeMetadata(image);
+
             // Jpegs can be saved with different settings to include a quality setting for the JPEG compression.
             // This improves output compression and quality.
             using (EncoderParameters encoderParameters = FormatUtilities.GetEncodingParameters(this.Quality))
@@ -111,6 +117,19 @@ namespace ImageProcessor.Imaging.Formats
             }
 
             return image;
+        }
+
+        // System.Drawing's jpeg encoder throws when proprietory tags are included in the metadata
+        // https://github.com/JimBobSquarePants/ImageProcessor/issues/811
+        private static void SantizeMetadata(Image image)
+        {
+            foreach (int id in image.PropertyIdList)
+            {
+                if (Array.IndexOf(ExifPropertyTagConstants.Ids, id) == -1)
+                {
+                    image.RemovePropertyItem(id);
+                }
+            }
         }
     }
 }

--- a/src/ImageProcessor/Imaging/Formats/JpegFormat.cs
+++ b/src/ImageProcessor/Imaging/Formats/JpegFormat.cs
@@ -119,7 +119,7 @@ namespace ImageProcessor.Imaging.Formats
             return image;
         }
 
-        // System.Drawing's jpeg encoder throws when proprietory tags are included in the metadata
+        // System.Drawing's jpeg encoder throws when proprietary tags are included in the metadata
         // https://github.com/JimBobSquarePants/ImageProcessor/issues/811
         private static void SantizeMetadata(Image image)
         {

--- a/src/ImageProcessor/Imaging/MetaData/ExifPropertyTagConstants.cs
+++ b/src/ImageProcessor/Imaging/MetaData/ExifPropertyTagConstants.cs
@@ -83,5 +83,10 @@ namespace ImageProcessor.Imaging.MetaData
         /// Gets all known property items
         /// </summary>
         public static readonly ExifPropertyTag[] All = (ExifPropertyTag[])Enum.GetValues(typeof(ExifPropertyTag));
+
+        /// <summary>
+        /// Gets the ids of all valid EXIF property items.
+        /// </summary>
+        public static readonly int[] Ids = Enum.GetValues(typeof(ExifPropertyTag)).Cast<int>().ToArray();
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/JimBobSquarePants/ImageProcessor/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practise as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [ ] I have provided test coverage for my change (where applicable)

### Description
Manually tested, not bothering to add test as it's not worth the dev effort.  Fixes #811 by trimming out any non-supported tags.

<!-- Thanks for contributing to ImageProcessor! -->
