### PR TITLE
Improve ISupportedImageFormat handling for vector and video types

### DIFF
--- a/src/ImageProcessor.Web/Configuration/ImageProcessorConfiguration.cs
+++ b/src/ImageProcessor.Web/Configuration/ImageProcessorConfiguration.cs
@@ -230,19 +230,21 @@ namespace ImageProcessor.Web.Configuration
 
             foreach (ImageProcessingSection.PluginElement pluginConfig in pluginConfigs)
             {
-                var type = Type.GetType(pluginConfig.Type);
-
-                if (type == null)
+                try
                 {
+                    var type = Type.GetType(pluginConfig.Type, true);
+
+                    Dictionary<string, string> settings = this.GetPluginSettings(type.Name);
+
+                    // No reason for this to fail.
+                    this.AvailableWebGraphicsProcessors.TryAdd(type, settings);
+                }
+                catch (Exception ex)
+                { 
                     string message = "Couldn't load IWebGraphicsProcessor: " + pluginConfig.Type;
                     ImageProcessorBootstrapper.Instance.Logger.Log<ImageProcessorConfiguration>(message);
-                    throw new TypeLoadException(message);
+                    throw new TypeLoadException(message, ex);
                 }
-
-                Dictionary<string, string> settings = this.GetPluginSettings(type.Name);
-
-                // No reason for this to fail.
-                this.AvailableWebGraphicsProcessors.TryAdd(type, settings);
             }
         }
 

--- a/src/ImageProcessor/ImageFactory.cs
+++ b/src/ImageProcessor/ImageFactory.cs
@@ -236,6 +236,13 @@ namespace ImageProcessor
                 throw new ImageFormatException("Input stream is not a supported format.");
             }
 
+            // Assign animation process mode before loading file
+            // Useful for file types where loading all frames would be wasteful (e.g. video, PDF)
+            if (format is IAnimatedImageFormat imageFormat)
+            {
+                imageFormat.AnimationProcessMode = this.AnimationProcessMode;
+            }
+
             // Set our image as the memory stream value.
             this.Image = format.Load(memoryStream);
 
@@ -257,11 +264,6 @@ namespace ImageProcessor
             foreach (int id in this.Image.PropertyIdList)
             {
                 this.ExifPropertyItems[id] = this.Image.GetPropertyItem(id);
-            }
-
-            if (this.CurrentImageFormat is IAnimatedImageFormat imageFormat)
-            {
-                imageFormat.AnimationProcessMode = this.AnimationProcessMode;
             }
 
             this.backupExifPropertyItems = new ConcurrentDictionary<int, PropertyItem>(this.ExifPropertyItems);

--- a/src/ImageProcessor/ImageFactory.cs
+++ b/src/ImageProcessor/ImageFactory.cs
@@ -244,7 +244,7 @@ namespace ImageProcessor
             }
 
             // Set our image as the memory stream value.
-            this.Image = format.Load(memoryStream);
+            this.Image = format.Load(memoryStream, this);
 
             // Save the bit depth
             this.CurrentBitDepth = Image.GetPixelFormatSize(this.Image.PixelFormat);

--- a/src/ImageProcessor/Imaging/Formats/FormatBase.cs
+++ b/src/ImageProcessor/Imaging/Formats/FormatBase.cs
@@ -83,6 +83,19 @@ namespace ImageProcessor.Imaging.Formats
         }
 
         /// <summary>
+        /// Decodes the image to process.
+        /// </summary>
+        /// <param name="stream">The <see cref="T:System.IO.Stream" /> containing the image information.</param>
+        /// <param name="imageFactory">The <see cref="T:ImageProcessor.ImageFactory" /> that loads the image.</param>
+        /// <returns>
+        /// The <see cref="T:System.Drawing.Image" />.
+        /// </returns>
+        public virtual Image Load(Stream stream, ImageFactory imageFactory)
+        {
+            return Load(stream);
+        }
+
+        /// <summary>
         /// Saves the current image to the specified output stream.
         /// </summary>
         /// <param name="stream">

--- a/src/ImageProcessor/Imaging/Formats/ISupportedImageFormat.cs
+++ b/src/ImageProcessor/Imaging/Formats/ISupportedImageFormat.cs
@@ -78,6 +78,16 @@ namespace ImageProcessor.Imaging.Formats
         Image Load(Stream stream);
 
         /// <summary>
+        /// Decodes the image to process.
+        /// </summary>
+        /// <param name="stream">The <see cref="T:System.IO.Stream" /> containing the image information.</param>
+        /// <param name="imageFactory">The <see cref="T:ImageProcessor.ImageFactory" /> that loads the image.</param>
+        /// <returns>
+        /// The <see cref="T:System.Drawing.Image" />.
+        /// </returns>
+        Image Load(Stream stream, ImageFactory imageFactory);
+
+        /// <summary>
         /// Saves the current image to the specified output stream.
         /// </summary>
         /// <param name="stream">


### PR DESCRIPTION
### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have verified that there are no overlapping [pull-requests](https://github.com/JimBobSquarePants/ImageProcessor/pulls) open
- [X] I have verified that I am following matches the existing coding patterns and practise as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [X] I have provided test coverage for my change (where applicable)

### Description
Changes that make it easier to load certain frames and pages in ISupportedImageFormat implementations.

<!-- Thanks for contributing to ImageProcessor! -->
